### PR TITLE
use function expressions in suite and test blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
       {
         "files": "test/**/*.js",
         "rules": {
-          "max-nested-callbacks": "off"
+          "max-nested-callbacks": "off",
+          "prefer-arrow-callback": "off"
         }
       }
     ]

--- a/test/context.js
+++ b/test/context.js
@@ -1,11 +1,11 @@
 const expect = require('expect');
 const Context = require('../lib/context');
 
-describe('Context', () => {
+describe('Context', function () {
   let event;
   let context;
 
-  beforeEach(() => {
+  beforeEach(function () {
     event = {
       payload: {
         repository: {
@@ -18,18 +18,18 @@ describe('Context', () => {
     context = new Context(event);
   });
 
-  describe('repo', () => {
-    it('returns attributes from repository payload', () => {
+  describe('repo', function () {
+    it('returns attributes from repository payload', function () {
       expect(context.repo()).toEqual({owner: 'bkeepers', repo:'probot'});
     });
 
-    it('merges attributes', () => {
+    it('merges attributes', function () {
       expect(context.repo({foo: 1, bar: 2})).toEqual({
         owner: 'bkeepers', repo:'probot', foo: 1, bar: 2
       });
     });
 
-    it('overrides repo attributes', () => {
+    it('overrides repo attributes', function () {
       expect(context.repo({owner: 'muahaha'})).toEqual({
         owner: 'muahaha', repo:'probot'
       });
@@ -37,7 +37,7 @@ describe('Context', () => {
 
     // The `repository` object on the push event has a different format than the other events
     // https://developer.github.com/v3/activity/events/types/#pushevent
-    it('properly handles the push event', () => {
+    it('properly handles the push event', function () {
       event.payload = require('./fixtures/webhook/push');
 
       context = new Context(event);
@@ -45,18 +45,18 @@ describe('Context', () => {
     });
   });
 
-  describe('issue', () => {
-    it('returns attributes from repository payload', () => {
+  describe('issue', function () {
+    it('returns attributes from repository payload', function () {
       expect(context.issue()).toEqual({owner: 'bkeepers', repo:'probot', number: 4});
     });
 
-    it('merges attributes', () => {
+    it('merges attributes', function () {
       expect(context.issue({foo: 1, bar: 2})).toEqual({
         owner: 'bkeepers', repo:'probot', number: 4, foo: 1, bar: 2
       });
     });
 
-    it('overrides repo attributes', () => {
+    it('overrides repo attributes', function () {
       expect(context.issue({owner: 'muahaha', number: 5})).toEqual({
         owner: 'muahaha', repo:'probot', number: 5
       });

--- a/test/robot.js
+++ b/test/robot.js
@@ -8,17 +8,17 @@ const nullLogger = {};
   nullLogger[level] = function () { };
 });
 
-describe('Robot', () => {
+describe('Robot', function () {
   let webhook;
   let robot;
 
-  beforeEach(() => {
+  beforeEach(function () {
     webhook = new EventEmitter();
     robot = createRobot({webhook, logger: nullLogger});
   });
 
-  describe('on', () => {
-    it('calls the callback', () => {
+  describe('on', function () {
+    it('calls the callback', function () {
       const spy = expect.createSpy();
       const event = {};
 
@@ -30,7 +30,7 @@ describe('Robot', () => {
       expect(spy.calls[0].arguments[1]).toBeA(Context);
     });
 
-    it('emits event with acton', () => {
+    it('emits event with acton', function () {
       const spy = expect.createSpy();
 
       robot.on('test.bar', spy);


### PR DESCRIPTION
When writing Mocha tests, the blocks should be function expressions instead of lambdas.  The reasoning is that it's easier to refactor if a test needs a custom timeout, or needs to be conditionally skipped:

    it('should do x', () => {
      this.skip(); // throws exception
    });

    it('should do x', function () {
      this.skip(); // ok
    });