### PR TITLE
[WIP] Adds an option to expose the http server for adding more routes

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ const createRobot = require('./lib/robot');
 const createServer = require('./lib/server');
 
 module.exports = (options = {}) => {
+  options.webhookPath = options.webhookPath || '/';
   const cache = cacheManager.caching({
     store: 'memory',
     ttl: 60 * 60 // 1 hour
@@ -24,13 +25,13 @@ module.exports = (options = {}) => {
     }
   });
 
-  const webhook = createWebhook({path: '/', secret: options.secret || 'development'});
+  const webhook = createWebhook({path: options.webhookPath, secret: options.secret || 'development'});
   const app = createApp({
     id: options.id,
     cert: options.cert,
     debug: process.env.LOG_LEVEL === 'trace'
   });
-  const server = createServer(webhook);
+  const server = createServer(webhook, options.handler);
   const robot = createRobot({app, webhook, cache, logger, catchErrors: true});
 
   // Forward webhooks to robot

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,7 +1,7 @@
 const http = require('http');
 
-module.exports = function (webhook) {
-  return http.createServer((req, res) => {
+const createHandler = function (webhook, handler) {
+  return function (req, res) {
     webhook(req, res, err => {
       if (err) {
         console.error(err);
@@ -9,10 +9,18 @@ module.exports = function (webhook) {
         res.end('Something has gone terribly wrong.');
       } else if (req.url.split('?').shift() === '/ping') {
         res.end('PONG');
+      } else if (handler) {
+        handler(req, res);
       } else {
         res.statusCode = 404;
         res.end('no such location');
       }
     });
-  });
+  };
 };
+
+const createServer = function (webhook, handler = undefined) {
+  return http.createServer(createHandler(webhook, handler));
+};
+createServer.createHandler = createHandler;
+module.exports = createServer;

--- a/test/server.js
+++ b/test/server.js
@@ -1,0 +1,60 @@
+const expect = require('expect');
+const createServer = require('../lib/server');
+
+describe('Server', () => {
+  let handler;
+  let webhook;
+  let req;
+  let res;
+
+  describe('handler', () => {
+    it('should 500 on a webhook error', () => {
+      webhook = function (req, res, callback) {
+        callback('webhook error');
+      };
+      handler = createServer.createHandler(webhook);
+      req = {url: ''};
+      res = {};
+      res.end = expect.createSpy();
+      handler(req, res);
+      expect(res.end).toHaveBeenCalledWith('Something has gone terribly wrong.');
+      expect(res.statusCode).toEqual(500);
+    });
+
+    it('should respond with PONG for `/ping`', () => {
+      webhook = function (req, res, callback) {
+        callback(null);
+      };
+      handler = createServer.createHandler(webhook);
+      req = {url: '/ping'};
+      res = {};
+      res.end = expect.createSpy();
+      handler(req, res);
+      expect(res.end).toHaveBeenCalledWith('PONG');
+    });
+
+    it('should respond with 404 if no handler is present', () => {
+      webhook = function (req, res, callback) {
+        callback(null);
+      };
+      handler = createServer.createHandler(webhook);
+      req = {url: '/404'};
+      res = {};
+      res.end = expect.createSpy();
+      handler(req, res);
+      expect(res.end).toHaveBeenCalledWith('no such location');
+      expect(res.statusCode).toEqual(404);
+    });
+
+    it('should delegate to the handler if present and webhook 404s', () => {
+      webhook = function (req, res, callback) {
+        callback(null);
+      };
+      const handlerSpy = expect.createSpy();
+      handler = createServer.createHandler(webhook, handlerSpy);
+      req = {url: '/blog'};
+      handler(req, res);
+      expect(handlerSpy).toHaveBeenCalledWith(req, res);
+    });
+  });
+});


### PR DESCRIPTION
**tl;dr** First pass at allowing probot to respond to more http requests than just those for webhooks.

---
:wave: Hi! I've been wanting to use probot for a while but I also want to have some simple express routes accessible from the same process. I considered sharing a large lib and writing two different entrypoints, one for probot and one for express. But then I realized the default webhook path (which is not currently configurable) would mean I would still have to mess with probot code b/c I didn't `/` to be used for webhooks. 

I'm not super confident in the approach I took. The way I exported the new `createHandler` function felt weird but I didn't want break existing probot integrations that might rely on `var createServer = require('./lib/server');` returning a single method that creates the server. 

That being said, happy to iterate w/ any feedback from the team! Thanks again for all your hard work 😄 

This should fix #107 

