### PR TITLE
Add `context.log` to add event context to each log message

### DIFF
--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -20,7 +20,7 @@ The `robot` parameter is an instance of [`Robot`](https://probot.github.io/probo
 module.exports = robot => {
   robot.on('issues.opened', async context => {
     // A new issue was opened, what should we do with it?
-    robot.log(context)
+    context.log(context.payload)
   })
 }
 ```

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -11,7 +11,7 @@ module.exports = robot => {
   robot.on('issues.opened', context => {
     context.github.paginate(context.github.issues.getAll(context.repo()), res => {
       res.data.issues.forEach(issue => {
-        robot.log('Issue: %s', issue.title)
+        context.log('Issue: %s', issue.title)
       })
     })
   })

--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const bunyan = require('bunyan')
-const bunyanFormat = require('bunyan-format')
 const sentryStream = require('bunyan-sentry-stream')
 const cacheManager = require('cache-manager')
 const createApp = require('github-app')
@@ -9,18 +7,11 @@ const Raven = require('raven')
 const createRobot = require('./lib/robot')
 const createServer = require('./lib/server')
 const resolve = require('./lib/resolver')
-const serializers = require('./lib/serializers')
+const logger = require('./lib/logger')
 
 const cache = cacheManager.caching({
   store: 'memory',
   ttl: 60 * 60 // 1 hour
-})
-
-const logger = bunyan.createLogger({
-  name: 'Probot',
-  level: process.env.LOG_LEVEL || 'debug',
-  stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
-  serializers
 })
 
 const defaultApps = [

--- a/lib/context.js
+++ b/lib/context.js
@@ -7,11 +7,13 @@ const yaml = require('js-yaml')
  *
  * @property {github} github - An authenticated GitHub API client
  * @property {payload} payload - The webhook event payload
+ * @property {logger} log - A logger
  */
 class Context {
-  constructor (event, github) {
+  constructor (event, github, log) {
     Object.assign(this, event)
     this.github = github
+    this.log = log
   }
 
   /**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,10 @@
+const bunyan = require('bunyan')
+const bunyanFormat = require('bunyan-format')
+const serializers = require('./serializers')
+
+module.exports = bunyan.createLogger({
+  name: 'Probot',
+  level: process.env.LOG_LEVEL || 'debug',
+  stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
+  serializers
+})

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -3,6 +3,7 @@ const GitHubApi = require('github')
 const Bottleneck = require('bottleneck')
 const express = require('express')
 const Context = require('./context')
+const logger = require('./logger')
 
 /**
  * The `robot` parameter available to apps
@@ -10,7 +11,7 @@ const Context = require('./context')
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor ({app, cache, logger, router, catchErrors} = {}) {
+  constructor ({app, cache, router, catchErrors} = {}) {
     this.events = new EventEmitter()
     this.app = app
     this.cache = cache
@@ -95,7 +96,9 @@ class Robot {
       if (!action || action === event.payload.action) {
         try {
           const github = await this.auth(event.payload.installation.id)
-          const context = new Context(event, github)
+          const log = wrapLogger(logger.child({id: event.id}, true))
+
+          const context = new Context(event, github, log)
           await callback(context)
         } catch (err) {
           this.log.error({err, event})

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -96,7 +96,9 @@ class Robot {
       if (!action || action === event.payload.action) {
         try {
           const github = await this.auth(event.payload.installation.id)
-          const log = wrapLogger(logger.child({id: event.id}, true))
+          const log = wrapLogger(logger.child({
+            event: logger.serializers.event(event)
+          }, true))
 
           const context = new Context(event, github, log)
           await callback(context)

--- a/lib/serializers.js
+++ b/lib/serializers.js
@@ -8,7 +8,8 @@ module.exports = {
         id: event.id,
         event: event.event,
         action: event.payload.action,
-        repository: event.payload.repository && event.payload.repository.full_name
+        repository: event.payload.repository && event.payload.repository.full_name,
+        installation: event.payload.installation && event.payload.installation.id
       }
     }
   },

--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,3 +1,7 @@
 module.exports = robot => {
-  console.log('loaded app')
+  robot.log('loaded app')
+
+  robot.on('issue_comment.created', context => {
+    context.log('Comment created')
+  })
 }

--- a/test/robot.test.js
+++ b/test/robot.test.js
@@ -1,5 +1,6 @@
 const Context = require('../lib/context')
 const createRobot = require('../lib/robot')
+const logger = require('../lib/logger')
 
 describe('Robot', function () {
   let robot
@@ -16,23 +17,6 @@ describe('Robot', function () {
         installation: {id: 1}
       }
     }
-  })
-
-  describe('constructor', () => {
-    it('takes a logger', () => {
-      const logger = {
-        trace: jest.fn(),
-        debug: jest.fn(),
-        info: jest.fn(),
-        warn: jest.fn(),
-        error: jest.fn(),
-        fatal: jest.fn()
-      }
-      robot = createRobot({logger})
-
-      robot.log('hello world')
-      expect(logger.debug).toHaveBeenCalledWith('hello world')
-    })
   })
 
   describe('on', function () {
@@ -86,6 +70,31 @@ describe('Robot', function () {
       await robot.receive(event)
       await robot.receive(event2)
       expect(spy.mock.calls.length).toEqual(2)
+    })
+
+    it('adds a logger on the context', async () => {
+      // Add a new stream for testing the logginer
+      // https://github.com/trentm/node-bunyan#adding-a-stream
+      const output = []
+      logger.addStream({
+        level: 'trace',
+        type: 'raw',
+        stream: {write: log => output.push(log)}
+      })
+
+      const handler = jest.fn().mockImplementation(context => {
+        expect(context.log).toBeDefined()
+        context.log('testing')
+
+        expect(output[0]).toEqual(expect.objectContaining({
+          msg: 'testing',
+          id: context.id
+        }))
+      })
+
+      robot.on('test', handler)
+      await robot.receive(event)
+      expect(handler).toHaveBeenCalled()
     })
   })
 

--- a/test/robot.test.js
+++ b/test/robot.test.js
@@ -11,6 +11,7 @@ describe('Robot', function () {
     robot.auth = () => {}
 
     event = {
+      id: '123-456',
       event: 'test',
       payload: {
         action: 'foo',
@@ -88,7 +89,10 @@ describe('Robot', function () {
 
         expect(output[0]).toEqual(expect.objectContaining({
           msg: 'testing',
-          id: context.id
+          event: expect.objectContaining({
+            id: context.id,
+            installation: event.payload.installation.id
+          })
         }))
       })
 

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -7,13 +7,28 @@ describe('serializers', () => {
         event: 'test',
         payload: {
           action: 'test',
-          repository: {full_name: 'probot/test'}
+          repository: {full_name: 'probot/test'},
+          installation: {id: 1}
         }}
       expect(serializers.event(event)).toEqual({
         id: 1,
         event: 'test',
         action: 'test',
-        repository: 'probot/test'
+        repository: 'probot/test',
+        installation: 1
+      })
+    })
+
+    it('works a malformed event', () => {
+      const event = {id: 1,
+        event: 'test',
+        payload: {}}
+      expect(serializers.event(event)).toEqual({
+        id: 1,
+        event: 'test',
+        action: undefined,
+        repository: undefined,
+        installation: undefined
       })
     })
 


### PR DESCRIPTION
cc https://github.com/probot/probot/issues/320

This PR adds `context.log`, which will include information about the context in each log message.

```js
module.exports = robot => {
  robot.on('issue_comment.created', context => {
    context.log('Comment created')
  })
}
```

```
17:42:05.326Z DEBUG Probot: Comment created
    event: {
      "id": "4cfd3e80-c575-11e7-8e7b-a2d9629ce9eb",
      "event": "issue_comment",
      "action": "created",
      "repository": "robotland/test",
      "installation": 13055
    }
```
or with `LOG_LEVEL=json`

```json
{"name":"Probot","hostname":"Brandons-MacBook-Pro-3.local","pid":96993,"event":{"id":"afdcb370-c57d-11e7-9b26-0f31120e45b8","event":"issue_comment","action":"created","repository":"robotland/test","installation":13055},"level":20,"msg":"Comment created","time":"2017-11-09T18:42:07.312Z","v":0}
```