### PR TITLE
Response timing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -4,6 +4,7 @@ const path = require('path')
 
 module.exports = function (webhook) {
   const app = express()
+  app.set('x-powered-by', false)
 
   app.use(responseTime())
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,13 +1,17 @@
 const express = require('express')
+const responseTime = require('response-time')
 const path = require('path')
 
 module.exports = function (webhook) {
   const app = express()
 
+  app.use(responseTime())
+
   app.use('/probot/static/', express.static(path.join(__dirname, '..', 'static')))
   app.use(webhook)
   app.set('view engine', 'ejs')
   app.set('views', path.join(__dirname, '..', 'views'))
+
   app.get('/ping', (req, res) => res.end('PONG'))
 
   return app

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "promise-events": "^0.1.3",
     "raven": "^2.1.2",
     "resolve": "^1.4.0",
+    "response-time": "^2.3.2",
     "semver": "^5.4.1"
   },
   "devDependencies": {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -21,7 +21,13 @@ describe('server', function () {
     })
 
     it('includes X-Response-Time header', () => {
-      return request(server).get('/ping').expect('X-Response-Time', /^[\d\.]+ms$/)
+      return request(server).get('/ping').expect('X-Response-Time', /^[\d.]+ms$/)
+    })
+
+    it('does not include X-Powered-By header', () => {
+      return request(server).get('/ping').expect(res => {
+        expect(res.headers['x-powered-by']).toBe(undefined)
+      })
     })
   })
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -19,6 +19,10 @@ describe('server', function () {
     it('returns a 200 response', () => {
       return request(server).get('/ping').expect(200, 'PONG')
     })
+
+    it('includes X-Response-Time header', () => {
+      return request(server).get('/ping').expect('X-Response-Time', /^[\d\.]+ms$/)
+    })
   })
 
   describe('webhook handler', () => {


### PR DESCRIPTION
This adds the `X-Response-Time` header to report how long a request takes. I also noticed the `X-Powered-By` header was reporting `Express`. I debated about updating it to `Probot`, but it is generally considered bad practice to include this header, so I just disabled it entirely.