### PR TITLE
Fix private key loading

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -21,6 +21,10 @@ if (!program.integration) {
   program.help();
 }
 
+if (!program.privateKey) {
+  program.privateKey = findPrivateKey();
+}
+
 if (program.tunnel) {
   try {
     setupTunnel();


### PR DESCRIPTION
Commander only calls the function if an argument is provided. This updates the run command to find the private key if one is not provided with the command line options.

cc #127 @boneskull 