### PR TITLE
Fix the linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node ./bin/probot run",
-    "test": "mocha && xo --extend eslint-config-probot",
+    "test": "mocha && xo",
     "doc": "jsdoc -c .jsdoc.json",
     "postpublish": "script/publish-docs"
   },
@@ -46,6 +46,7 @@
     "xo": "^0.19.0"
   },
   "xo": {
+    "extends": "eslint-config-probot",
     "overrides": [
       {
         "files": "test/**/*.js",


### PR DESCRIPTION
XO was giving me a hard time so I fixed it 👍 

Prior to these commits, running `xo` via command line return **958 errors** (many of them tabs/spaces). Now there are 0 errors 🎉 All those errors were also showing up in my code editor.