### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM node:7.9
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+COPY package.json /usr/src/app/
+RUN npm install
+COPY . /usr/src/app


### PR DESCRIPTION
Adds a Dockerfile to support running probot in a container.

## Sample use case

```
$ docker build -t probot .
...
$ docker run --rm -it probot node bin/probot.js

  Usage: probot <command> [options]


  Commands:

    run         run the bot
    help [cmd]  display help for [cmd]

  Options:

    -h, --help     output usage information
    -V, --version  output the version number

```