### PR TITLE
fix: use lowercase username for localtunnel

### DIFF
--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -3,7 +3,7 @@ const localtunnel = require('localtunnel')
 
 module.exports = function setupTunnel (subdomain, port, retries = 0) {
   if (typeof subdomain !== 'string') {
-    subdomain = require('os').userInfo().username
+    subdomain = require('os').userInfo().username.toLowerCase()
   }
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
Since localtunnel only takes lowercase values, and windows usernames can be in uppercase