### PR TITLE
Rename plugin => app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Apps are easy to write, deploy, and share. Here are just a few examples of thing
 
 - [stale](https://github.com/probot/stale) - closes abandoned issues after a period of inactivity.
 - [owners](https://github.com/probot/owners) - @mentions people in Pull Requests based on contents of the OWNERS file
-- [configurer](https://github.com/probot/configurer) - syncs repository settings defined in `.github/config.yml` to GitHub, enabling Pull Requests for repository settings.
+- [settings](https://github.com/probot/settings) - syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
 
 Check out [all Probot apps](https://github.com/search?q=topic%3Aprobot-app&type=Repositories).
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ There are some great services that offer [apps in the GitHub Marketplace](https:
 
 ## Apps
 
-Apps are easy to write, deploy, and share. Here are just a few examples of things that can be build with Probot:
+Apps are easy to write, deploy, and share. Here are just a few examples of things that can be built with Probot:
 
 - [stale](https://github.com/probot/stale) - closes abandoned issues after a period of inactivity.
 - [owners](https://github.com/probot/owners) - @mentions people in Pull Requests based on contents of the OWNERS file

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you 
 
 There are some great services that offer [apps in the GitHub Marketplace](https://github.com/marketplace), and you can build a bunch of really cool things yourself. Probot aims to make that easy.
 
-## Plugins
+## Apps
 
-Bots are implemented as plugins, which are easy to write, deploy, and share. Here are just a few examples of things probot can do:
+Apps are easy to write, deploy, and share. Here are just a few examples of things that can be build with Probot:
 
 - [stale](https://github.com/probot/stale) - closes abandoned issues after a period of inactivity.
 - [owners](https://github.com/probot/owners) - @mentions people in Pull Requests based on contents of the OWNERS file
 - [configurer](https://github.com/probot/configurer) - syncs repository settings defined in `.github/config.yml` to GitHub, enabling Pull Requests for repository settings.
 
-Check out [all probot plugins](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories).
+Check out [all Probot apps](https://github.com/search?q=topic%3Aprobot-app&type=Repositories).
 
 ## Contributing
 
-Most of the interesting things are built with plugins, so consider starting by [writing a new plugin](docs/plugins.md) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories).
+Most of the interesting things are built with plugins, so consider starting by [writing a new app](docs/) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-app&type=Repositories).

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -8,7 +8,7 @@ const program = require('commander');
 const {findPrivateKey} = require('../lib/private-key');
 
 program
-  .usage('[options] <plugins...>')
+  .usage('[options] <apps...>')
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
   .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET)
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
@@ -48,7 +48,7 @@ const probot = createProbot({
 });
 
 pkgConf('probot').then(pkg => {
-  const plugins = require('../lib/plugin')(probot);
+  const apps = require('../lib/plugin')(probot);
   const requestedPlugins = program.args.concat(pkg.plugins || []);
 
   // If we have explicitly requested plugins, load them; otherwise use autoloading

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -48,7 +48,7 @@ const probot = createProbot({
 });
 
 pkgConf('probot').then(pkg => {
-  const apps = require('../lib/plugin')(probot);
+  const plugins = require('../lib/plugin')(probot);
   const requestedPlugins = program.args.concat(pkg.plugins || []);
 
   // If we have explicitly requested plugins, load them; otherwise use autoloading

--- a/bin/probot-simulate.js
+++ b/bin/probot-simulate.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-// Usage: bin/simulate issues path/to/payload plugin.js
+// Usage: bin/simulate issues path/to/payload app.js
 
 require('dotenv').config({silent: true});
 
@@ -8,7 +8,7 @@ const program = require('commander');
 const {findPrivateKey} = require('../lib/private-key');
 
 program
-  .usage('[options] <event-name> <path/to/payload.json> [path/to/plugin.js...]')
+  .usage('[options] <event-name> <path/to/payload.json> [path/to/app.js...]')
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
   .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
   .parse(process.argv);

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ Probot apps are easy to write, deploy, and share. Many of the most popular Probo
 - [stale](/apps/stale/) - closes abandoned issues after a period of inactivity.
 - [settings](/apps/settings/) - syncs repository settings defined in `.github/config.yml` to GitHub, enabling Pull Requests for repository settings.
 - [request-info](/apps/request-info/) - requests more info from newly opened Pull Requests and Issues that contain either default titles or whose description is left blank.
-- [Browse more examples](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories)
+- [Browse more examples](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
 
 Ready to get started?

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,12 +1,12 @@
-# Best Practices
+Plu# Best Practices
 
-First and foremost, your plugin must obey the [The Three Laws of Robotics](https://en.wikipedia.org/wiki/Three_Laws_of_Robotics):
+First and foremost, your app must obey the [The Three Laws of Robotics](https://en.wikipedia.org/wiki/Three_Laws_of_Robotics):
 
 > 1. A robot may not injure a human being or, through inaction, allow a human being to come to harm.
 > 2. A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
 > 3. A robot must protect its own existence as long as such protection does not conflict with the First or Second Laws.
 
-Now that we agree that nobody will get hurt, here are some tips to make your plugin more effective.
+Now that we agree that nobody will get hurt, here are some tips to make your app more effective.
 
 **Contents:**
 
@@ -18,7 +18,7 @@ Now that we agree that nobody will get hurt, here are some tips to make your plu
 
 Understanding and being aware of the what another person is thinking or feeling is critical to healthy relationships. This is true for interactions with humans as well as bots, and it works both ways. Empathy enhances our [ability to receive and process information](http://5a5f89b8e10a225a44ac-ccbed124c38c4f7a3066210c073e7d55.r9.cf1.rackcdn.com/files/pdfs/news/Empathy_on_the_Edge.pdf), and it helps us communicate more effectively.
 
-Think about how how people will experience the interactions with your plugin.
+Think about how how people will experience the interactions with your app.
 
 ### Avoid the uncanny valley
 
@@ -35,26 +35,26 @@ Your bot should be empathetic, but it shouldn't pretend to be human. It is a bot
 
 ### Never take bulk actions without explicit permission
 
-Being installed on an account is sufficient permission for actions in response to a user action, like replying on a single issue. But a plugin _must_ have explicit permission before performing bulk actions, like labeling all open issues.
+Being installed on an account is sufficient permission for actions in response to a user action, like replying on a single issue. But a app _must_ have explicit permission before performing bulk actions, like labeling all open issues.
 
-For example, the [stale](https://github.com/probot/stale) plugin will only scan a repository for stale issues and pull requests if `.github/stale.yml` exists in the repository.
+For example, the [stale](https://github.com/probot/stale) app will only scan a repository for stale issues and pull requests if `.github/stale.yml` exists in the repository.
 
 ### Include "dry run" functionality
 
-A dry run is when a plugin, instead of actually taking an action, only logs what actions it would have taken if it wasn't a dry run. A plugin _must_ offer a dry run feature if it does anything destructive and _should_ offer a dry run feature in all cases.
+A dry run is when a app, instead of actually taking an action, only logs what actions it would have taken if it wasn't a dry run. A app _must_ offer a dry run feature if it does anything destructive and _should_ offer a dry run feature in all cases.
 
-For example, the [stale](https://github.com/probot/stale) plugin will perform a dry run if there is no `.github/stale.yml` file in the repository.
+For example, the [stale](https://github.com/probot/stale) app will perform a dry run if there is no `.github/stale.yml` file in the repository.
 
 ## Configuration
 
 ### Require minimal configuration
 
-Plugins _should_ provide sensible defaults for all settings.
+Apps _should_ provide sensible defaults for all settings.
 
 ### Provide full configuration
 
-Plugins _should_ allow all settings to customized for each installation.
+Apps _should_ allow all settings to customized for each installation.
 
 ### Store configuration in the repository
 
-Any configuration _should_ be stored in the repository. Unless the plugin is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/probot/latest/Context.html#config).
+Any configuration _should_ be stored in the repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/probot/latest/Context.html#config).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,35 +4,35 @@ next: docs/best-practices.md
 
 # Deployment
 
-Every plugin can either be deployed as a stand-alone bot, or combined with other plugins in one deployment.
+Every app can either be deployed stand-alone, or combined with other apps in one deployment.
 
-> **Heads up!** Note that most [plugins in the @probot organization](https://github.com/search?q=topic%3Aprobot-plugin+org%3Aprobot&type=Repositories) have an official hosted app that you can use for your open source project. Use the hosted instance if you don't want to deploy your own.
+> **Heads up!** Note that most [apps in the @probot organization](https://github.com/search?q=topic%3Aprobot-app+org%3Aprobot&type=Repositories) have an official hosted app that you can use for your open source project. Use the hosted instance if you don't want to deploy your own.
 
 **Contents:**
 
 1. [Create the GitHub App](#create-the-github-app)
-1. [Deploy the plugin](#deploy-the-plugin)
+1. [Deploy the app](#deploy-the-app)
     1. [Heroku](#heroku)
     1. [Now](#now)
-1. [Combining plugins](#combining-plugins)
+1. [Combining apps](#combining-apps)
 
 ## Create the GitHub App
 
 Every deployment will need an [App](https://developer.github.com/apps/).
 
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
-    - **Homepage URL**: the URL to the GitHub repository for your plugin
-    - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed plugin.
-    - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed plugin.
-    - **Permissions & events**: See `docs/deploy.md` in the plugin for a list of the permissions and events that it needs access to.
+    - **Homepage URL**: the URL to the GitHub repository for your app
+    - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed app.
+    - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed app.
+    - **Permissions & events**: See `docs/deploy.md` in the app for a list of the permissions and events that it needs access to.
 
 1. Download the private key from the app.
 
 1. Make sure that you click the green **Install** button on the top left of the app page. This gives you an option of installing the app on all or a subset of your repositories.
 
-## Deploy the plugin
+## Deploy the app
 
-To deploy a plugin to any cloud provider, you will need 3 environment variables:
+To deploy a app to any cloud provider, you will need 3 environment variables:
 
 - `APP_ID`: the ID of the app, which you can get from the [app settings page](https://github.com/settings/apps).
 - `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
@@ -50,7 +50,7 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
 
 1. Make sure you have the [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) client installed.
 
-1. Clone the plugin that you want to deploy. e.g. `git clone https://github.com/probot/stale`
+1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
 
 1. Create the Heroku app with the `heroku create` command:
 
@@ -67,7 +67,7 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
             WEBHOOK_SECRET=bbb \
             PRIVATE_KEY="$(cat ~/Downloads/*.private-key.pem)"
 
-1. Deploy the plugin to heroku with `git push`:
+1. Deploy the app to heroku with `git push`:
 
         $ git push heroku master
         ...
@@ -76,7 +76,7 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
         -----> Launching... done
               http://arcane-lowlands-8408.herokuapp.com deployed to Heroku
 
-1. Your plugin should be up and running! To verify that your plugin
+1. Your app should be up and running! To verify that your app
    is receiving webhook data, you can tail your app's logs:
 
         $ heroku config:set LOG_LEVEL=trace
@@ -84,11 +84,11 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
 
 ### Now
 
-Zeit [Now](http://zeit.co/now) is a great service for running Probot plugins. After [creating the GitHub App](#create-the-github-app):
+Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After [creating the GitHub App](#create-the-github-app):
 
 1. Install the now CLI with `npm i -g now`
 
-1. Clone the plugin that you want to deploy. e.g. `git clone https://github.com/probot/stale`
+1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
 
 1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the path for the `PRIVATE_KEY`:
 
@@ -98,11 +98,11 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot plugins. Af
 
 1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
 
-Your plugin should be up and running!
+Your app should be up and running!
 
-## Combining plugins
+## Combining apps
 
-To deploy a bot that includes multiple plugins, create a new app that has the plugins listed as dependencies in `package.json`:
+To deploy a bot that includes multiple apps, create a new app that has the apps listed as dependencies in `package.json`:
 
 ```json
 {

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,13 +2,13 @@
 next: docs/webhooks.md
 ---
 
-# Developing a Plugin
+# Developing an App
 
-To develop a Probot plugin, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Probot uses the `async/await` keywords, so Node.js 7.6 is the minimum required version.
+To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Probot uses the `async/await` keywords, so Node.js 7.6 is the minimum required version.
 
-## Generating a new plugin
+## Generating a new app
 
-[create-probot-plugin](https://github.com/probot/create-probot-plugin) is the best way to start building a new plugin. It will generate a new plugin with everything you need to get started and run your plugin in production.
+[create-probot-plugin](https://github.com/probot/create-probot-plugin) is the best way to start building a new app. It will generate a new app with everything you need to get started and run your app in production.
 
 To get started, install the module from npm:
 
@@ -22,7 +22,7 @@ Next, run the app:
 $ create-probot-plugin my-first-plugin
 ```
 
-This will ask you a series of questions about your plugin, which should look something like this:
+This will ask you a series of questions about your app, which should look something like this:
 
 ```
 Let's create a Probot plugin!
@@ -46,11 +46,11 @@ created file: my-first-plugin/docs/deploy.md
 Done!
 ```
 
-The most important files note here are `index.js`, which is where the code for your plugin will go, and `package.json`, which makes this a standard [npm module](https://docs.npmjs.com/files/package.json).
+The most important files note here are `index.js`, which is where the code for your app will go, and `package.json`, which makes this a standard [npm module](https://docs.npmjs.com/files/package.json).
 
 ## Configure a GitHub App
 
-To run your plugin in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
+To run your app in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
 
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Set to `https://example.com/` and we'll update it in a minute.
@@ -63,9 +63,9 @@ To run your plugin in development, you will need to configure a GitHub App to de
 
 You'll need to create a test repository and install your app by clicking the "Install" button on the settings page of your app.
 
-## Running the plugin
+## Running the app
 
-Once you've set the `APP_ID` of your GitHub app in `.env` and downloaded the  private key, you're ready to run your bot.
+Once you've set the `APP_ID` of your GitHub App in `.env` and downloaded the  private key, you're ready to run your Probot app.
 
 ```
 $ npm start
@@ -76,7 +76,7 @@ Yay, the plugin was loaded!
 Listening on https://bkeepers.localtunnel.me
 ```
 
-Optionally, you can also run your plugin through [nodemon](https://github.com/remy/nodemon#nodemon) which will listen on any files changes in your local development environment and automatically restart the server. After installing nodemon, you can run `nodemon --exec "npm start"` and from there the server will automatically restart upon file changes.
+Optionally, you can also run your app through [nodemon](https://github.com/remy/nodemon#nodemon) which will listen on any files changes in your local development environment and automatically restart the server. After installing nodemon, you can run `nodemon --exec "npm start"` and from there the server will automatically restart upon file changes.
 
 ## Debugging
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,42 +8,46 @@ To develop a Probot app, you will first need a recent version of [Node.js](https
 
 ## Generating a new app
 
-[create-probot-plugin](https://github.com/probot/create-probot-plugin) is the best way to start building a new app. It will generate a new app with everything you need to get started and run your app in production.
+[create-probot-app](https://github.com/probot/create-probot-app) is the best way to start building a new app. It will generate a new app with everything you need to get started and run your app in production.
 
 To get started, install the module from npm:
 
 ```
-$ npm install -g create-probot-plugin
+$ npm install -g create-probot-app
 ```
 
 Next, run the app:
 
 ```
-$ create-probot-plugin my-first-plugin
+$ create-probot-app my-first-app
 ```
 
 This will ask you a series of questions about your app, which should look something like this:
 
 ```
-Let's create a Probot plugin!
-? Plugin's package name: my-first-plugin
-? Description of plugin: A "Hello World" GitHub App built with Probot
-? Plugin author's full name: Brandon Keepers
-? Plugin author's email address: bkeepers@github.com
-? Plugin author's homepage:
-? Plugin's GitHub user or org name: bkeepers
-? Plugin's repo name: my-first-plugin
-created file: my-first-plugin/.env.example
-created file: my-first-plugin/.gitignore
-created file: my-first-plugin/.travis.yml
-created file: my-first-plugin/LICENSE
-created file: my-first-plugin/README.md
-created file: my-first-plugin/app.json
-created file: my-first-plugin/index.js
-created file: my-first-plugin/package-lock.json
-created file: my-first-plugin/package.json
-created file: my-first-plugin/docs/deploy.md
-Done!
+Let's create a Probot app!
+? Package name: my-first-app
+? Description of app: A "Hello World" GitHub App built with Probot
+? Author's full name: Brandon Keepers
+? Author's email address: bkeepers@github.com
+? Homepage:
+? GitHub user or org name: bkeepers
+? Repository name: my-first-app
+created file: my-first-app/.env.example
+created file: my-first-app/.gitignore
+created file: my-first-app/.travis.yml
+created file: my-first-app/LICENSE
+created file: my-first-app/README.md
+created file: my-first-app/app.json
+created file: my-first-app/index.js
+created file: my-first-app/package-lock.json
+created file: my-first-app/package.json
+created file: my-first-app/docs/deploy.md
+Finished scaffolding files!
+
+Installing Node dependencies!
+
+Done! Enjoy building your Probot app!
 ```
 
 The most important files note here are `index.js`, which is where the code for your app will go, and `package.json`, which makes this a standard [npm module](https://docs.npmjs.com/files/package.json).

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -8,7 +8,7 @@ Probot uses [GitHub Apps](https://developer.github.com/apps/). An app is a first
 
 `context.github` is an authenticated GitHub client that can be used to make API calls. It is an instance of the [github Node.js module](https://github.com/mikedeboer/node-github), which wraps the [GitHub API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
 
-Here is an example of an autoresponder plugin that comments on opened issues:
+Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
 module.exports = robot => {

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -4,7 +4,7 @@ next: docs/development.md
 
 # Hello World
 
-A Probot plugin is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
+A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 
 ```js
 module.exports = robot => {
@@ -14,7 +14,7 @@ module.exports = robot => {
 
 The `robot` parameter is an instance of [`Robot`](https://probot.github.io/probot/latest/Robot.html) and gives you access to all of the bot goodness.
 
-`robot.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your plugin wants to know about.
+`robot.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 
 ```js
 module.exports = robot => {
@@ -27,7 +27,7 @@ module.exports = robot => {
 
 The `context` passed to the event handler includes everything about the event that was triggered, as well as some helpful properties for doing something useful in response to the event. `context.github` is an authenticated GitHub client that can be used to [make API calls](./github-api.md), and allows you to do almost anything programmatically that you can do through a web browser on GitHub.
 
-Here is an example of an autoresponder plugin that comments on opened issues:
+Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
 module.exports = robot => {

--- a/docs/http.md
+++ b/docs/http.md
@@ -4,12 +4,12 @@ next: docs/simulating-webhooks.md
 
 # HTTP Routes
 
-Calling `robot.route('/my-plugin')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your plugin.
+Calling `robot.route('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
 
 ```js
 module.exports = robot => {
   // Get an express router to expose new HTTP endpoints
-  const app = robot.route('/my-plugin');
+  const app = robot.route('/my-app');
 
   // Use any middleware
   app.use(require('express').static(__dirname + '/public'));
@@ -21,8 +21,8 @@ module.exports = robot => {
 };
 ```
 
-Visit https://localhost:3000/my-plugin/hello-world to access the endpoint.
+Visit https://localhost:3000/my-app/hello-world to access the endpoint.
 
-It is strongly encouraged to use the name of your package as the prefix so none of your routes or middleware conflict with other plugins. For example, if [`probot/owners`](https://github.com/probot/owners) exposed an endpoint, the plugin would call `robot.route('/owners')` to prefix all endpoints with `/owners`.
+It is strongly encouraged to use the name of your package as the prefix so none of your routes or middleware conflict with other apps. For example, if [`probot/owners`](https://github.com/probot/owners) exposed an endpoint, the app would call `robot.route('/owners')` to prefix all endpoints with `/owners`.
 
 See the [express documentation](http://expressjs.com/en/guide/routing.html) for more information.

--- a/docs/simulating-webhooks.md
+++ b/docs/simulating-webhooks.md
@@ -4,7 +4,7 @@ next: docs/pagination.md
 
 # Simulating Webhooks
 
-As you are developing your plugin, you will likely want to test it by repeatedly trigging the same webhook. You can simulate a webhook being delivered by saving the payload to a file, and then calling `probot simulate` from the command line.
+As you are developing your app, you will likely want to test it by repeatedly trigging the same webhook. You can simulate a webhook being delivered by saving the payload to a file, and then calling `probot simulate` from the command line.
 
 To save a copy of the payload, go to the  [settings](https://github.com/settings/apps) page for your App, and go to the **Advanced** tab. Click on one of the **Recent Deliveries** to expand it and see the details of the webhook event. Copy the JSON from the the **Payload** and save it to a new file. (`test/fixtures/issues.labeled.json` in this example).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,7 +4,7 @@ next: docs/pagination.md
 
 # Testing
 
-We highly recommend working in the style of [test-driven development](http://agiledata.org/essays/tdd.html) when creating probot plugins. It frustrating to constantly create real GitHub events in order to test a plugin. Redelivering webhooks is possible and can be accessed in your app's [settings](https://github.com/settings/apps) page under the **Advanced** tab. We do offer the above documented `simulate` method to help make this easier; however, by writing your tests first, you can avoid repeatedly recreating actual events from GitHub to check if your code is working.
+We highly recommend working in the style of [test-driven development](http://agiledata.org/essays/tdd.html) when creating probot apps. It frustrating to constantly create real GitHub events in order to test a app. Redelivering webhooks is possible and can be accessed in your app's [settings](https://github.com/settings/apps) page under the **Advanced** tab. We do offer the above documented `simulate` method to help make this easier; however, by writing your tests first, you can avoid repeatedly recreating actual events from GitHub to check if your code is working.
 
 For our testing examples, we use [mocha](https://mochajs.org/) and [expect](https://github.com/mjackson/expect), but there are other options that can perform similar operations. Here's an example of creating a robot instance and mocking out the GitHub API:
 
@@ -17,15 +17,15 @@ const {createRobot} = require('probot');
 // Then put any larger testing payloads in there
 const payload = require('./fixtures/payload');
 
-describe('your-plugin', () => {
+describe('your-app', () => {
   let robot;
   let github;
 
   beforeEach(() => {
     // Here we create a robot instance
     robot = createRobot();
-    // Here we initialize the plugin on the robot instance
-    plugin(robot);
+    // Here we initialize the app on the robot instance
+    app(robot);
     // This is an easy way to mock out the GitHub API
     github = {
       issues: {

--- a/lib/context.js
+++ b/lib/context.js
@@ -63,18 +63,18 @@ class Context {
   }
 
   /**
-   * Reads the plugin configuration from the given YAML file in the `.github`
+   * Reads the app configuration from the given YAML file in the `.github`
    * directory of the repository.
    *
-   * @example <caption>Contents of <code>.github/myplugin.yml</code>.</caption>
+   * @example <caption>Contents of <code>.github/myapp.yml</code>.</caption>
    *
    * close: true
    * comment: Check the specs on the rotary girder.
    *
-   * @example <caption>Plugin that reads from <code>.github/myplugin.yml</code>.</caption>
+   * @example <caption>App that reads from <code>.github/myapp.yml</code>.</caption>
    *
-   * // Load config from .github/myplugin.yml in the repository
-   * const config = await context.config('myplugin.yml');
+   * // Load config from .github/myapp.yml in the repository
+   * const config = await context.config('myapp.yml');
    *
    * if(config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}));

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -19,7 +19,7 @@ function pluginLoaderFactory(probot, opts = {}) {
     try {
       return resolver(pluginName, {basedir});
     } catch (err) {
-      err.message = `Failed to resolve plugin "${pluginName}". Is it installed?
+      err.message = `Failed to resolve "${pluginName}". Is it installed?
   Original error message:
   ${err.message}`;
       throw err;
@@ -35,8 +35,7 @@ function pluginLoaderFactory(probot, opts = {}) {
     try {
       probot.load(typeof plugin === 'string' ? require(plugin) : plugin);
     } catch (err) {
-      err.message = `Failed to load plugin "${pluginName}". This is a problem with the plugin itself; not probot.
-  Original error message:
+      err.message = `Failed to load "${pluginName}" because of the following error:
   ${err.message}`;
       throw err;
     }
@@ -49,7 +48,7 @@ function pluginLoaderFactory(probot, opts = {}) {
     const plugins = autoloader('probot-*');
     Object.keys(plugins).forEach(pluginName => {
       loadPlugin(pluginName, plugins[pluginName]);
-      probot.logger.info(`Automatically loaded plugin: ${pluginName}`);
+      probot.logger.info(`Automatically loaded ${pluginName}`);
     });
   }
 
@@ -61,7 +60,7 @@ function pluginLoaderFactory(probot, opts = {}) {
     pluginNames.forEach(pluginName => {
       const pluginPath = resolvePlugin(pluginName);
       loadPlugin(pluginName, pluginPath);
-      probot.logger.debug(`Loaded plugin: ${pluginName}`);
+      probot.logger.debug(`Loaded ${pluginName}`);
     });
   }
 

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -5,7 +5,7 @@ const express = require('express');
 const Context = require('./context');
 
 /**
- * The `robot` parameter available to plugins
+ * The `robot` parameter available to apps
  *
  * @property {logger} log - A logger
  */
@@ -32,7 +32,7 @@ class Robot {
    * @example
    * module.exports = robot => {
    *   // Get an express router to expose new HTTP endpoints
-   *   const app = robot.route('/my-plugin');
+   *   const app = robot.route('/my-app');
    *
    *   // Use any middleware
    *   app.use(require('express').static(__dirname + '/public'));

--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,3 +1,3 @@
 module.exports = robot => {
-  console.log('laoded plugin');
+  console.log('laoded app');
 }

--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,3 +1,3 @@
 module.exports = robot => {
-  console.log('laoded app');
+  console.log('loaded app');
 }

--- a/test/robot.js
+++ b/test/robot.js
@@ -99,16 +99,16 @@ describe('Robot', function () {
       expect(spy).toHaveBeenCalled();
     });
 
-    it('returns a reject errors thrown in plugins', async () => {
+    it('returns a reject errors thrown in apps', async () => {
       robot.on('test', () => {
-        throw new Error('error from plugin');
+        throw new Error('error from app');
       });
 
       try {
         await robot.receive(event);
-        throw new Error('expected error to be raised from plugin');
+        throw new Error('expected error to be raised from app');
       } catch (err) {
-        expect(err.message).toEqual('error from plugin');
+        expect(err.message).toEqual('error from app');
       }
     });
   });


### PR DESCRIPTION
As discussed in https://github.com/probot/probot/issues/207#issuecomment-323522926, this changes the terminology:

- **plugins => apps** - Akin to "react apps" or "rails apps", Probot apps are just node apps that have a dependency on `probot` and use features of the framework. They can be run standalone or combined with other apps with the `probot run` command. 
- **helper => extension** - Probot extensions are reusable modules that extend Probot itself.
 `probot-scheduler` is currently the only example, but there are a few others I can imagine, such as `probot-command` which would do slash command handling similar to what @jbjonesjr's [snooze](https://github.com/jbjonesjr/probot-snooze) app does.

TODO:

- [x] docs
- [x] helper => extension in http://github.com/probot/scheduler
- [x] create-probot-plugin => create-probot-app (https://github.com/probot/create-probot-plugin/pull/6)
- [x] ~~Figure out what to do with `lib/plugin.js`~~ waiting until future iteration
- [x] `#probot-plugin` => `#probot-app` [topic on all repos](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)

