### PR TITLE
Fix deprecation test

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -82,9 +82,10 @@ describe('Probot', () => {
 
   describe('robot', () => {
     it('will be removed in 0.10', () => {
+      // This test will fail in version 0.10
       const semver = require('semver');
       const pkg = require('../package');
-      expect(semver.satisfies(pkg.version, '>=0.9')).toBe(false, 'remove in 0.10.0');
+      expect(semver.satisfies(pkg.version, '<=0.9')).toBe(true);
     });
 
     it('returns the first defined (for now)', () => {

--- a/test/index.js
+++ b/test/index.js
@@ -85,7 +85,7 @@ describe('Probot', () => {
       // This test will fail in version 0.10
       const semver = require('semver');
       const pkg = require('../package');
-      expect(semver.satisfies(pkg.version, '<=0.9')).toBe(true);
+      expect(semver.satisfies(pkg.version, '<0.10')).toBe(true);
     });
 
     it('returns the first defined (for now)', () => {


### PR DESCRIPTION
This test should fail while the current version is less than `0.10`. The previous logic was flipped (which was confusing to me) and failing because we are on exactly 0.9

This should allow the CI for #192 to pass.