### PR TITLE
Update Documentation

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,10 +83,10 @@ Once you have an app created, install `probot`:
 $ npm install -g probot
 ```
 
-and run your bot from your plugin's directory, replacing `private-key.pem` below with the path to the private key of your app.
+and run your bot from your plugin's directory, replacing `APP_ID` and `private-key.pem` below with your App's ID and the path to the private key of your app.
 
 ```
-$ probot run -P private-key.pem ./index.js
+$ probot run -a APP_ID -P private-key.pem ./index.js
 Listening on http://localhost:3000
 ```
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -83,10 +83,10 @@ Once you have an app created, install `probot`:
 $ npm install -g probot
 ```
 
-and run your bot from your plugin's directory, replacing `9999` and `private-key.pem` below with the ID and path to the private key of your app.
+and run your bot from your plugin's directory, replacing `private-key.pem` below with the path to the private key of your app.
 
 ```
-$ probot run -i 9999 -P private-key.pem ./index.js
+$ probot run -P private-key.pem ./index.js
 Listening on http://localhost:3000
 ```
 


### PR DESCRIPTION
including -i and the APP_ID in the command line argument are deprecated and give this command line error `DEPRECATION: The --integration flag and APP_ID environment variable are
deprecated. Use the --app flag or set APP_ID environment variable instead.`