### PR TITLE
Release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+## v0.6.0
+
+Breaking Changes:
+
+- Update to [node-github](https://github.com/mikedeboer/node-github) v9, which namespaces all responses with a `data` attribute. (https://github.com/mikedeboer/node-github/pull/505). This is likely to be a breaking change for all plugins.
+
+    Before:
+
+    ```js
+    const data = await github.search.issues(params);
+    data.items.forEach(item => doTheThing(issue));
+    ```
+
+    After:
+
+    ```js
+    const res = await github.search.issues(params);
+    res.data.items.forEach(item => doTheThing(issue));
+    ```
+
+- "GitHub Integrations" were renamed to "GitHub Apps". The `INTEGRATION_ID` environment variable has been deprecated. Use `APP_ID` instead. ([#154](https://github.com/probot/probot/pull/154))
+
+Enhancements:
+
+- Errors thrown in handlers from plugins were being silently ignored. That's not cool. Now, they're being caught and logged.
+ ([#152](https://github.com/probot/probot/pull/152))
+
+
+[View full changelog](https://github.com/probot/probot/compare/v0.5.0...v0.6.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-## v0.6.0
+# Changelog
+
+## v0.6.0 (2017-06-09)
 
 Breaking Changes:
 
@@ -24,6 +26,5 @@ Enhancements:
 
 - Errors thrown in handlers from plugins were being silently ignored. That's not cool. Now, they're being caught and logged.
  ([#152](https://github.com/probot/probot/pull/152))
-
 
 [View full changelog](https://github.com/probot/probot/compare/v0.5.0...v0.6.0)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "a trainable robot that responds to activity on GitHub",
   "repository": "https://github.com/probot/probot",
   "main": "index.js",


### PR DESCRIPTION
v0.6.0 will be a breaking change for most plugins because the GitHub client has changed the response format (https://github.com/mikedeboer/node-github/pull/505).

Before:

```js
const data = await github.search.issues(params);
data.items.forEach(item => doTheThing(issue));
```

After:

```js
const res = await github.search.issues(params);
res.data.items.forEach(item => doTheThing(issue));
``` 

- [x] Add `CHANGELOG.md`
- [x] :shipit: 
- [ ] Update [all the plugins](https://github.com/search?utf8=%E2%9C%93&q=topic%3Aprobot-plugin&type=Repositories)
  - [ ] https://github.com/probot/stale
  - [ ] https://github.com/probot/visitor
  - [ ] https://github.com/probot/autoresponder
  - [ ] https://github.com/probot/configurer
  - [ ] https://github.com/probot/dco
  - [ ] https://github.com/probot/owners
  - [ ] https://github.com/probot/workflow


[See Full Changelog](https://github.com/probot/probot/compare/v0.5.0...master)
