### PR TITLE
Hack to throttle requests

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,6 +1,7 @@
 const bunyan = require('bunyan');
 const bunyanFormat = require('bunyan-format');
 const GitHubApi = require('github');
+const Bottleneck = require('bottleneck');
 const Context = require('./context');
 
 const logger = bunyan.createLogger({
@@ -34,12 +35,23 @@ class Robot {
 
     const github = new GitHubApi({debug: process.env.LOG_LEVEL === 'trace'});
     github.authenticate({type: 'token', token: token.token});
-    return github;
+    return rateLimitedClient(github);
   }
 
   log(...args) {
     return logger.debug(...args);
   }
+}
+
+// Hack client to only allow one request at a time with a 1s delay
+// https://github.com/mikedeboer/node-github/issues/526
+function rateLimitedClient(github) {
+  const limiter = new Bottleneck(1, 1000);
+  const oldHandler = github.handler;
+  github.handler = (msg, block, callback) => {
+    limiter.submit(oldHandler.bind(github), msg, block, callback);
+  };
+  return github;
 }
 
 // Add level methods on the logger

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
+    "bottleneck": "^1.15.1",
     "bunyan": "^1.8.5",
     "bunyan-format": "^0.2.1",
     "cache-manager": "^2.4.0",


### PR DESCRIPTION
This hacks the github client to use [bottleneck](https://github.com/SGrondin/bottleneck) to throttle requests to the GitHub API, allowing only 1 request at a time, and adding a 1s delay between requests as the [best practices](https://developer.github.com/guides/best-practices-for-integrators/#dealing-with-abuse-rate-limits) guide suggests.

Fixes https://github.com/probot/stale/issues/10