### PR TITLE
Sssssssshhhh

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -1,8 +1,6 @@
 const expect = require('expect')
 const createProbot = require('..')
 
-process.env.LOG_LEVEL = 'fatal'
-
 describe('Probot', () => {
   let probot
   let event

--- a/test/index.js
+++ b/test/index.js
@@ -1,6 +1,8 @@
 const expect = require('expect')
 const createProbot = require('..')
 
+process.env.LOG_LEVEL = 'fatal'
+
 describe('Probot', () => {
   let probot
   let event
@@ -69,6 +71,10 @@ describe('Probot', () => {
 
     it('allows users to configure webhook paths', async () => {
       probot = createProbot({webhookPath: '/webhook'})
+      // Error handler to avoid printing logs
+      // eslint-disable-next-line handle-callback-err
+      probot.server.use((err, req, res, next) => { })
+
       probot.load(robot => {
         const app = robot.route()
         app.get('/webhook', (req, res) => res.end('get-webhook'))
@@ -85,6 +91,10 @@ describe('Probot', () => {
     })
 
     it('defaults webhook path to `/`', async () => {
+      // Error handler to avoid printing logs
+      // eslint-disable-next-line handle-callback-err
+      probot.server.use((err, req, res, next) => { })
+
       // GET requests to `/` should 404 at express level, not 400 at webhook level
       await request(probot.server).get('/')
         .expect(404)

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,2 @@
 --recursive
+--require ./test/setup

--- a/test/server.js
+++ b/test/server.js
@@ -9,6 +9,11 @@ describe('server', function () {
   beforeEach(() => {
     webhook = expect.createSpy().andCall((req, res, next) => next())
     server = createServer(webhook)
+
+    // Error handler to avoid printing logs
+    server.use(function (err, req, res, next) {
+      res.status(500).send(err.message)
+    })
   })
 
   describe('GET /ping', () => {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,0 +1,3 @@
+// This file gets loaded when mocha is run
+
+process.env.LOG_LEVEL = 'fatal'


### PR DESCRIPTION
Fixes #224 by

- adding default [error handlers](http://expressjs.com/en/guide/error-handling.html) for express instances
- setting `LOG_LEVEL=trace` for all tests
- Move initialization of `logger` and other unchanged constants outside of the exported function in `index.js` to fix the warning about a potential memory leak due to `process.on(unhandledRejection, ...)` being called multiple times.

There's still one random thing being logged, but it should be removed in the next release:

```
DEPRECATED: the `SENTRY_URL` key is now called `SENTRY_DSN`. Use of `SENTRY_URL` is deprecated and will be removed in 0.11.0
```