### PR TITLE
Retry localtunnel

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -36,9 +36,13 @@ if (!program.privateKey) {
 }
 
 if (program.tunnel) {
-  const setupTunnel = require('../lib/tunnel');
   try {
-    setupTunnel(program.tunnel, program.port);
+    const setupTunnel = require('../lib/tunnel');
+    setupTunnel(program.tunnel, program.port).then(tunnel => {
+      console.log('Listening on ' + tunnel.url);
+    }).catch(err => {
+      console.warn('Could not open tunnel: ', err.message);
+    });
   } catch (err) {
     console.warn('Run `npm install --save-dev localtunnel` to enable localtunnel.');
   }

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -36,31 +36,12 @@ if (!program.privateKey) {
 }
 
 if (program.tunnel) {
+  const setupTunnel = require('../lib/tunnel');
   try {
-    setupTunnel();
+    setupTunnel(program.tunnel, program.port);
   } catch (err) {
     console.warn('Run `npm install --save-dev localtunnel` to enable localtunnel.');
   }
-}
-
-function setupTunnel() {
-  // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
-  const localtunnel = require('localtunnel');
-  const subdomain = typeof program.tunnel === 'string' ?
-    program.tunnel :
-    require('os').userInfo().username;
-
-  const tunnel = localtunnel(program.port, {subdomain}, (err, tunnel) => {
-    if (err) {
-      console.warn('Could not open tunnel: ', err.message);
-    } else {
-      console.log('Listening on ' + tunnel.url);
-    }
-  });
-
-  tunnel.on('close', () => {
-    console.warn('Local tunnel closed');
-  });
 }
 
 const createProbot = require('../');

--- a/lib/server.js
+++ b/lib/server.js
@@ -7,6 +7,8 @@ module.exports = function (webhook) {
         console.error(err);
         res.statusCode = 500;
         res.end('Something has gone terribly wrong.');
+      } else if (req.url.split('?').shift() === '/ping') {
+        res.end('PONG');
       } else {
         res.statusCode = 404;
         res.end('no such location');

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,9 +1,9 @@
+const https = require('https');
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const localtunnel = require('localtunnel');
-const https = require('https');
 
 module.exports = function setupTunnel(subdomain, port, retries = 0) {
-  if(typeof subdomain !== 'string') {
+  if (typeof subdomain !== 'string') {
     subdomain = require('os').userInfo().username;
   }
 
@@ -12,18 +12,18 @@ module.exports = function setupTunnel(subdomain, port, retries = 0) {
       if (err) {
         reject(err);
       } else {
-        testTunnel(subdomain).then(() => resolve(tunnel)).catch(err => {
-          if(retries < 3) {
+        testTunnel(subdomain).then(() => resolve(tunnel)).catch(() => {
+          if (retries < 3) {
             console.warn(`Failed to connect to localtunnel.me. Trying again (tries: ${retries + 1})`);
             resolve(setupTunnel(subdomain, port, retries + 1));
           } else {
-            reject('Failed to connect to localtunnel.me. Giving up.');
+            reject(new Error('Failed to connect to localtunnel.me. Giving up.'));
           }
         });
       }
     });
   });
-}
+};
 
 // When a tunnel is closed and then immediately reopened (e.g. restarting the
 // server to reload changes), then localtunnel.me may connect but not pass
@@ -37,8 +37,8 @@ function testTunnel(subdomain) {
   };
 
   return new Promise((resolve, reject) => {
-    https.request(options, function(res) {
-      res.statusCode == 200 ? resolve() : reject();
+    https.request(options, res => {
+      return res.statusCode === 200 ? resolve() : reject();
     }).end();
   });
 }

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,22 +1,44 @@
 // eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const localtunnel = require('localtunnel');
+const https = require('https');
 
-module.exports = function (subdomain, port) {
-  if(subdomain !== 'string') {
+module.exports = function setupTunnel(subdomain, port, retries = 0) {
+  if(typeof subdomain !== 'string') {
     subdomain = require('os').userInfo().username;
   }
 
-  const tunnel = localtunnel(port, {subdomain}, (err, tunnel) => {
-    if (err) {
-      console.warn('Could not open tunnel: ', err.message);
-    } else {
-      console.log('Listening on ' + tunnel.url);
-    }
+  return new Promise((resolve, reject) => {
+    localtunnel(port, {subdomain}, (err, tunnel) => {
+      if (err) {
+        reject(err);
+      } else {
+        testTunnel(subdomain).then(() => resolve(tunnel)).catch(err => {
+          if(retries < 3) {
+            console.warn(`Failed to connect to localtunnel.me. Trying again (tries: ${retries + 1})`);
+            resolve(setupTunnel(subdomain, port, retries + 1));
+          } else {
+            reject('Failed to connect to localtunnel.me. Giving up.');
+          }
+        });
+      }
+    });
   });
+}
 
-  tunnel.on('close', () => {
-    console.warn('Local tunnel closed');
+// When a tunnel is closed and then immediately reopened (e.g. restarting the
+// server to reload changes), then localtunnel.me may connect but not pass
+// requests through. This test that the tunnel returns 200 for /ping.
+function testTunnel(subdomain) {
+  const options = {
+    host: `${subdomain}.localtunnel.me`,
+    port: 443,
+    path: '/ping',
+    method: 'GET'
+  };
+
+  return new Promise((resolve, reject) => {
+    https.request(options, function(res) {
+      res.statusCode == 200 ? resolve() : reject();
+    }).end();
   });
-
-  return tunnel;
 }

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,0 +1,22 @@
+// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
+const localtunnel = require('localtunnel');
+
+module.exports = function (subdomain, port) {
+  if(subdomain !== 'string') {
+    subdomain = require('os').userInfo().username;
+  }
+
+  const tunnel = localtunnel(port, {subdomain}, (err, tunnel) => {
+    if (err) {
+      console.warn('Could not open tunnel: ', err.message);
+    } else {
+      console.log('Listening on ' + tunnel.url);
+    }
+  });
+
+  tunnel.on('close', () => {
+    console.warn('Local tunnel closed');
+  });
+
+  return tunnel;
+}

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "github-integration": "^2.0.1",
     "github-webhook-handler": "^0.6.0",
     "load-plugins": "^2.1.2",
+    "localtunnel": "^1.8.2",
     "pkg-conf": "^2.0.0",
     "raven": "^2.0.0",
     "resolve": "^1.3.2",


### PR DESCRIPTION
When developing plugins, you have to restart the probot process to reload the code and localtunnel fails to reconnect about 50% of the time. I experimented with it and it just appears to be some race condition on the server. I didn't see anything [obvious looking through the code](https://github.com/localtunnel/server), but my guess is that it's not getting the disconnect from the first process until after the second connects, which then unroutes the newly connected client.

This PR updates probot to try making a request to the local tunnel and if it fails retrying to connect. Here's what it looks like.

```
$ npm start
Listening on https://bkeepers.localtunnel.me
^C
                                                                                                                                                              
$ npm start
Failed to connect to localtunnel.me. Trying again (tries: 1)
Listening on https://bkeepers.localtunnel.me
```

cc @jbjonesjr