### PR TITLE
ensure "start" script runs from local directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "probot": "./bin/probot"
   },
   "scripts": {
-    "start": "probot run",
+    "start": "node ./bin/probot run",
     "test": "mocha && xo"
   },
   "author": "Brandon Keepers",


### PR DESCRIPTION
If a `probot` contributor has linked probot globally (via `npm link`), `npm start` will execute `probot` from the global npm prefix *instead* of the working copy.

The development workflow is a bit strange here, but if a contributor happened to `npm install localtunnel --save` in a working copy, `probot` won't recognize `localtunnel` *unless* the `start` script is specific about the path of the `probot` executable (it's a `NODE_PATH` issue).

May be an edge case, but using the relative path seems to fix it.