### PR TITLE
Link README to website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,24 +2,12 @@
 
 [![Greenkeeper badge](https://badges.greenkeeper.io/probot/probot.svg)](https://greenkeeper.io/)
 
-Probot is a bot framework for GitHub. It's like [Hubot](https://hubot.github.com/), but for GitHub instead of chat.
-
 If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you right there. Most features can actually be added via [GitHub Apps](https://developer.github.com/apps/), which extend GitHub and can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. Apps are first class actors within GitHub.
 
-There are some great services that offer [apps in the GitHub Marketplace](https://github.com/marketplace), and you can build a bunch of really cool things yourself. Probot aims to make that easy.
-
-## Apps
-
-Apps are easy to write, deploy, and share. Here are just a few examples of things that can be built with Probot:
-
-- [stale](https://github.com/probot/stale) - closes abandoned issues after a period of inactivity.
-- [owners](https://github.com/probot/owners) - @mentions people in Pull Requests based on contents of the OWNERS file
-- [settings](https://github.com/probot/settings) - syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
-
-Check out [all Probot apps](https://github.com/search?q=topic%3Aprobot-app&type=Repositories).
+**Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. Check out some of the [featured apps](https://probot.github.io/apps) or learn more about [writing a new app](https://probot.github.io/docs/).
 
 ## Contributing
 
-Most of the interesting things are built with plugins, so consider starting by [writing a new app](docs/) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-app&type=Repositories).
+Probot is built by people just like you! Most of the interesting things are built _with_ Probot, so consider starting by [writing a new app](https://probot.github.io/docs/) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-app&type=Repositories), and check out our [contributing docs](CONTRIBUTING.md) for other ways to get started.
 
 Want to chat with Probot users and contributors? [Join us in Slack](https://probot-slackin.herokuapp.com/)!

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ Probot apps are easy to write, deploy, and share. Many of the most popular Probo
 - [stale](https://probot.github.io/apps/stale) - closes abandoned issues after a period of inactivity.
 - [settings](https://probot.github.io/apps/settings) - syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
 - [request-info](https://probot.github.io/apps/request-info) - requests more info from newly opened Pull Requests and Issues that contain either default titles or whose description is left blank.
-- Check out the [featured apps](ttps://probot.github.io/apps/) or [browse more examples on GitHub](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
+- Check out the [featured apps](https://probot.github.io/apps/) or [browse more examples on GitHub](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
 
 Ready to get started?

--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,6 @@ Probot apps are easy to write, deploy, and share. Many of the most popular Probo
 - [stale](https://probot.github.io/apps/stale) - closes abandoned issues after a period of inactivity.
 - [settings](https://probot.github.io/apps/settings) - syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
 - [request-info](https://probot.github.io/apps/request-info) - requests more info from newly opened Pull Requests and Issues that contain either default titles or whose description is left blank.
-- [Browse more examples](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
+- Check out the [featured apps](ttps://probot.github.io/apps/) or [browse more examples on GitHub](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
 
 Ready to get started?


### PR DESCRIPTION
I noticed while linking someone to the repo that the README links to the docs in the repo, which are a little harder to browse. This updates it to use the intro copy from the docs, and then link to the docs on the website for more info