### PR TITLE
removes unnecessary eslint disables

### DIFF
--- a/lib/paginate.js
+++ b/lib/paginate.js
@@ -1,5 +1,3 @@
-/* eslint-disable no-await-in-loop */
-
 // Default callback should just return the response passed to it.
 const defaultCallback = response => response
 

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,5 +1,4 @@
 const https = require('https')
-// eslint-disable-next-line import/no-extraneous-dependencies, import/no-unresolved
 const localtunnel = require('localtunnel')
 
 module.exports = function setupTunnel (subdomain, port, retries = 0) {

--- a/test/plugins.js
+++ b/test/plugins.js
@@ -1,5 +1,3 @@
-/* eslint prefer-arrow-callback: off */
-
 const expect = require('expect')
 const pluginLoaderFactory = require('../lib/plugin')
 


### PR DESCRIPTION
Noticed these still lurking unnecessarily since our switch to standard.