### PR TITLE
Add serializer for `repository` object

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,10 @@ module.exports = options => {
   const logger = bunyan.createLogger({
     name: 'PRobot',
     level: process.env.LOG_LEVEL || 'debug',
-    stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'})
+    stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
+    serializers: {
+      repository: repository => repository.full_name
+    }
   });
 
   const webhook = createWebhook({path: '/', secret: options.secret});


### PR DESCRIPTION
Given:

```js
robot.log.info({repository}, `Cancel interval schedule`);
```

Before:

```
22:16:08.744Z  INFO stale: Cancel interval schedule (id=84828848, full_name=probot/stale, private=false, html_url=https://github.com/probot/stale, description="automatically close stale Issues and Pull Requests", fork=false, url=https://api.github.com/repos/probot/stale, forks_url=https://api.github.com/repos/probot/stale/forks, teams_url=https://api.github.com/repos/probot/stale/teams, hooks_url=https://api.github.com/repos/probot/stale/hooks, events_url=https://api.github.com/repos/probot/stale/events, tags_url=https://api.github.com/repos/probot/stale/tags, merges_url=https://api.github.com/repos/probot/stale/merges, created_at=2017-03-13T13:21:06Z, updated_at=2017-06-09T06:28:19Z, pushed_at=2017-06-09T22:14:31Z, git_url=git://github.com/probot/stale.git, ssh_url=git@github.com:probot/stale.git, clone_url=https://github.com/probot/stale.git, svn_url=https://github.com/probot/stale, homepage=https://github.com/integration/probot-stale, size=75, stargazers_count=90, watchers_count=90, language=JavaScript, has_issues=true, has_projects=true, has_downloads=true, has_wiki=true, has_pages=false, forks_count=8, mirror_url=null, open_issues_count=14, forks=8, open_issues=14, watchers=90, default_branch=master)
```

After:

```
22:16:08.744Z  INFO stale: Cancel interval schedule (repository=probot/stale)
```