### PR TITLE
docs: improve visibility of documentation site

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you right there. Most features can actually be added via [GitHub Apps](https://developer.github.com/apps/), which extend GitHub and can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. Apps are first class actors within GitHub.
 
-**Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. Check out some of the [featured apps](https://probot.github.io/apps) or learn more about [writing a new app](https://probot.github.io/docs/).
+**Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. Check out some of the [featured apps](https://probot.github.io/apps) or [read the docs](https://probot.github.io/docs/) to learn more about writing a new app.
 
 ## Contributing
 


### PR DESCRIPTION
Hello, and thanks for making probot -- it seems like a great tool.

I was working on a project that uses probot earlier today, and I had some difficulty finding the API reference, despite the fact that the documentation site is linked in the readme and a few other places. My process for trying to find the documentation was something like this:

1. I quickly skimmed the readme to see if the API was described in the readme itself.
1. I used command-F to look for the word "docs" on the https://github.com/probot/probot page, to see if it was mentioned in the readme. I didn't find anything related in the readme, but I did find a [`docs/`](https://github.com/probot/probot/tree/81ad1f2a46f9031030fc50bec74583bed05b2fcd/docs) folder in the repo.
1. I opened the `docs/` folder on GitHub, but I didn't see anything about an API reference in that folder's readme, or in any of the titles of the files in that folder. (I now realize that the `docs/` folder is intended to be displayed on https://probot.github.io/docs/, but I didn't realize that at the time.)
1. Back on the front page of the repo, I saw a link to the https://probot.github.io/ in the repo description. I went to that page and used command-F to look for the word "docs" again, but didn't find anything relevant.
1. I ran a [search](https://github.com/probot/probot/search?p=2&q=context&type=&utf8=%E2%9C%93) in the GitHub repo for the word "context" (I was specifically looking for the `Context` API reference). I saw a reference to API docs on the [Best Practices](https://github.com/probot/probot/blob/81ad1f2a46f9031030fc50bec74583bed05b2fcd/docs/best-practices.md) page, which finally led me to the [`Context` API reference](https://probot.github.io/probot/latest/Context.html#config).

Ideally, I think future users should have less trouble finding the docs than I did. Afterwards, I realized that the docs are linked in the readme and on https://probot.github.io/, but I wasn't able to find these links when I was looking for them. Part of the solution might be for me to RTFM more thoroughly, but I think there is also room for improvement in the docs to make the API reference more visible.

Specifically, I think it would be good to use the word "docs" when linking to the documentation -- in my case, at least, that would have made it more for me to the term while skimming, or when using Command-F. (Currently, the documentation link in the readme is labeled as "learn more about writing a new app", and the link on https://probot.github.io/ is labelled as "Build". Neither of those labels seemed relevant at the time when I was just looking for an API reference, so I didn't realize that I would find the docs if I clicked on them.

This PR updates the readme to label the documentation link more clearly.