### PR TITLE
Add test for event serializer and fix cause of error

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const Raven = require('raven');
 
 const createRobot = require('./lib/robot');
 const createServer = require('./lib/server');
+const serializers = require('./lib/serializers');
 
 module.exports = (options = {}) => {
   const cache = cacheManager.caching({
@@ -19,16 +20,7 @@ module.exports = (options = {}) => {
     name: 'PRobot',
     level: process.env.LOG_LEVEL || 'debug',
     stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
-    serializers: {
-      repository: repository => repository.full_name,
-      event: ({id, event, payload}) => {
-        return {
-          id, event,
-          action: payload.action,
-          repository: payload.repository && payload.repository.full_name
-        };
-      }
-    }
+    serializers
   });
 
   const webhook = createWebhook({path: '/', secret: options.secret || 'development'});

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -1,0 +1,16 @@
+module.exports = {
+  repository: repository => repository.full_name,
+  event: event => {
+    if (typeof event !== 'object' || !event.payload) {
+      return event;
+    } else {
+      return {
+        id: event.id,
+        event: event.event,
+        action: event.payload.action,
+        repository: event.payload.repository && event.payload.repository.full_name
+      };
+    }
+  },
+  installation: installation => installation.account.login
+};

--- a/test/serializers.js
+++ b/test/serializers.js
@@ -1,0 +1,27 @@
+const expect = require('expect');
+const serializers = require('../lib/serializers');
+
+describe('serializers', () => {
+  describe('event', () => {
+    it('works with a legit event', () => {
+      const event = {id: 1, event: 'test', payload: {
+        action: 'test',
+        repository: {full_name: 'probot/test'}
+      }};
+      expect(serializers.event(event)).toEqual({
+        id: 1,
+        event: 'test',
+        action: 'test',
+        repository: 'probot/test'
+      });
+    });
+
+    it('works with boolean', () => {
+      expect(serializers.event(false)).toBe(false);
+    });
+
+    it('works empty object', () => {
+      expect(serializers.event({})).toEqual({});
+    });
+  });
+});


### PR DESCRIPTION
The serializer in #196 is causing the following log occasionally:

```
bunyan: ERROR: Exception thrown from the "event" Bunyan serializer. This should never happen. This is a bug in that serializer function.
TypeError: Cannot read property 'action' of undefined
```

This extracts the serializers so they can be tested, and fixes the event serializer to work if it's passed anything that doesn't look like a webhook event.