### PR TITLE
fix: use posix join for config path

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -96,7 +96,7 @@ class Context {
    * @return {Promise<Object>} - Configuration object read from the file
    */
   async config (fileName, defaultConfig) {
-    const params = this.repo({path: path.join('.github', fileName)})
+    const params = this.repo({path: path.posix.join('.github', fileName)})
 
     try {
       const res = await this.github.repos.getContent(params)


### PR DESCRIPTION
On Windows when I use `const config = await context.config('triage.yml');` I get the following error:

```sh
REQUEST:  { host: 'api.github.com',
  port: 443,
  path: '/repos/ocombe/test/contents/.github%5Ctriage.yml',
  method: 'get',
  headers:
   { host: 'api.github.com',
     'content-length': '0',
     Authorization: 'token v1.f013d09f149ef1fef8eb12e3172ff7e929dffabd',
     'user-agent': 'NodeJS HTTP Client',
     accept: 'application/vnd.github.v3+json' },
  ca: undefined,
  family: undefined }
STATUS: 404
HEADERS: {"server":"GitHub.com","date":"Tue, 31 Oct 2017 20:00:33 GMT","content-type":"application/json; charset=utf-8","content-length":"106","connection":"close","status":"404 Not Found","x-ratelimit-limit":"5000","x-ratelimit-remaining":"4998","x-ratelimit-reset":"1509482850","x-github-media-type":"github.v3; format=json","access-control-expose-headers":"ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval","access-control-allow-origin":"*","expect-ct":"max-age=2592000, report-uri=\"https://api.github.com/_private/browser/errors\"","content-security-policy":"default-src 'none'","strict-transport-security":"max-age=31536000; includeSubdomains; preload","x-content-type-options":"nosniff","x-frame-options":"deny","x-xss-protection":"1; mode=block","x-runtime-rack":"0.039522","x-github-request-id":"E312:606E:31C9F12:7CD86AD:59F8D661"}
[error] { [Error: {"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/contents/#get-contents"}]
[error]   message: '{"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/contents/#get-contents"}',
[error]   code: 404,
[error]   status: 'Not Found',
[error]   headers:
[error]    { server: 'GitHub.com',
[error]      date: 'Tue, 31 Oct 2017 20:00:33 GMT',
[error]      'content-type': 'application/json; charset=utf-8',
[error]      'content-length': '106',
[error]      connection: 'close',
[error]      status: '404 Not Found',
[error]      'x-ratelimit-limit': '5000',
[error]      'x-ratelimit-remaining': '4998',
[error]      'x-ratelimit-reset': '1509482850',
[error]      'x-github-media-type': 'github.v3; format=json',
[error]      'access-control-expose-headers': 'ETag, Link, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval',
[error]      'access-control-allow-origin': '*',
[error]      'expect-ct': 'max-age=2592000, report-uri="https://api.github.com/_private/browser/errors"',
[error]      'content-security-policy': 'default-src \'none\'',
[error]      'strict-transport-security': 'max-age=31536000; includeSubdomains; preload',
[error]      'x-content-type-options': 'nosniff',
[error]      'x-frame-options': 'deny',
[error]      'x-xss-protection': '1; mode=block',
[error]      'x-runtime-rack': '0.039522',
[error]      'x-github-request-id': 'E312:606E:31C9F12:7CD86AD:59F8D661' } } { owner: 'ocombe', repo: 'test', path: '.github\\triage.yml' }
```

The problem is that you use `path.join` for the url, which will create the path `.github\\triage.yml` on Windows instead of `.github/triage.yml` on unix.
Using path.posix fixes the problem.