### PR TITLE
adds 'probot scaffold' command; closes #98

### DIFF
--- a/bin/probot-init.js
+++ b/bin/probot-init.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const inquirer = require('inquirer');
+const program = require('commander');
+const {scaffold} = require('egad');
+const kebabCase = require('lodash.kebabcase');
+const chalk = require('chalk');
+const stringifyAuthor = require('stringify-author');
+const {guessEmail, guessAuthor, guessGitHubUsername} = require('conjecture');
+
+const PLUGIN_REPO_URL = 'https://github.com/probot/plugin-template.git';
+
+program
+  .usage('[options] [destination]')
+  .option('-p, --pkgname <package-name>', 'Plugin package name')
+  .option('-d, --desc "<description>"',
+    'Plugin description (contain in quotes)')
+  .option('-a, --author "<full-name>"',
+    'Plugin author name (contain in quotes)')
+  .option('-e, --email <email>', 'Plugin author email address')
+  .option('-h, --homepage <homepage>', 'Plugin author\'s homepage')
+  .option('-u, --user <username>', 'GitHub username or org (repo owner)')
+  .option('-r, --repo <repo-name>', 'Plugin repo name')
+  .option('--overwrite', 'Overwrite existing files', false)
+  .option('--template <template-url>', 'URL of custom plugin template',
+    PLUGIN_REPO_URL)
+  .parse(process.argv);
+
+const destination = program.args.length ?
+  path.resolve(process.cwd(), program.args.shift()) :
+  process.cwd();
+
+const prompts = [
+  {
+    type: 'input',
+    name: 'name',
+    default(answers) {
+      return answers.repo || kebabCase(path.basename(destination));
+    },
+    message: 'Plugin\'s package name:',
+    when: !program.pkgname
+  },
+  {
+    type: 'input',
+    name: 'desc',
+    default() {
+      return 'A Probot plugin';
+    },
+    message: 'Description of plugin:',
+    when: !program.desc
+  },
+  {
+    type: 'input',
+    name: 'author',
+    default() {
+      return guessAuthor();
+    },
+    message: 'Plugin author\'s full name:',
+    when: !program.author
+  },
+  {
+    type: 'input',
+    name: 'email',
+    default() {
+      return guessEmail();
+    },
+    message: 'Plugin author\'s email address:',
+    when: !program.email
+  },
+  {
+    type: 'input',
+    name: 'homepage',
+    message: 'Plugin author\'s homepage:',
+    when: !program.homepage
+  },
+  {
+    type: 'input',
+    name: 'owner',
+    default(answers) {
+      return guessGitHubUsername(answers.email);
+    },
+    message: 'Plugin\'s GitHub user or org name:',
+    when: !program.user
+  },
+  {
+    type: 'input',
+    name: 'repo',
+    default(answers) {
+      return answers.pkgname || kebabCase(path.basename(destination));
+    },
+    message: 'Plugin\'s repo name:',
+    when: !program.repo
+  }
+];
+
+console.log(chalk.blue('Let\'s create a Probot plugin!'));
+
+inquirer.prompt(prompts)
+  .then(answers => {
+    answers.author = stringifyAuthor({
+      name: answers.author,
+      email: answers.email,
+      url: answers.homepage
+    });
+    return scaffold(program.template, destination, answers, {
+      overwrite: Boolean(program.overwrite)
+    });
+  })
+  .then(results => {
+    results.forEach(fileinfo => {
+      console.log(`${fileinfo.skipped ? chalk.yellow('skipped existing file') :
+        chalk.green('created file')}: ${fileinfo.path}`);
+    });
+    console.log(chalk.blue('Done!'));
+  });

--- a/bin/probot.js
+++ b/bin/probot.js
@@ -12,4 +12,5 @@ require('commander')
   .version(require('../package').version)
   .usage('<command> [options]')
   .command('run', 'run the bot')
+  .command('init', 'initialize a new plugin')
   .parse(process.argv);

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,6 +10,22 @@ module.exports = robot => {
 
 The `robot` parameter is an instance of [`Robot`](/lib/robot.js) and gives you access to all of the bot goodness.
 
+## Creating a plugin
+
+Use the `probot init` command to scaffold a new plugin.
+
+Probot will ask you some questions about your plugin, then create files in the directory of your choosing (the current working directory, unless otherwise specified).  Providing this information is optional, but reduces some boilerplate.
+
+If you don't wish to interact with the prompts, you can provide command-line options instead.  See the output of `probot init --help` for the full list.
+
+### Custom Plugin Template
+
+By default, Probot will use the official [plugin template](https://github.com/probot/plugin-template), but this can be customized via `--template`.
+
+### Overwriting Files
+
+By default, Probot will **not** overwrite files which already exist.  Use the `--overwrite` flag to enable this behavior.
+
 ## Receiving GitHub webhooks
 
 [GitHub webhooks](https://developer.github.com/webhooks/) are fired for almost every significant action that users take on GitHub, whether it's pushes to code, opening or closing issues, opening or merging pull requests, or commenting on a discussion.

--- a/package.json
+++ b/package.json
@@ -20,16 +20,22 @@
     "bunyan-format": "^0.2.1",
     "bunyan-sentry-stream": "^1.1.0",
     "cache-manager": "^2.4.0",
+    "chalk": "^1.1.3",
     "commander": "^2.9.0",
+    "conjecture": "^0.1.2",
     "dotenv": "~4.0.0",
+    "egad": "^0.2.0",
     "github": "^8.1.0",
     "github-integration": "^1.0.0",
     "github-webhook-handler": "^0.6.0",
+    "inquirer": "^3.0.6",
     "load-plugins": "^2.1.2",
+    "lodash.kebabcase": "^4.1.1",
     "pkg-conf": "^2.0.0",
     "raven": "^2.0.0",
     "resolve": "^1.3.2",
-    "semver": "^5.3.0"
+    "semver": "^5.3.0",
+    "stringify-author": "^0.1.3"
   },
   "devDependencies": {
     "expect": "^1.20.2",


### PR DESCRIPTION
Here's basic support for scaffolding a plugin.

~~In the end, I didn't go with `init` for the command name.  To me, `init` means "let's start a Probot-based project", not necessarily "let's create a new Probot plugin".~~

**EDIT** Renamed to `probot init`

Anyway, here's a [screencast of what it does](https://asciinema.org/a/dq9xz5e450jaqfhav7ah3cnnh).

As you can see from the output, it wants [this PR to fix the plugin template](https://github.com/probot/plugin-template/pull/13) to land.

Please let me know if you have questions about how I'm guessing default values (see `user.js`).