### PR TITLE
How should context.config handle new line characters in the yml file?

### DIFF
--- a/test/context.js
+++ b/test/context.js
@@ -197,5 +197,20 @@ describe('Context', function () {
         baz: 11
       });
     });
+    it('respects new line characters', async function () {
+      github.repos.getContent.andReturn(Promise.resolve(readConfig('multiline.yml')));
+      const config = await context.config('test-file.yml');
+
+      expect(github.repos.getContent).toHaveBeenCalledWith({
+        owner: 'bkeepers',
+        repo: 'probot',
+        path: '.github/test-file.yml'
+      });
+
+      expect(config).toEqual({
+        multiline: "Foo foo, foo foo\nbar bar bar",
+        singleline: "Foo foo, foo foo bar bar bar"
+      });
+    });
   });
 });

--- a/test/fixtures/config/multiline.yml
+++ b/test/fixtures/config/multiline.yml
@@ -1,0 +1,7 @@
+multiline: |
+  Foo foo, foo foo
+  bar bar bar
+
+singleline: >
+  Foo foo, foo foo
+  bar bar bar


### PR DESCRIPTION
👋 I noticed that the cat gif in first merge comment was not on a new line in #215. I added a `<br>` tag which GitHub respects but I was wondering if the expected behavior of new lines in reading configs is indeed correct. 

---

I wrote a couple test cases while I was playing around with line breaks and I pushed those here. My biggest questions is: **Should reading a multiline yml key have a trailing newline?** 

**Input**

```yml
singleline: >
  Foo foo, foo foo
  bar bar bar
```

```
const config = await context.config('test-file.yml');
console.log(config);
```

**Expected Output**
```
{
    singleline: "Foo foo, foo foo\nbar bar bar"
}
```
**Actual Output**
```
{
    singleline: "Foo foo, foo foo\nbar bar bar\n"
}
```
I'm not sure what is the average expected behavior here but I wanted to document the multiline test case and if we decide that the trailing newline literal is expected, I'll update the tests to make them represent that decision. 

/cc @probot/maintainers @hiimbex 
