### PR TITLE
Fix two 404s to the API docs

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -58,4 +58,4 @@ Apps _should_ allow all settings to customized for each installation.
 
 ### Store configuration in the repository
 
-Any configuration _should_ be stored in the repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/probot/latest/Context.html#config).
+Any configuration _should_ be stored in the repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/api/latest/Context.html#config).

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -12,7 +12,7 @@ module.exports = robot => {
 }
 ```
 
-The `robot` parameter is an instance of [`Robot`](https://probot.github.io/probot/latest/Robot.html) and gives you access to all of the bot goodness.
+The `robot` parameter is an instance of [`Robot`](https://probot.github.io/api/latest/Robot.html) and gives you access to all of the bot goodness.
 
 `robot.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 


### PR DESCRIPTION
There are some darn 404s popping up on the website, which are also causing new PRs to that repo to fail CI.