### PR TITLE
Return null if config is not found

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -87,9 +87,18 @@ class Context {
    */
   async config(fileName, defaultConfig = {}) {
     const params = this.repo({path: path.join('.github', fileName)});
-    const res = await this.github.repos.getContent(params);
-    const config = yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString()) || {};
-    return Object.assign({}, defaultConfig, config);
+
+    try {
+      const res = await this.github.repos.getContent(params);
+      const config = yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString()) || {};
+      return Object.assign({}, defaultConfig, config);
+    } catch (err) {
+      if (err.code === 404) {
+        return null;
+      } else {
+        throw err;
+      }
+    }
   }
 }
 

--- a/test/context.js
+++ b/test/context.js
@@ -105,20 +105,12 @@ describe('Context', function () {
       });
     });
 
-    it('throws when the file is missing', async function () {
-      github.repos.getContent.andReturn(Promise.reject(new Error('An error occurred')));
+    it('returns null when the file is missing', async function () {
+      const error = new Error('An error occurred');
+      error.code = 404;
+      github.repos.getContent.andReturn(Promise.reject(error));
 
-      let e;
-      let contents;
-      try {
-        contents = await context.config('test-file.yml');
-      } catch (err) {
-        e = err;
-      }
-
-      expect(contents).toNotExist();
-      expect(e).toExist();
-      expect(e.message).toEqual('An error occurred');
+      expect(await context.config('test-file.yml')).toBe(null);
     });
 
     it('throws when the configuration file is malformed', async function () {


### PR DESCRIPTION
Before:

```js
try {
  const config = await context.config('foobar.yml');
  // do stuff with the config
} catch (err) {
  if(err.code !== 404) {
    throw err;
  } else {
    // config was not found
  } 
}
```

After:

```js
const config = await context.config('foobar.yml');

if (config) {
    // do stuff with the config
} else {
    // config was not found
}
```

cc @hiimbex 