### PR TITLE
Include the authenticated client in context

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -38,22 +38,6 @@ module.exports = robot => {
 };
 ```
 
-### auth
-
-`robot.auth(id)` will return an authenticated GitHub client that can be used to make API calls. It takes the ID of the installation, which can be extracted from an event:
-
-```js
-module.exports = function(robot) {
-  robot.on('issues.opened', async (event, context) => {
-    const github = await robot.auth(event.payload.installation.id);
-  });
-};
-```
-
-> Note: `robot.auth` is asynchronous, so it needs to be prefixed with a [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait for the magic to happen.
-
-The `github` object returned from authenticating is an instance of the [github Node.js module](https://github.com/mikedeboer/node-github), which wraps the [GitHub API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
-
 ### log
 
 `robot.log` is a logger backed by [bunyan](https://github.com/trentm/node-bunyan).
@@ -72,7 +56,11 @@ The default log level is `debug`, but you can change it by setting the `LOG_LEVE
 
 ## Context
 
-[Context](/lib/context.js) has helpers for extracting information from the webhook event, which can be passed to GitHub API calls.
+[Context](/lib/context.js) has an authenticated GitHub client, and helpers for extracting information from the webhook event, which can be passed to GitHub API calls.
+
+### github
+
+Return an authenticated GitHub client that can be used to make API calls. It is an instance of the [github Node.js module](https://github.com/mikedeboer/node-github), which wraps the [GitHub API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
 
 ### `repo`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -41,35 +41,20 @@ module.exports = robot => {
 
 Probot uses [GitHub Integrations](https://developer.github.com/early-access/integrations/). An integration is a first-class actor on GitHub, like a user (e.g. [@defunkt](https://github/defunkt)) or a organization (e.g. [@github](https://github.com/github)). The integration is given access to a repository or repositories by being "installed" on a user or organization account and can perform actions through the API like [commenting on an issue](https://developer.github.com/v3/issues/comments/#create-a-comment) or [creating a status](https://developer.github.com/v3/repos/statuses/#create-a-status).
 
-Each event delivered includes an ID of the installation that triggered it, which can be used to authenticate. `robot.auth(id)` will give your plugin an authenticated GitHub client that can be used to make API calls.
-
-```js
-module.exports = robot => {
-  robot.on('issues.opened', async (event, context) => {
-    const github = await robot.auth(event.payload.installation.id);
-    // do something useful with the github client
-  });
-};
-```
-
-> Note: `robot.auth` is asynchronous, so it needs to be prefixed with a [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await) to wait for the magic to happen.
-
-The `github` object returned from authenticating is an instance of the [github Node.js module](https://github.com/mikedeboer/node-github), which wraps the [GitHub API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
+`context.github` is an authenticated GitHub client that can be used to make API calls. It is an instance of the [github Node.js module](https://github.com/mikedeboer/node-github), which wraps the [GitHub API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
 
 Here is an example of an autoresponder plugin that comments on opened issues:
 
 ```js
 module.exports = robot => {
   robot.on('issues.opened', async (event, context) => {
-    const github = await robot.auth(event.payload.installation.id);
-
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:
     //   {owner: 'yourname', repo: 'yourrepo', number: 123, body: 'Hello World!}
     const params = context.issue({body: 'Hello World!'})
 
     // Post a comment on the issue
-    return github.issues.createComment(params);
+    return context.github.issues.createComment(params);
   });
 }
 ```
@@ -81,9 +66,7 @@ See the [full API docs](https://mikedeboer.github.io/node-github/) to see all th
 Many GitHub API endpoints are paginated. The `github.paginate` method can be used to get each page of the results.
 
 ```js
-const github = await robot.auth(event.payload.installation.id);
-
-github.paginate(github.issues.getAll(context.repo()), issues => {
+context.github.paginate(context.github.issues.getAll(context.repo()), issues => {
   issues.forEach(issue => {
     robot.console.log('Issue: %s', issue.title);
   });

--- a/lib/context.js
+++ b/lib/context.js
@@ -1,6 +1,7 @@
 module.exports = class Context {
-  constructor(event) {
+  constructor(event, github) {
     this.event = event;
+    this.github = github;
   }
 
   repo(object) {

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -15,9 +15,10 @@ class Robot {
   on(event, callback) {
     const [name, action] = event.split('.');
 
-    return this.webhook.on(name, event => {
+    return this.webhook.on(name, async event => {
       if (!action || action === event.payload.action) {
-        callback(event, new Context(event));
+        const github = await this.auth(event.payload.installation.id);
+        return callback(event, new Context(event, github));
       }
     });
   }

--- a/test/robot.js
+++ b/test/robot.js
@@ -1,4 +1,3 @@
-const EventEmitter = require('events').EventEmitter;
 const expect = require('expect');
 const Context = require('../lib/context');
 const createRobot = require('../lib/robot');
@@ -18,10 +17,14 @@ describe('Robot', function () {
   beforeEach(function () {
     callbacks = {};
     webhook = {
-      on: (name, callback) => callbacks[name] = callback,
-      emit: (name, event) => callbacks[name](event)
+      on: (name, callback) => {
+        callbacks[name] = callback;
+      },
+      emit: (name, event) => {
+        return callbacks[name](event);
+      }
     };
-    
+
     robot = createRobot({webhook, logger: nullLogger});
     robot.auth = () => {};
 
@@ -30,7 +33,7 @@ describe('Robot', function () {
         action: 'foo',
         installation: {id: 1}
       }
-    }
+    };
 
     spy = expect.createSpy();
   });

--- a/test/robot.js
+++ b/test/robot.js
@@ -11,33 +11,53 @@ const nullLogger = {};
 describe('Robot', function () {
   let webhook;
   let robot;
+  let event;
+  let callbacks;
+  let spy;
 
   beforeEach(function () {
-    webhook = new EventEmitter();
+    callbacks = {};
+    webhook = {
+      on: (name, callback) => callbacks[name] = callback,
+      emit: (name, event) => callbacks[name](event)
+    };
+    
     robot = createRobot({webhook, logger: nullLogger});
+    robot.auth = () => {};
+
+    event = {
+      payload: {
+        action: 'foo',
+        installation: {id: 1}
+      }
+    }
+
+    spy = expect.createSpy();
   });
 
   describe('on', function () {
-    it('calls the callback', function () {
-      const spy = expect.createSpy();
-      const event = {};
-
+    it('calls callback when no action is specified', async function () {
       robot.on('test', spy);
+
       expect(spy).toNotHaveBeenCalled();
-      webhook.emit('test', event);
+      await webhook.emit('test', event);
       expect(spy).toHaveBeenCalled();
       expect(spy.calls[0].arguments[0]).toBe(event);
       expect(spy.calls[0].arguments[1]).toBeA(Context);
     });
 
-    it('emits event with acton', function () {
-      const spy = expect.createSpy();
+    it('calls callback with same action', async function () {
+      robot.on('test.foo', spy);
 
-      robot.on('test.bar', spy);
-      webhook.emit('test', {payload: {action: 'foo'}});
-      expect(spy).toNotHaveBeenCalled();
-      webhook.emit('test', {payload: {action: 'bar'}});
+      await webhook.emit('test', event);
       expect(spy).toHaveBeenCalled();
+    });
+
+    it('does not call callback with different action', async function () {
+      robot.on('test.nope', spy);
+
+      await webhook.emit('test', event);
+      expect(spy).toNotHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
`robot.auth()` is one of the first things called in almost every plugin to get an authenticated GitHub client. It's also been error prone because it's async and you have to prefix it with `await`, and omitting it gives a confusing error.

This PR sets `context.github` to an instance of the github client so it's just always available.

```js
module.exports = robot => {
  robot.on('issues.opened', async (event, context) => {
    const params = context.issue({body: 'Hello World!'});

    return context.github.issues.createComment(params);
  });
}
```