### PR TITLE
Move unhandled rejection listener to cli scripts

### DIFF
--- a/bin/probot-simulate.js
+++ b/bin/probot-simulate.js
@@ -28,6 +28,7 @@ const probot = createProbot({
   id: program.app,
   cert: findPrivateKey()
 })
+
 probot.setup(program.args.slice(2))
 
 probot.logger.debug('Simulating event', eventName)

--- a/index.js
+++ b/index.js
@@ -28,9 +28,6 @@ const defaultApps = [
   require('./lib/plugins/default')
 ]
 
-// Log all unhandled rejections
-process.on('unhandledRejection', logger.error.bind(logger))
-
 module.exports = (options = {}) => {
   const webhook = createWebhook({path: options.webhookPath || '/', secret: options.secret || 'development'})
   const app = createApp({
@@ -83,6 +80,10 @@ module.exports = (options = {}) => {
   }
 
   function setup (apps) {
+    // Log all unhandled rejections
+    process.on('unhandledRejection', logger.error.bind(logger))
+
+    // Load the given apps along with the default apps
     apps.concat(defaultApps).forEach(app => load(app))
   }
 


### PR DESCRIPTION
When running tests that `require('probot')` with `jest --watch`, you'll eventually get:

```
(node:42819) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 unhandledRejection listeners added. Use emitter.setMaxListeners() to increase limit
```

To reproduce it, save the following in a file and run it with `jest --watch`. Hit enter 10 times to re-run the test, and you should see the warning above appear.

```js
// example.test.js
const createProbot = require('probot')

test('MaxListenersExceededWarning', () => {
  createProbot({})
})
```

This has to do with the way jest reloads code. This PR moves the registering of the `unhandledRejection` rejection listener to the `setup` method, which is called by the CLI scripts.