### PR TITLE
Fix typo in deprecation warning

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -20,7 +20,7 @@ program
 if (program.integration) {
   // FIXME: remove in v0.7.0
   console.warn(
-    `DEPRECATION: The --integration flag and APP_ID environment variable are\n` +
+    `DEPRECATION: The --integration flag and INTEGRATION_ID environment variable are\n` +
     `deprecated. Use the --app flag or set APP_ID environment variable instead.`
   );
   program.app = program.integration;


### PR DESCRIPTION
The deprecation warning boiled down to: APP_ID is deprecated, set APP_ID instead.
The deprecated environment variable is named INTEGRATION_ID.