### PR TITLE
Make it easier to test plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.7.2 (2017-06-30)
+
+Enhancements:
+
+- Refactor some internals to improve the testability of plugins. Docs coming soon after building out tests for several of the plugins.
+
 ## 0.7.1 (2017-06-16)
 
 Fixes:

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -11,7 +11,7 @@ program
   .usage('[options] <plugins...>')
   .option('-i, --integration <id>', 'DEPRECATED: ID of the GitHub App', process.env.INTEGRATION_ID)
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
-  .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET || 'development')
+  .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET)
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
   .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
   .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV !== 'production')

--- a/index.js
+++ b/index.js
@@ -73,3 +73,5 @@ module.exports = (options = {}) => {
     }
   };
 };
+
+module.exports.createRobot = createRobot;

--- a/index.js
+++ b/index.js
@@ -60,6 +60,10 @@ module.exports = options => {
 
     load(plugin) {
       plugin(robot);
+    },
+
+    receive(event) {
+      return webhook.emit(event.event, event);
     }
   };
 };

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = (options = {}) => {
     debug: process.env.LOG_LEVEL === 'trace'
   });
   const server = createServer(webhook);
-  const robot = createRobot({app, webhook, cache, logger});
+  const robot = createRobot({app, webhook, cache, logger, catchErrors: true});
 
   // Forward webhooks to robot
   webhook.on('*', event => {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const Raven = require('raven');
 const createRobot = require('./lib/robot');
 const createServer = require('./lib/server');
 
-module.exports = options => {
+module.exports = (options = {}) => {
   const cache = cacheManager.caching({
     store: 'memory',
     ttl: 60 * 60 // 1 hour
@@ -24,7 +24,7 @@ module.exports = options => {
     }
   });
 
-  const webhook = createWebhook({path: '/', secret: options.secret});
+  const webhook = createWebhook({path: '/', secret: options.secret || 'development'});
   const app = createApp({
     id: options.id,
     cert: options.cert,

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ module.exports = (options = {}) => {
   const server = createServer(webhook);
   const robot = createRobot({app, webhook, cache, logger});
 
+  // Forward webhooks to robot
+  webhook.on('*', event => {
+    this.log.trace(event, 'webhook received');
+    robot.receive(event);
+  });
+
   // Log all webhook errors
   webhook.on('error', logger.error.bind(logger));
 
@@ -63,7 +69,7 @@ module.exports = (options = {}) => {
     },
 
     receive(event) {
-      return webhook.emit(event.event, event);
+      return robot.receive(event);
     }
   };
 };

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -9,12 +9,12 @@ const Context = require('./context');
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor({app, cache, logger, throwErrors} = {}) {
+  constructor({app, cache, logger, catchErrors} = {}) {
     this.events = new EventEmitter();
     this.app = app;
     this.cache = cache;
     this.log = wrapLogger(logger);
-    this.throwErrors = throwErrors;
+    this.catchErrors = catchErrors;
   }
 
   async receive(event) {
@@ -66,10 +66,9 @@ class Robot {
           const context = new Context(event, github);
           return callback(context, context /* DEPRECATED: for backward compat */);
         } catch (err) {
-          if (this.throwErrors) {
+          this.log.error(err);
+          if (!this.catchErrors) {
             throw err;
-          } else {
-            this.log.error(err);
           }
         }
       }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -137,11 +137,11 @@ function rateLimitedClient(github) {
 //     robot.log.trace("verbose details");
 //
 function wrapLogger(logger) {
-  const fn = logger.debug.bind(logger);
+  const fn = logger ? logger.debug.bind(logger) : function () { };
 
   // Add level methods on the logger
   ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(level => {
-    fn[level] = logger[level].bind(logger);
+    fn[level] = logger ? logger[level].bind(logger) : function () { };
   });
 
   return fn;

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,4 +1,4 @@
-const {EventEmitter} = require('events');
+const {EventEmitter} = require('promise-events');
 const GitHubApi = require('github');
 const Bottleneck = require('bottleneck');
 const Context = require('./context');
@@ -16,9 +16,9 @@ class Robot {
     this.log = wrapLogger(logger);
   }
 
-  receive(event) {
-    this.events.emit('*', event);
-    this.events.emit(event.event, event);
+  async receive(event) {
+    await this.events.emit('*', event);
+    await this.events.emit(event.event, event);
   }
 
   /**

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -9,7 +9,7 @@ const Context = require('./context');
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor({app, cache, logger}) {
+  constructor({app, cache, logger} = {}) {
     this.events = new EventEmitter();
     this.app = app;
     this.cache = cache;

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -17,7 +17,8 @@ class Robot {
   }
 
   receive(event) {
-    return this.events.emit(event.event, event);
+    this.events.emit('*', event);
+    this.events.emit(event.event, event);
   }
 
   /**

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -9,16 +9,18 @@ const Context = require('./context');
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor({app, cache, logger} = {}) {
+  constructor({app, cache, logger, throwErrors} = {}) {
     this.events = new EventEmitter();
     this.app = app;
     this.cache = cache;
     this.log = wrapLogger(logger);
+    this.throwErrors = throwErrors;
   }
 
   async receive(event) {
-    await this.events.emit('*', event);
-    await this.events.emit(event.event, event);
+    return this.events.emit('*', event).then(() => {
+      return this.events.emit(event.event, event);
+    });
   }
 
   /**
@@ -64,7 +66,11 @@ class Robot {
           const context = new Context(event, github);
           return callback(context, context /* DEPRECATED: for backward compat */);
         } catch (err) {
-          this.log.error(err);
+          if (this.throwErrors) {
+            throw err;
+          } else {
+            this.log.error(err);
+          }
         }
       }
     });

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,3 +1,4 @@
+const {EventEmitter} = require('events');
 const GitHubApi = require('github');
 const Bottleneck = require('bottleneck');
 const Context = require('./context');
@@ -8,13 +9,15 @@ const Context = require('./context');
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor({app, webhook, cache, logger}) {
+  constructor({app, cache, logger}) {
+    this.events = new EventEmitter();
     this.app = app;
-    this.webhook = webhook;
     this.cache = cache;
     this.log = wrapLogger(logger);
+  }
 
-    this.webhook.on('*', event => this.log.trace(event, 'webhook received'));
+  receive(event) {
+    return this.events.emit(event.event, event);
   }
 
   /**
@@ -53,7 +56,7 @@ class Robot {
 
     const [name, action] = event.split('.');
 
-    return this.webhook.on(name, async event => {
+    return this.events.on(name, async event => {
       if (!action || action === event.payload.action) {
         try {
           const github = await this.auth(event.payload.installation.id);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "lockfileVersion": 1,
   "dependencies": {
     "acorn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2219,6 +2219,11 @@
       "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
       "dev": true
     },
+    "promise-events": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/promise-events/-/promise-events-0.1.3.tgz",
+      "integrity": "sha1-VyzKwrr4Joueup8zf1a+PIGB8n0="
+    },
     "proto-props": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/proto-props/-/proto-props-0.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "github-webhook-handler": "^0.6.0",
     "load-plugins": "^2.1.2",
     "pkg-conf": "^2.0.0",
+    "promise-events": "^0.1.3",
     "raven": "^2.1.0",
     "resolve": "^1.3.2",
     "semver": "^5.3.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "a trainable robot that responds to activity on GitHub",
   "repository": "https://github.com/probot/probot",
   "main": "index.js",

--- a/test/index.js
+++ b/test/index.js
@@ -17,7 +17,7 @@ describe('Probot', () => {
 
   describe('receive', () => {
     it('delivers the event', async () => {
-      spy = expect.createSpy();
+      const spy = expect.createSpy();
       probot.load(robot => robot.on('push', spy));
 
       await probot.receive(event);
@@ -26,8 +26,6 @@ describe('Probot', () => {
     });
 
     it('raises errors thrown in plugins', async () => {
-      spy = expect.createSpy();
-
       probot.load(robot => robot.on('push', () => {
         throw new Error('something happened');
       }));

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,40 @@
+const expect = require('expect');
+const createProbot = require('..');
+
+describe('Probot', () => {
+  let probot;
+  let event;
+
+  beforeEach(() => {
+    probot = createProbot();
+    probot.robot.auth = () => Promise.resolve({});
+
+    event = {
+      event: 'push',
+      payload: require('./fixtures/webhook/push')
+    };
+  });
+
+  describe('receive', () => {
+    it('delivers the event', async () => {
+      spy = expect.createSpy();
+      probot.load(robot => robot.on('push', spy));
+
+      await probot.receive(event);
+
+      expect(spy).toHaveBeenCalled();
+    });
+
+    it('raises errors thrown in plugins', async () => {
+      spy = expect.createSpy();
+
+      probot.load(robot => robot.on('push', () => {
+        throw new Error('something happened');
+      }));
+
+      expect(async () => {
+        await probot.receive(event);
+      }).toThrow();
+    });
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -6,7 +6,7 @@ describe('Robot', () => {
   let event;
 
   beforeEach(() => {
-    robot = createRobot({throwErrors: true});
+    robot = createRobot();
     robot.auth = () => Promise.resolve({});
 
     event = {

--- a/test/index.js
+++ b/test/index.js
@@ -1,13 +1,13 @@
 const expect = require('expect');
-const createProbot = require('..');
+const {createRobot} = require('..');
 
-describe('Probot', () => {
-  let probot;
+describe('Robot', () => {
+  let robot;
   let event;
 
   beforeEach(() => {
-    probot = createProbot();
-    probot.robot.auth = () => Promise.resolve({});
+    robot = createRobot({throwErrors: true});
+    robot.auth = () => Promise.resolve({});
 
     event = {
       event: 'push',
@@ -18,21 +18,24 @@ describe('Probot', () => {
   describe('receive', () => {
     it('delivers the event', async () => {
       const spy = expect.createSpy();
-      probot.load(robot => robot.on('push', spy));
+      robot.on('push', spy);
 
-      await probot.receive(event);
+      await robot.receive(event);
 
       expect(spy).toHaveBeenCalled();
     });
 
-    it('raises errors thrown in plugins', async () => {
-      probot.load(robot => robot.on('push', () => {
-        throw new Error('something happened');
-      }));
+    it('returns a reject errors thrown in plugins', async () => {
+      robot.on('push', () => {
+        throw new Error('error from plugin');
+      });
 
-      expect(async () => {
-        await probot.receive(event);
-      }).toThrow();
+      try {
+        await robot.receive(event);
+        throw new Error('expected error to be raised from plugin');
+      } catch (err) {
+        expect(err.message).toEqual('error from plugin');
+      }
     });
   });
 });

--- a/test/robot.js
+++ b/test/robot.js
@@ -72,6 +72,25 @@ describe('Robot', function () {
     });
   });
 
+  describe('receive', () => {
+    it('waits for async events to resolve', async () => {
+      const spy = expect.createSpy();
+
+      robot.on('test', () => {
+        return new Promise(resolve => {
+          setTimeout(() => {
+            spy();
+            resolve();
+          }, 1);
+        })
+      });
+
+      await robot.receive(event);
+
+      expect(spy).toHaveBeenCalled();
+    });
+  });
+
   describe('error handling', () => {
     it('logs errors throw from handlers', async () => {
       const error = new Error('testing');

--- a/test/robot.js
+++ b/test/robot.js
@@ -51,7 +51,7 @@ describe('Robot', function () {
       robot.on('*', spy);
 
       await robot.receive(event);
-      expect(spy).toNotHaveBeenCalled();
+      expect(spy).toHaveBeenCalled();
     });
   });
 

--- a/test/robot.js
+++ b/test/robot.js
@@ -82,7 +82,7 @@ describe('Robot', function () {
             spy();
             resolve();
           }, 1);
-        })
+        });
       });
 
       await robot.receive(event);

--- a/test/robot.js
+++ b/test/robot.js
@@ -2,23 +2,12 @@ const expect = require('expect');
 const Context = require('../lib/context');
 const createRobot = require('../lib/robot');
 
-function createNullLogger() {
-  const logger = expect.createSpy();
-
-  ['trace', 'debug', 'info', 'warn', 'error', 'fatal'].forEach(level => {
-    logger[level] = expect.createSpy();
-  });
-
-  return logger;
-}
-
 describe('Robot', function () {
   let webhook;
   let robot;
   let event;
   let callbacks;
   let spy;
-  let logger;
 
   beforeEach(function () {
     callbacks = {};
@@ -33,8 +22,7 @@ describe('Robot', function () {
       }
     };
 
-    logger = createNullLogger();
-    robot = createRobot({webhook, logger});
+    robot = createRobot({webhook});
     robot.auth = () => {};
 
     event = {
@@ -76,6 +64,7 @@ describe('Robot', function () {
   describe('error handling', () => {
     it('logs errors throw from handlers', async () => {
       const error = new Error('testing');
+      robot.log.error = expect.createSpy();
 
       robot.on('test', () => {
         throw error;
@@ -83,7 +72,7 @@ describe('Robot', function () {
 
       await webhook.emit('test', event);
 
-      expect(logger.error).toHaveBeenCalledWith(error);
+      expect(robot.log.error).toHaveBeenCalledWith(error);
     });
   });
 });

--- a/test/robot.js
+++ b/test/robot.js
@@ -100,7 +100,11 @@ describe('Robot', function () {
         throw error;
       });
 
-      await robot.receive(event);
+      try {
+        await robot.receive(event);
+      } catch (err) {
+        // Expected
+      }
 
       expect(robot.log.error).toHaveBeenCalledWith(error);
     });

--- a/test/robot.js
+++ b/test/robot.js
@@ -8,7 +8,7 @@ describe('Robot', function () {
   let spy;
 
   beforeEach(function () {
-    robot = createRobot({});
+    robot = createRobot();
     robot.auth = () => {};
 
     event = {
@@ -20,6 +20,23 @@ describe('Robot', function () {
     };
 
     spy = expect.createSpy();
+  });
+
+  describe('constructor', () => {
+    it('takes a logger', () => {
+      const logger = {
+        trace: expect.createSpy(),
+        debug: expect.createSpy(),
+        info: expect.createSpy(),
+        warn: expect.createSpy(),
+        error: expect.createSpy(),
+        fatal: expect.createSpy()
+      };
+      robot = createRobot({logger});
+
+      robot.log('hello world');
+      expect(logger.debug).toHaveBeenCalledWith('hello world');
+    });
   });
 
   describe('on', function () {


### PR DESCRIPTION
This is a WIP to try to make it easier to test plugins. Here's basically how it works:

```js
const createProbot = require('probot');
const plugin = require('path/to/my/plugin');

const probot = createProbot();
probot.load(plugin);

probot.receive({
  event: 'push',
  // `push.json` has the payload copied from the webhook deliveries listed on GitHub
  payload: require('./fixtures/push') 
});
```

@hiimbex @kytrinyx @lee-dohm #101 