### PR TITLE
Fix error when receiving events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 7.7.0
+## 0.7.1
+
+Fixes:
+
+- Fix error introduced in 0.7.0 that was preventing events from being received.
+
+[View full changelog](https://github.com/probot/probot/compare/v0.7.0...v0.7.1)
+
+## 0.7.0
 
 Breaking Changes:
 

--- a/lib/context.js
+++ b/lib/context.js
@@ -11,11 +11,6 @@ class Context {
     this.github = github;
   }
 
-  get event() {
-    console.warn('DEPRECATED: All properties of `context.event` are now directly available on `context` (e.g. `context.payload.sender`).');
-    return this;
-  }
-
   /**
    * Return the `owner` and `repo` params for making API requests against a
    * repository.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "a trainable robot that responds to activity on GitHub",
   "repository": "https://github.com/probot/probot",
   "main": "index.js",

--- a/test/context.js
+++ b/test/context.js
@@ -7,6 +7,7 @@ describe('Context', function () {
 
   beforeEach(function () {
     event = {
+      event: 'push',
       payload: {
         repository: {
           owner: {login: 'bkeepers'},


### PR DESCRIPTION
#158 had a bug that prevented any events from being received. It was caused by the `events` getter, which was really just trying to support backward compatibility with projects using `context.event`. I don't see any public code that uses that, so removing the getter.

cc @hiimbex