### PR TITLE
Deprecate (context, event) for 0.10

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -86,7 +86,7 @@ class Robot {
   on(event, callback) {
     if (callback.length === 2) {
       const caller = (new Error()).stack.split('\n')[2];
-      console.warn('DEPRECATED: Event callbacks now only take a single `context` argument.');
+      console.warn('DEPRECATED: Event callbacks now only take a single `context` argument. This feature will be removed in version 0.10');
       console.warn(caller);
     }
 
@@ -98,6 +98,8 @@ class Robot {
           const github = await this.auth(event.payload.installation.id);
           const context = new Context(event, github);
           await callback(context, context /* DEPRECATED: for backward compat */);
+          // This will be removed in version 0.10 and will become:
+          // await callback(context)
         } catch (err) {
           this.log.error({err, event});
           if (!this.catchErrors) {

--- a/test/robot.js
+++ b/test/robot.js
@@ -50,6 +50,14 @@ describe('Robot', function () {
       expect(spy.calls[0].arguments[0].payload).toBe(event.payload);
     });
 
+    it('(context, event) will be removed in 0.10', () => {
+      // This test will fail in version 0.10 to remind us to
+      // remove the deprecated (context, event)
+      const semver = require('semver');
+      const pkg = require('../package');
+      expect(semver.satisfies(pkg.version, '< 0.10')).toBe(true);
+    });
+
     it('calls callback with same action', async function () {
       robot.on('test.foo', spy);
 


### PR DESCRIPTION
In version `0.7.0` we deprecated event callbacks to instead of taking `(context, event)` to just a `context` that contains all necessary information. This was brought up re: https://github.com/probot/probot/pull/212#discussion_r134323462

This updates the` console.warn`, adds an inline comment, and adds a test to make sure this feature is deprecated by version `0.10`. 

I tried to research if there were any existing plugins that would be broken by this change and discovered these:
- https://github.com/tcbyrd/probot-lambda cc/ @tcbyrd
- https://github.com/akinori-i/PR-AnalyzeBot
- https://github.com/probot/no-response

I used [this search](https://github.com/search?l=JavaScript&p=1&q=event+context+probot&type=Code&utf8=%E2%9C%93), and I'm not sure if I caught all the cases. Any ideas on how to better do this search?

I opened a [PR for no-reposnse](https://github.com/probot/no-response/pull/4) to update it to prevent this deprecation, and was planning on opening either issues or PRs in the other 2 repos regarding this.