### PR TITLE
Add cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - "6"
+  - "7.7.1"
 notifications:
   disabled: true
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,3 @@ node_js:
   - "7.7.1"
 notifications:
   disabled: true
-env:
-  - PRIVATE_KEY=ssssshhh
-  - INTEGRATION_ID=1
-  - WEBHOOK_SECRET=test

--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
+const cacheManager = require('cache-manager');
 const createWebhook = require('github-webhook-handler');
 const createIntegration = require('github-integration');
 const createRobot = require('./lib/robot');
 const createServer = require('./lib/server');
 
 module.exports = options => {
+  const cache = cacheManager.caching({
+    store: 'memory',
+    ttl: 60 * 60 // 1 hour
+  });
+
   const webhook = createWebhook({path: '/', secret: options.secret});
   const integration = createIntegration({
     id: options.id,
@@ -11,7 +17,7 @@ module.exports = options => {
     debug: process.env.LOG_LEVEL === 'trace'
   });
   const server = createServer(webhook);
-  const robot = createRobot(integration, webhook);
+  const robot = createRobot(integration, webhook, cache);
 
   // Show trace for any unhandled rejections
   process.on('unhandledRejection', reason => {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,5 +1,6 @@
 const bunyan = require('bunyan');
 const bunyanFormat = require('bunyan-format');
+const GitHubApi = require('github');
 const Context = require('./context');
 
 const logger = bunyan.createLogger({
@@ -9,9 +10,10 @@ const logger = bunyan.createLogger({
 });
 
 class Robot {
-  constructor(integration, webhook) {
+  constructor(integration, webhook, cache) {
     this.integration = integration;
     this.webhook = webhook;
+    this.cache = cache;
   }
 
   on(event, callback) {
@@ -24,8 +26,15 @@ class Robot {
     });
   }
 
-  auth(id) {
-    return this.integration.asInstallation(id);
+  async auth(id) {
+    const token = await this.cache.wrap(`integration:${id}:token`, () => {
+      this.log.info(`creating token for installation ${id}`);
+      return this.integration.createToken(id);
+    }, {ttl: 60 * 60});
+
+    const github = new GitHubApi({debug: process.env.LOG_LEVEL === 'trace'});
+    github.authenticate({type: 'token', token: token.token});
+    return github;
   }
 
   log(...args) {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,10 @@
   "dependencies": {
     "bunyan": "^1.8.5",
     "bunyan-format": "^0.2.1",
+    "cache-manager": "^2.4.0",
     "commander": "^2.9.0",
     "dotenv": "~4.0.0",
+    "github": "^8.1.0",
     "github-integration": "^1.0.0",
     "github-webhook-handler": "^0.6.0",
     "pkg-conf": "^2.0.0",


### PR DESCRIPTION
This is step 1 of fixing https://github.com/probot/stale/issues/10, which is caused by too many requests and no throttling.

Currently an API request is made to create a new token every time `robot.auth` is called, even though tokens last for an hour. So this caches the result in an in-memory LRU cache with a TTL of 1 hour, which should have a pretty big impact on plugins like the stale plugin that authenticate and make a request for every webhook received.