### PR TITLE
Update docs on running plugins locally

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,10 +83,10 @@ Once you have an integration created, install `probot`:
 $ npm install -g probot
 ```
 
-and run your bot, replacing `9999` and `private-key.pem` below with the ID and path to the private key of your integration.
+and run your bot from your plugin's directory, replacing `9999` and `private-key.pem` below with the ID and path to the private key of your integration.
 
 ```
-$ probot run -i 9999 -P private-key.pem ./autoresponder.js
+$ probot run -i 9999 -P private-key.pem ./index.js
 Listening on http://localhost:3000
 ```
 


### PR DESCRIPTION
These instructions referred to a file `autoresponder.js` which does not exist (a) for a plugin in general, or (b) for the autoresponder plugin in particular. The plugin template repo contains a file named `index.js` to export the plugin module, and this naming scheme seems to have been adopted widely (e.g. autoresponder, stale plugins both use `index.js`).