### PR TITLE
Add nodemon option to  development docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -16,6 +16,8 @@ You'll need to create a test repository and install your app by clicking the "In
 
 Whenever you come back to work on the app after you've already had it running once, you should only need to run `$ npm start`.
 
+Optionally, you can also run your plguin through [nodemon](https://github.com/remy/nodemon#nodemon) which will listen on any files changes in your local development environment and automatically restart the server. After installing nodemon, you can run `nodemon --exec "npm start"` and from there the server will automatically restart upon file changes.
+
 ## Debugging
 
 1. Always run `$ npm install` and restart the server if package.json has changed.

--- a/docs/development.md
+++ b/docs/development.md
@@ -16,7 +16,7 @@ You'll need to create a test repository and install your app by clicking the "In
 
 Whenever you come back to work on the app after you've already had it running once, you should only need to run `$ npm start`.
 
-Optionally, you can also run your plguin through [nodemon](https://github.com/remy/nodemon#nodemon) which will listen on any files changes in your local development environment and automatically restart the server. After installing nodemon, you can run `nodemon --exec "npm start"` and from there the server will automatically restart upon file changes.
+Optionally, you can also run your plugin through [nodemon](https://github.com/remy/nodemon#nodemon) which will listen on any files changes in your local development environment and automatically restart the server. After installing nodemon, you can run `nodemon --exec "npm start"` and from there the server will automatically restart upon file changes.
 
 ## Debugging
 


### PR DESCRIPTION
I know we mentioned finding a better way to restart the server in our last conversation, so I thought in the mean time it might be worth adding this npm module as an option that automatically restarts the server for you.

For me, a newbie to some development practices, it would've been nice to have this recommendation I think. Thoughts?

cc/ @bkeepers @kytrinyx 