### PR TITLE
Integrate pagination support into Probot core

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -76,6 +76,20 @@ module.exports = robot => {
 
 See the [full API docs](https://mikedeboer.github.io/node-github/) to see all the ways you can interact with GitHub. Some API endpoints are not available on GitHub Integrations yet, so check [which ones are available](https://developer.github.com/early-access/integrations/available-endpoints/) first.
 
+### Pagination
+
+Many GitHub API endpoints are paginated. The `github.paginate` method can be used to get each page of the results.
+
+```js
+const github = await robot.auth(event.payload.installation.id);
+
+github.paginate(github.issues.getAll(context.repo()), issues => {
+  issues.forEach(issue => {
+    robot.console.log('Issue: %s', issue.title);
+  });
+});
+```
+
 ## Running plugins
 
 Before you can run your plugin against GitHub, you'll need to set up your [development environment](development.md) and configure a GitHub Integration for testing. You will the the ID and private key of a GitHub Integration to run the bot.

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,8 +1,10 @@
 /* eslint-disable no-await-in-loop */
 
 module.exports = async function (responsePromise, callback) {
+  let collection = [];
   let response = await responsePromise;
-  let collection = await callback(response);
+
+  collection = collection.concat(await callback(response));
 
   while (this.hasNextPage(response)) {
     response = await this.getNextPage(response);

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,0 +1,11 @@
+module.exports = async function paginate(responsePromise, callback) {
+  let response = await responsePromise;
+  let collection = await callback(response);
+
+  while (this.hasNextPage(response)) {
+    response = await this.getNextPage(response);
+    collection = collection.concat(await callback(response));
+  }
+
+  return collection;
+}

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-await-in-loop */
 
-module.exports = async (responsePromise, callback) => {
+module.exports = async function (responsePromise, callback) {
   let response = await responsePromise;
   let collection = await callback(response);
 

--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,4 +1,6 @@
-module.exports = async function paginate(responsePromise, callback) {
+/* eslint-disable no-await-in-loop */
+
+module.exports = async (responsePromise, callback) => {
   let response = await responsePromise;
   let collection = await callback(response);
 
@@ -8,4 +10,4 @@ module.exports = async function paginate(responsePromise, callback) {
   }
 
   return collection;
-}
+};

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -35,12 +35,20 @@ class Robot {
 
     const github = new GitHubApi({debug: process.env.LOG_LEVEL === 'trace'});
     github.authenticate({type: 'token', token: token.token});
-    return rateLimitedClient(github);
+    return probotEnhancedClient(github);
   }
 
   log(...args) {
     return logger.debug(...args);
   }
+}
+
+function probotEnhancedClient(github) {
+  github = rateLimitedClient(github);
+
+  github.paginate = require('./lib/paginate');
+
+  return github;
 }
 
 // Hack client to only allow one request at a time with a 1s delay

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -28,13 +28,20 @@ class Robot {
   }
 
   async auth(id) {
-    const token = await this.cache.wrap(`integration:${id}:token`, () => {
-      this.log.info(`creating token for installation ${id}`);
-      return this.integration.createToken(id);
-    }, {ttl: 60 * 60});
+    let github;
 
-    const github = new GitHubApi({debug: process.env.LOG_LEVEL === 'trace'});
-    github.authenticate({type: 'token', token: token.token});
+    if(id) {
+      const token = await this.cache.wrap(`integration:${id}:token`, () => {
+        this.log.info(`creating token for installation ${id}`);
+        return this.integration.createToken(id);
+      }, {ttl: 60 * 60});
+
+      github = new GitHubApi({debug: process.env.LOG_LEVEL === 'trace'});
+      github.authenticate({type: 'token', token: token.token});
+    } else {
+      github = await this.integration.asIntegration();
+    }
+
     return probotEnhancedClient(github);
   }
 
@@ -46,7 +53,7 @@ class Robot {
 function probotEnhancedClient(github) {
   github = rateLimitedClient(github);
 
-  github.paginate = require('./lib/paginate');
+  github.paginate = require('./paginate');
 
   return github;
 }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -32,7 +32,7 @@ class Robot {
 
     if (id) {
       const token = await this.cache.wrap(`integration:${id}:token`, () => {
-        this.log.info(`creating token for installation ${id}`);
+        this.log.trace(`creating token for installation ${id}`);
         return this.integration.createToken(id);
       }, {ttl: 60 * 60});
 

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -30,7 +30,7 @@ class Robot {
   async auth(id) {
     let github;
 
-    if(id) {
+    if (id) {
       const token = await this.cache.wrap(`integration:${id}:token`, () => {
         this.log.info(`creating token for installation ${id}`);
         return this.integration.createToken(id);


### PR DESCRIPTION
Pagination of GitHub API results is something that every plugin author is going to need to deal with at some point. So this is a scenario that needs to be addressed in core.