### PR TITLE
Return defaultConfig

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -85,7 +85,7 @@ class Context {
    * @param {object} [defaultConfig] - An object of default config options
    * @return {Promise<Object>} - Configuration object read from the file
    */
-  async config(fileName, defaultConfig = {}) {
+  async config(fileName, defaultConfig) {
     const params = this.repo({path: path.join('.github', fileName)});
 
     try {
@@ -94,6 +94,9 @@ class Context {
       return Object.assign({}, defaultConfig, config);
     } catch (err) {
       if (err.code === 404) {
+        if (defaultConfig) {
+          return defaultConfig;
+        }
         return null;
       } else {
         throw err;

--- a/test/context.js
+++ b/test/context.js
@@ -113,6 +113,19 @@ describe('Context', function () {
       expect(await context.config('test-file.yml')).toBe(null);
     });
 
+    it('returns the default config when the file is missing and default config is passed', async function () {
+      const error = new Error('An error occurred');
+      error.code = 404;
+      github.repos.getContent.andReturn(Promise.reject(error));
+      const defaultConfig = {
+        foo: 5,
+        bar: 7,
+        baz: 11
+      };
+      const contents = await context.config('test-file.yml', defaultConfig);
+      expect(contents).toEqual(defaultConfig);
+    });
+
     it('throws when the configuration file is malformed', async function () {
       github.repos.getContent.andReturn(Promise.resolve(readConfig('malformed.yml')));
 


### PR DESCRIPTION
This is an extension of #198 and [my original comment there](https://github.com/probot/probot/pull/198#issuecomment-321295433).

When calling:

```js
const content = await context.config('filename.yml', {foo: 'bar'});
```

If the config file is missing *and* a default config object has been passed, return that object instead of `null`.