### PR TITLE
Adds a line break

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,3 +1,3 @@
 firstPRMergeComment: >
-  Thanks for your contribution to probot! :tada:
+  Thanks for your contribution to probot! :tada: <br>
   ![Congrats!](https://media.giphy.com/media/o0vwzuFwCGAFO/giphy.gif)


### PR DESCRIPTION
I _think_ the gif is supposed to be on a new line b/c it is in the [`config.yml`](https://github.com/probot/probot/pull/215/files#diff-51ae5ef21b0bd169a283475e122567d3L2) file. The `<br>` enforces this. 

I know this is not a pressing issue 🙃 

<img width="640" alt="bumps_webhook_dep_and_adds_webhookpath_config_by_anglinb_ _pull_request__203_ _probot_probot_and_jerry_mendel_at_university_of_southern_california_-_ratemyprofessors_com_and_check_your_email____slack" src="https://user-images.githubusercontent.com/2637602/29588507-a88663d4-8746-11e7-8e04-fdc9fa304d0d.png">
