### PR TITLE
Fix POSIX compliance on bootstrap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,4 +5,4 @@ set -e
 npm install
 
 # Copy .env template
-[[ -f .env ]] || cp .env.example .env
+[ -f .env ] || cp .env.example .env


### PR DESCRIPTION
`./script/bootstrap`  was failing on linux

```
./script/bootstrap: 8: ./script/bootstrap: [[: not found
```
Fixed by using POSIX compliant `[` instead of `[[`