### PR TITLE
Remove deprecated integration id

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -9,22 +9,12 @@ const {findPrivateKey} = require('../lib/private-key');
 
 program
   .usage('[options] <plugins...>')
-  .option('-i, --integration <id>', 'DEPRECATED: ID of the GitHub App', process.env.INTEGRATION_ID)
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
   .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET)
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
   .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
   .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV !== 'production')
   .parse(process.argv);
-
-if (program.integration) {
-  // FIXME: remove in v0.7.0
-  console.warn(
-    `DEPRECATION: The --integration flag and INTEGRATION_ID environment variable are\n` +
-    `deprecated. Use the --app flag or set APP_ID environment variable instead.`
-  );
-  program.app = program.integration;
-}
 
 if (!program.app) {
   console.warn('Missing GitHub App ID.\nUse --app flag or set APP_ID environment variable.');


### PR DESCRIPTION
Integration id was set to be removed in 0.7. We're past that version, so cleaning up the deprecated option.