### PR TITLE
docs: Replace examples with include from website

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,9 +11,8 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you 
 
 Probot apps are easy to write, deploy, and share. Many of the most popular Probot apps are hosted, so there's nothing for you to deploy and manage. Here are just a few examples of things that have been built with Probot:
 
-- [stale](https://probot.github.io/apps/stale) - closes abandoned issues after a period of inactivity.
-- [settings](https://probot.github.io/apps/settings) - syncs repository settings defined in `.github/settings.yml` to GitHub, enabling Pull Requests for repository settings.
-- [request-info](https://probot.github.io/apps/request-info) - requests more info from newly opened Pull Requests and Issues that contain either default titles or whose description is left blank.
-- Check out the [featured apps](https://probot.github.io/apps/) or [browse more examples on GitHub](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
+{% include docs/examples.html %}
+
+Check out the [featured apps](https://probot.github.io/apps/) or [browse more examples on GitHub](https://github.com/search?q=topic%3Aprobot-app&type=Repositories)
 
 Ready to get started?


### PR DESCRIPTION
This replaces the list of example apps with an include added in https://github.com/probot/probot.github.io/pull/101.