### PR TITLE
Add @example for defaultConfig

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -74,21 +74,21 @@ class Context {
    * @example <caption>App that reads from <code>.github/myapp.yml</code>.</caption>
    *
    * // Load config from .github/myapp.yml in the repository
-   * const config = await context.config('myapp.yml');
+   * const config = await context.config('myapp.yml')
    *
    * if (config.close) {
-   *   context.github.issues.comment(context.issue({body: config.comment}));
-   *   context.github.issues.edit(context.issue({state: 'closed'}));
+   *   context.github.issues.comment(context.issue({body: config.comment}))
+   *   context.github.issues.edit(context.issue({state: 'closed'}))
    * }
    *
    * @example <caption>Using a <code>defaultConfig</code> object.</caption>
    *
    * // Load config from .github/myapp.yml in the repository and combine with default config
-   * const config = await context.config('myapp.yml', {comment: 'Make sure to check all the specs.'});
+   * const config = await context.config('myapp.yml', {comment: 'Make sure to check all the specs.'})
    *
    * if (config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}));
-   *   context.github.issues.edit(context.issue({state: 'closed'}));
+   *   context.github.issues.edit(context.issue({state: 'closed'}))
    * }
    *
    * @param {string} fileName - Name of the YAML file in the `.github` directory

--- a/lib/context.js
+++ b/lib/context.js
@@ -76,7 +76,17 @@ class Context {
    * // Load config from .github/myapp.yml in the repository
    * const config = await context.config('myapp.yml');
    *
-   * if(config.close) {
+   * if (config.close) {
+   *   context.github.issues.comment(context.issue({body: config.comment}));
+   *   context.github.issues.edit(context.issue({state: 'closed'}));
+   * }
+   *
+   * @example <caption>Using a <code>defaultConfig</code> object.</caption>
+   *
+   * // Load config from .github/myapp.yml in the repository and combine with default config
+   * const config = await context.config('myapp.yml', { comment: 'Make sure to check all the specs.' });
+   *
+   * if (config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}));
    *   context.github.issues.edit(context.issue({state: 'closed'}));
    * }

--- a/lib/context.js
+++ b/lib/context.js
@@ -84,7 +84,7 @@ class Context {
    * @example <caption>Using a <code>defaultConfig</code> object.</caption>
    *
    * // Load config from .github/myapp.yml in the repository and combine with default config
-   * const config = await context.config('myapp.yml', { comment: 'Make sure to check all the specs.' });
+   * const config = await context.config('myapp.yml', {comment: 'Make sure to check all the specs.'});
    *
    * if (config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}));


### PR DESCRIPTION
Fixes #256 - add a JSDoc `@example` for using the `context.config()` method with a `defaultConfig` object. I did build the docs locally, LGTM but feel free to check it out yourself.


🐟 