### PR TITLE
Move the note for robot.log before the @example

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -229,6 +229,11 @@ module.exports = (...args) => new Robot(...args)
   * `LOG_LEVEL` environment variable to `trace`, `info`, `warn`, `error`, or
   * `fatal`.
   *
+  * **Note**: Probot supports execption tracking through raven, a client for
+  * [sentry](https://github.com/getsentry/sentry). If the `SENTRY_DSN` is set
+  * as an environment variable, all errors will be forwarded to the sentry host
+  * specified by the environment variable.
+  *
   * @typedef logger
   *
   * @example
@@ -240,9 +245,4 @@ module.exports = (...args) => new Robot(...args)
   * robot.log.warn("Woah there");
   * robot.log.error("ETOOMANYLOGS");
   * robot.log.fatal("Goodbye, cruel world!");
-  *
-  * Note: Probot supports execption tracking through raven, a client for
-  * [sentry](https://github.com/getsentry/sentry). If the `SENTRY_DSN` is set
-  * as an environment variable, all errors will be forwarded to the sentry host
-  * specified by the environment variable.
   */


### PR DESCRIPTION
Currently, the note is shown as part of the example.

Is there anything else I have to do to update the docs?