### PR TITLE
Multiple events per robot.on()

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -25,25 +25,6 @@ class Robot {
     })
   }
 
-  addEventToListeners(event, callback) {
-    const [name, action] = event.split('.');
-
-    this.events.on(name, async event => {
-      if (!action || action === event.payload.action) {
-        try {
-          const github = await this.auth(event.payload.installation.id);
-          const context = new Context(event, github);
-          await callback(context, context /* DEPRECATED: for backward compat */);
-        } catch (err) {
-          this.log.error({err, event});
-          if (!this.catchErrors) {
-            throw err;
-          }
-        }
-      }
-    });
-  }
-
   /**
    * Get an {@link http://expressjs.com|express} router that can be used to
    * expose HTTP endpoints
@@ -103,6 +84,10 @@ class Robot {
    * });
    */
   on (event, callback) {
+    if (event.constructor === Array) {
+      event.forEach(e => this.on(e, callback));
+      return;
+    }
     if (callback.length === 2) {
       const caller = (new Error()).stack.split('\n')[2]
       console.warn('DEPRECATED: Event callbacks now only take a single `context` argument. This feature will be removed in version 0.10')

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -25,6 +25,25 @@ class Robot {
     })
   }
 
+  addEventToListeners(event, callback) {
+    const [name, action] = event.split('.');
+
+    this.events.on(name, async event => {
+      if (!action || action === event.payload.action) {
+        try {
+          const github = await this.auth(event.payload.installation.id);
+          const context = new Context(event, github);
+          await callback(context, context /* DEPRECATED: for backward compat */);
+        } catch (err) {
+          this.log.error({err, event});
+          if (!this.catchErrors) {
+            throw err;
+          }
+        }
+      }
+    });
+  }
+
   /**
    * Get an {@link http://expressjs.com|express} router that can be used to
    * expose HTTP endpoints

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -85,8 +85,8 @@ class Robot {
    */
   on (event, callback) {
     if (event.constructor === Array) {
-      event.forEach(e => this.on(e, callback));
-      return;
+      event.forEach(e => this.on(e, callback))
+      return
     }
     if (callback.length === 2) {
       const caller = (new Error()).stack.split('\n')[2]

--- a/test/robot.js
+++ b/test/robot.js
@@ -5,7 +5,6 @@ const createRobot = require('../lib/robot')
 describe('Robot', function () {
   let robot
   let event
-  let event2
   let spy
 
   beforeEach(function () {
@@ -17,14 +16,6 @@ describe('Robot', function () {
       payload: {
         action: 'foo',
         installation: {id: 1}
-      }
-    }
-
-    event2 = {
-      event: 'arrayTest',
-      payload: {
-        action: 'bar',
-        installation: {id: 2}
       }
     }
 
@@ -89,6 +80,14 @@ describe('Robot', function () {
     })
 
     it('calls callback x amount of times when an array of x actions is passed', async function () {
+      const event2 = {
+        event: 'arrayTest',
+        payload: {
+          action: 'bar',
+          installation: {id: 2}
+        }
+      }
+
       robot.on(['test.foo', 'arrayTest.bar'], spy)
 
       await robot.receive(event)

--- a/test/robot.js
+++ b/test/robot.js
@@ -5,6 +5,7 @@ const createRobot = require('../lib/robot')
 describe('Robot', function () {
   let robot
   let event
+  let event2
   let spy
 
   beforeEach(function () {
@@ -16,6 +17,14 @@ describe('Robot', function () {
       payload: {
         action: 'foo',
         installation: {id: 1}
+      }
+    }
+
+    event2 = {
+      event: 'arrayTest',
+      payload: {
+        action: 'bar',
+        installation: {id: 2}
       }
     }
 
@@ -77,6 +86,14 @@ describe('Robot', function () {
 
       await robot.receive(event)
       expect(spy).toHaveBeenCalled()
+    })
+
+    it('calls callback x amount of times when an array of x actions is passed', async function () {
+      robot.on(['test.foo', 'arrayTest.bar'], spy)
+
+      await robot.receive(event)
+      await robot.receive(event2)
+      expect(spy.calls.length).toEqual(2)
     })
   })
 


### PR DESCRIPTION
Previously you could only use `robot.on()` in the following way:
```js
robot.on('issues.opened', async context => {
  robot.log(context);
});
```

Now you can also pass an array to the first argument of `robot.on()` to do the following:
```js
robot.on(['issues.opened', 'issues.closed'], async context => {
  robot.log(context);
});
```

This will allow for for example the following lines from probot/stale to be expressed slightly more neatly:

https://github.com/probot/stale/blob/257c8af485c8577d83d8c29fa9d0620fe373388e/index.js#L8-L13

Todo:
- [x] Tests. I'd want to add at least one test for the new input, but not super sure how to do that. So would love to pair with @bkeepers or @hiimbex if you're free 😎 