### PR TITLE
Add link to slack channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Check out [all probot plugins](https://github.com/search?q=topic%3Aprobot-plugin
 
 Most of the interesting things are built with plugins, so consider starting by [writing a new plugin](docs/plugins.md) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories).
 
-Want to chat with Probot users and contributors? Join us in the [Slack channel](https://probot-slackin.herokuapp.com/)!
+Want to chat with Probot users and contributors? [Join us in Slack](https://probot-slackin.herokuapp.com/)!

--- a/README.md
+++ b/README.md
@@ -19,3 +19,5 @@ Check out [all probot plugins](https://github.com/search?q=topic%3Aprobot-plugin
 ## Contributing
 
 Most of the interesting things are built with plugins, so consider starting by [writing a new plugin](docs/plugins.md) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories).
+
+Want to chat with Probot users and contributors? Join us in the [Slack channel](https://probot-slackin.herokuapp.com/badge.svg)](https://probot-slackin.herokuapp.com/)!

--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Check out [all probot plugins](https://github.com/search?q=topic%3Aprobot-plugin
 
 Most of the interesting things are built with plugins, so consider starting by [writing a new plugin](docs/plugins.md) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-plugin&type=Repositories).
 
-Want to chat with Probot users and contributors? Join us in the [Slack channel](https://probot-slackin.herokuapp.com/badge.svg)](https://probot-slackin.herokuapp.com/)!
+Want to chat with Probot users and contributors? Join us in the [Slack channel](https://probot-slackin.herokuapp.com/)!


### PR DESCRIPTION
Eventually this will go on the website (https://github.com/probot/probot.github.io/issues/39), but documenting in the README for now.