### PR TITLE
Add http-request-logging with morgan

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,11 +1,13 @@
 const express = require('express')
 const path = require('path')
+const morgan = require('morgan')
 
 module.exports = function (webhook) {
   const app = express()
 
   app.use('/probot/static/', express.static(path.join(__dirname, '..', 'static')))
   app.use(webhook)
+  app.use(morgan('short'))
   app.set('view engine', 'ejs')
   app.set('views', path.join(__dirname, '..', 'views'))
   app.get('/ping', (req, res) => res.end('PONG'))

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "github-webhook-handler": "github:rvagg/github-webhook-handler#v0.6.1",
     "jest": "^21.2.1",
     "js-yaml": "^3.9.1",
+    "morgan": "^1.9.0",
     "pkg-conf": "^2.0.0",
     "promise-events": "^0.1.3",
     "raven": "^2.1.2",


### PR DESCRIPTION
Use morgan to log incoming http requests received on probot.route()

Example log output:

`::1 - POST /slack/events/ HTTP/1.1 200 0 - 14.873 ms`