### PR TITLE
Bumps webhook dep and adds webhookPath config

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -13,6 +13,7 @@ program
   .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET)
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
   .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
+  .option('-w, --webhook-path <path>', 'URL path which receives webhooks. Ex: `/webhook`', process.env.WEBHOOK_PATH)
   .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV !== 'production')
   .parse(process.argv);
 
@@ -44,7 +45,8 @@ const probot = createProbot({
   id: program.app,
   secret: program.secret,
   cert: program.privateKey,
-  port: program.port
+  port: program.port,
+  webhookPath: program.webhookPath
 });
 
 pkgConf('probot').then(pkg => {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ module.exports = (options = {}) => {
     serializers
   });
 
-  const webhook = createWebhook({path: '/', secret: options.secret || 'development'});
+  const webhook = createWebhook({path: options.webhookPath || '/', secret: options.secret || 'development'});
   const app = createApp({
     id: options.id,
     cert: options.cert,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1680,9 +1680,7 @@
       }
     },
     "github-webhook-handler": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/github-webhook-handler/-/github-webhook-handler-0.6.0.tgz",
-      "integrity": "sha1-CYHJOMFjWZBkoMVeadyp4hOTxpY=",
+      "version": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
       "requires": {
         "bl": "1.1.2",
         "buffer-equal-constant-time": "1.0.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "express": "^4.15.3",
     "github": "^9.2.0",
     "github-app": "^3.0.0",
-    "github-webhook-handler": "^0.6.0",
+    "github-webhook-handler": "rvagg/github-webhook-handler#v0.6.1",
     "js-yaml": "^3.8.4",
     "load-plugins": "^2.1.2",
     "pkg-conf": "^2.0.0",


### PR DESCRIPTION
### Changes in this PR:

1. Pins the `github-webhook-handler` dependency to `v0.6.1`, which includes changes submitted by @bkeepers  in https://github.com/rvagg/github-webhook-handler/pull/24 to allow `GET` requests to get delegated to the next middleware instead of erroring out. 
2. Adds a command line parameter & config to support passing in a `webhookPath` variable. This allows the user to override the default `/` path used for webhooks. 

Fixes #202 - Serving static files should be completely doable from any route after these changes. 
/cc @tbarn @bkeepers @hiimbex 

--- 

### Notes

I added tests but I also wanted to prove to myself that the command line options were working as expected. I ran probot using these options:

`./bin/probot-run.js --app 234 --private-key='index.js' -w '/webhook'`

*Note:* `--app` and `--private-key` are required but I just picked random values that allowed me to get past the basic validation. 

Then I curled the server with these options to make sure the `-w` flag was working as expected:

```
~ ❯ curl http://localhost:3000/
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /</pre>
</body>
</html>
~ ❯ curl http://localhost:3000/webhook
<!DOCTYPE html>
<html lang="en">
<head>
<meta charset="utf-8">
<title>Error</title>
</head>
<body>
<pre>Cannot GET /webhook</pre>
</body>
</html>
~ ❯ curl -X POST  http://localhost:3000/webhook
{"error":"No X-Hub-Signature found on request"}% 
```
I don't think we have any "integration" tests that cover the command line parameter parsing so this can probably do for now. 🙃 