### PR TITLE
Create and expose HTTP server

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ module.exports = (options = {}) => {
     debug: process.env.LOG_LEVEL === 'trace'
   })
   const server = createServer(webhook)
-  const httpServer = Server(server)
+  const http = Server(server)
 
   // Log all received webhooks
   webhook.on('*', event => {
@@ -72,7 +72,14 @@ module.exports = (options = {}) => {
       plugin = resolve(plugin)
     }
 
-    const robot = createRobot({app, cache, logger, catchErrors: true, server: httpServer})
+    const robot = createRobot({
+      app,
+      cache,
+      logger,
+      server,
+      http,
+      catchErrors: true
+    })
 
     // Connect the router from the robot to the server
     server.use(robot.router)
@@ -90,7 +97,7 @@ module.exports = (options = {}) => {
 
   return {
     server,
-    httpServer,
+    http,
     webhook,
     receive,
     logger,
@@ -98,7 +105,7 @@ module.exports = (options = {}) => {
     setup,
 
     start () {
-      httpServer.listen(options.port)
+      http.listen(options.port)
       logger.trace('Listening on http://localhost:' + options.port)
     }
   }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -10,13 +10,14 @@ const Context = require('./context')
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor ({app, cache, logger, router, catchErrors, server} = {}) {
+  constructor ({app, cache, logger, router, catchErrors, server, http} = {}) {
     this.events = new EventEmitter()
     this.app = app
     this.cache = cache
     this.router = router || new express.Router()
     this.log = wrapLogger(logger)
     this.catchErrors = catchErrors
+    this.http = http
     this.server = server
   }
 

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -10,13 +10,14 @@ const Context = require('./context')
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor ({app, cache, logger, router, catchErrors} = {}) {
+  constructor ({app, cache, logger, router, catchErrors, server} = {}) {
     this.events = new EventEmitter()
     this.app = app
     this.cache = cache
     this.router = router || new express.Router()
     this.log = wrapLogger(logger)
     this.catchErrors = catchErrors
+    this.server = server
   }
 
   async receive (event) {


### PR DESCRIPTION
This came out of a discussion on Slack where I asked for opinions on how to expose the HTTP server that `express` creates on `.listen()`.

## Use case

I'm building a Probot App that uses [`socket.io`](https://socket.io), which needs to listen on a port. Since `express` only creates an HTTP server when `.listen()` is called, the two can't be used together without first working the `express` app into an HTTP server.

## Solution

While it can be achieved without changes to Probot core, the solutions are really hacky. Thus, the best way to allow this behavior without explicitly adding `socket.io` into core is to expose the HTTP server.

In this PR, I create a new HTTP server from the main `express` app, call `listen()` on it in the `start()` method, and expose the HTTP server on the `robot` class.

Let me know what y'all think!

cc @bkeepers @jarrodldavis (thanks for talking it through with me 💖)