### PR TITLE
Add a temp docs link

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -192,6 +192,10 @@ $ cd my-plugin
 $ npm install
 ```
 
+## API
+
+Currently our Probot API docs live [here](https://probot.github.io/probot/latest/).
+
 ## Next
 
 - [See the full Probot API](https://probot.github.io/probot/latest/)


### PR DESCRIPTION
I think it's worthwhile to draw more attention to these docs by giving them their own heading for now. Once we solidify the direction for docs and do that, this would probably be removed.

cc/ #205 @bkeepers 