### PR TITLE
Move combining apps docs

### DIFF
--- a/docs/combining-apps.md
+++ b/docs/combining-apps.md
@@ -1,0 +1,27 @@
+---
+next: docs/deployment.md
+---
+
+# Combining apps
+
+To include multiple apps in your own Probot app, install them via `npm install` then list them in your `package.json`:
+
+```json
+{
+  "name": "my-probot",
+  "private": true,
+  "dependencies": {
+    "probot-autoresponder": "probot/autoresponder",
+    "probot-settings": "probot/settings"
+  },
+  "scripts": {
+    "start": "probot run"
+ },
+ "probot": {
+   "apps": [
+     "probot-autoresponder",
+     "probot-settings"
+   ]
+ }
+}
+```

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -122,30 +122,6 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 Your app should be up and running!
 
-## Combining apps
-
-To deploy a bot that includes multiple apps, create a new app that has the apps listed as dependencies in `package.json`:
-
-```json
-{
-  "name": "my-probot",
-  "private": true,
-  "dependencies": {
-    "probot-autoresponder": "probot/autoresponder",
-    "probot-settings": "probot/settings"
-  },
-  "scripts": {
-    "start": "probot run"
- },
- "probot": {
-   "apps": [
-     "probot-autoresponder",
-     "probot-settings"
-   ]
- }
-}
-```
-
 ## Error tracking
 
 Probot comes bundled with a client for the [Sentry](https://github.com/getsentry/sentry) exception tracking platform. To enable Sentry:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,5 +1,5 @@
 ---
-next: docs/deployment.md
+next: docs/combining-apps.md
 ---
 
 # Extensions


### PR DESCRIPTION
Move **Combining Apps** into its own file, out of the **Deployment** docs. This came out of some discussions from the Campus Experts hackday, as documented in https://github.com/probot/friction/issues/13