### PR TITLE
Look for any `.pem` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 npm-debug.log
 .DS_Store
 node_modules/
-private-key.pem
+*.pem
 .env

--- a/bin/probot-run
+++ b/bin/probot-run
@@ -30,7 +30,6 @@ if(!program.privateKey) {
 
   if (key) {
     program.privateKey = fs.readFileSync(key);
-    console.log(program.privateKey);
   } else {
     console.warn("Missing GitHub Integration private key.\nUse --private-key flag or set PRIVATE_KEY environment variable.");
     process.exit(1);

--- a/bin/probot-run
+++ b/bin/probot-run
@@ -25,9 +25,13 @@ if(!program.integration) {
 }
 
 if(!program.privateKey) {
-  try {
-    program.privateKey = require('fs').readFileSync('private-key.pem');
-  } catch (err) {
+  const fs = require('fs');
+  const key = fs.readdirSync(process.cwd()).find(path => path.endsWith('.pem'));
+
+  if (key) {
+    program.privateKey = fs.readFileSync(key);
+    console.log(program.privateKey);
+  } else {
     console.warn("Missing GitHub Integration private key.\nUse --private-key flag or set PRIVATE_KEY environment variable.");
     process.exit(1);
   }

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,7 +9,7 @@ To run a plugin locally, you'll need to create a GitHub Integration and configur
     - **Callback URL** and **Webhook URL**: The full ngrok url above. For example: `https://4397efc6.ngrok.io/`
     - **Webhook Secret:** `development`
     - **Permissions & events** needed will depend on how you use the bot, but for development it may be easiest to enable everything.
-1. Download the private key and move it to `private-key.pem` in the project directory
+1. Download the private key and move it to the project directory
 1. Edit `.env` and set `INTEGRATION_ID` to the ID of the integration you just created.
 1. With `ngrok` still running, open another terminal and run `$ npm start` to start the server on http://localhost:3000
 


### PR DESCRIPTION
Currently you are required to move the private key downloaded from GitHub to `private-key.pem`. This changes it to look for any `.pem` file.

cc #115 