### PR TITLE
Update paginate to default to returning response

### DIFF
--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,6 +1,9 @@
 /* eslint-disable no-await-in-loop */
 
-module.exports = async function (responsePromise, callback) {
+// Default callback should just return the response passed to it.
+const defaultCallback = response => response;
+
+module.exports = async function (responsePromise, callback = defaultCallback) {
   let collection = [];
   let response = await responsePromise;
 


### PR DESCRIPTION
https://github.com/MarshallOfSound/probot-issue-duplicate-detection/pull/5 uses the `paginate` method to get a list of all issues in a repo. Since it just needs the concatenated list of all issues, it doesn't really need to pass a callback. So this PR updates `paginate` to have a default callback that just returns the response.