### PR TITLE
Add support for update-docs and new-issue-welcome

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,16 @@
 firstPRMergeComment: >
   Thanks for your contribution to probot! :tada:
   ![Congrats!](https://media.giphy.com/media/o0vwzuFwCGAFO/giphy.gif)
+
+updateDocsWhiteList:
+  - bug
+  - update doc
+  - updates doc
+
+updateDocsComment: >
+  Thanks for opening this pull request! :sparkles: 
+  The maintainers of probot would appreciate it if you would update some of our documentation, found [here](https://github.com/probot/probot/tree/master/docs) based on your changes.
+
+firstIssueWelcomeComment: >
+  Thanks for opening this issue. 
+  If this issue is regarding feedback about your probot experience, such as things that you found frustrating or confusing, it would be great if you could close this out and open an issue in our [probot/friction](https://github.com/probot/friction) repo instead.


### PR DESCRIPTION
So I was doing some more thinking about good use cases for the plugins I built, and saw #191 and the new probot/friction repo, and thought this seemed like an excellent potential use case for new-issue-welcome. I also added update-docs params since I think that's something we could improve on. This PR should be accompanied by the enablement of update-docs on probot.

These were just my initial draft up messages. I'd love to hear any other thoughts or ideas!