### PR TITLE
Catch and log errors from plugins

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -49,8 +49,12 @@ class Robot {
 
     return this.webhook.on(name, async event => {
       if (!action || action === event.payload.action) {
-        const github = await this.auth(event.payload.installation.id);
-        return callback(event, new Context(event, github));
+        try {
+          const github = await this.auth(event.payload.installation.id);
+          return callback(event, new Context(event, github));
+        } catch (err) {
+          this.log.error(err);
+        }
       }
     });
   }


### PR DESCRIPTION
Errors thrown in handlers from plugins were being silently ignored. This adds a catch around plugin handlers to log the errors, and updates how error logging is configured to ensure errors are always logged.