### PR TITLE
replace ngrok with localtunnel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,6 @@ WEBHOOK_SECRET=development
 
 # Uncomment this to get verbose logging
 # LOG_LEVEL=trace # or `info` to show less
+
+# Subdomain to use for localtunnel server. Defaults to your local username.
+# SUBDOMAIN=

--- a/bin/probot-run
+++ b/bin/probot-run
@@ -17,7 +17,7 @@ program
       process.exit(1);
     }
   }, process.env.PRIVATE_KEY)
-  .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.NODE_ENV != 'production')
+  .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV != 'production')
   .parse(process.argv);
 
 if(!program.integration) {
@@ -49,7 +49,7 @@ function setupTunnel() {
   const localtunnel = require('localtunnel');
   const subdomain = typeof program.tunnel == 'string' ?
     program.tunnel :
-    process.env.SUBDOMAIN || require('os').userInfo().username;
+    require('os').userInfo().username;
 
   const tunnel = localtunnel(program.port, {subdomain}, function (err, tunnel) {
     if (err) {

--- a/bin/probot-run
+++ b/bin/probot-run
@@ -17,6 +17,7 @@ program
       process.exit(1);
     }
   }, process.env.PRIVATE_KEY)
+  .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.NODE_ENV != 'production')
   .parse(process.argv);
 
 if(!program.integration) {
@@ -34,6 +35,34 @@ if(!program.privateKey) {
     console.warn("Missing GitHub Integration private key.\nUse --private-key flag or set PRIVATE_KEY environment variable.");
     process.exit(1);
   }
+}
+
+if(program.tunnel) {
+  try {
+    setupTunnel();
+  } catch(err) {
+    console.warn('Run `npm install --save-dev localtunnel` to enable localtunnel.');
+  }
+}
+
+function setupTunnel() {
+  const localtunnel = require('localtunnel');
+  const subdomain = typeof program.tunnel == 'string' ?
+    program.tunnel :
+    require('os').userInfo().username;
+
+  const tunnel = localtunnel(program.port, {subdomain}, function (err, tunnel) {
+    if (err) {
+      console.warn('Could not open tunnel: ', err.message);
+    } else {
+      console.log('Listening on ' + tunnel.url);
+      tunnel.url;
+    }
+  });
+
+  tunnel.on('close', function() {
+    console.warn('Local tunnel closed');
+  });
 }
 
 const pkgConf = require('pkg-conf');

--- a/bin/probot-run
+++ b/bin/probot-run
@@ -49,7 +49,7 @@ function setupTunnel() {
   const localtunnel = require('localtunnel');
   const subdomain = typeof program.tunnel == 'string' ?
     program.tunnel :
-    require('os').userInfo().username;
+    process.env.SUBDOMAIN || require('os').userInfo().username;
 
   const tunnel = localtunnel(program.port, {subdomain}, function (err, tunnel) {
     if (err) {

--- a/docs/development.md
+++ b/docs/development.md
@@ -3,23 +3,18 @@
 To run a plugin locally, you'll need to create a GitHub Integration and configure it to deliver webhooks to your local machine.
 
 1. Make sure you have a recent version of [Node.js](https://nodejs.org/) installed
-1. Install [ngrok](https://ngrok.com/download) (`$ brew cask install ngrok` on a mac), which will expose the local server to the internet so GitHub can send webhooks
-1. Run `$ ngrok http 3000` to start ngrok, which should output something like `Forwarding https://4397efc6.ngrok.io -> localhost:3000`
 1. [Create a new GitHub Integration](https://github.com/settings/integrations/new) with:
-    - **Callback URL** and **Webhook URL**: The full ngrok url above. For example: `https://4397efc6.ngrok.io/`
+    - **Webhook URL**: Set to `https://example.com/` and we'll update it in a minute.
     - **Webhook Secret:** `development`
     - **Permissions & events** needed will depend on how you use the bot, but for development it may be easiest to enable everything.
 1. Download the private key and move it to the project directory
 1. Edit `.env` and set `INTEGRATION_ID` to the ID of the integration you just created.
-1. With `ngrok` still running, open another terminal and run `$ npm start` to start the server on http://localhost:3000
+1. Run `$ npm start` to start the server, which will output `Listening on https://yourname.localtunnel.me`;
+1. Update the **Webhook URL** in the [integration settings](https://github.com/settings/integrations) to use the `localtunnel.me` URL.
 
 You'll need to create a test repository and install your Integration by clicking the "Install" button on the settings page.
 
-Whenever you com back to work on the app after you've already had it running once, then you need to:
-
-1. Run `$ npm start`
-1. Run `$ ngrok http 3000` in another terminal window
-1. `ngrok` will use a different URL every time it is restarted, so you will have to go into the [settings for your Integration](https://github.com/settings/integrations) and update all the URLs.
+Whenever you com back to work on the app after you've already had it running once, you should only need to run `$ npm start`.
 
 ## Debugging
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -107,8 +107,6 @@ $ probot run -i 9999 -P private-key.pem ./autoresponder.js
 Listening on http://localhost:3000
 ```
 
-Once your bot is running, you'll need to use `ngrok` to receive GitHub webhooks as described in the [development](development.md) documentation.
-
 ## Publishing your bot
 
 Plugins can be published in NPM modules, which can either be deployed as stand-alone bots, or combined with other plugins.

--- a/script/tunnel
+++ b/script/tunnel
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-ngrok http -bind-tls=true 3000


### PR DESCRIPTION
This replaces ngrok with [localtunnel](https://github.com/localtunnel/localtunnel), which supports custom domains and has a node module, allowing it to be built right in to probot.

By default `probot run` will start a tunnel in development, using the `SUBDOMAIN` env variable or the local username.

```
$ npm start
Listening on https://bkeepers.localtunnel.me
```

cc @jbjonesjr