### PR TITLE
Remove semantic-release from CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ notifications:
   disabled: true
 before_install:
 - npm install -g npm@5
-after_success:
-  - npm run semantic-release
 branches:
   except:
     - /^v\d+\.\d+\.\d+$/


### PR DESCRIPTION
I'd like to propose that we disable semantic-release when a PR is merged, and experiment for a while with continuing to use it manually.

We've been using semantic release for about 6 weeks now, and I feel like it has had a detrimental effect on the pace of the project. I know I've found the barrage of GreenKeeper updates on other repositories every time we merge a PR to be annoying, which causes me to hesitate before merging simple PRs. I've been noticing other people hesitant to make changes, or deciding against making changes, because it will bump the major version number.

Long term, I think I'd rather switch to something like https://github.com/johnbillion/probot-semver, where PRs are added to milestones for the appropriate next version and each release is thoughtful and intentional.

FYI @gr2m @johnbillion