### PR TITLE
Use logger for localtunnel messages

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -26,19 +26,6 @@ if (!program.privateKey) {
   program.privateKey = findPrivateKey()
 }
 
-if (program.tunnel && !process.env.DISABLE_TUNNEL) {
-  try {
-    const setupTunnel = require('../lib/tunnel')
-    setupTunnel(program.tunnel, program.port).then(tunnel => {
-      console.log('Listening on ' + tunnel.url)
-    }).catch(err => {
-      console.warn('Could not open tunnel: ', err.message)
-    })
-  } catch (err) {
-    console.warn('Run `npm install --save-dev localtunnel` to enable localtunnel.')
-  }
-}
-
 const createProbot = require('../')
 
 const probot = createProbot({
@@ -48,6 +35,15 @@ const probot = createProbot({
   port: program.port,
   webhookPath: program.webhookPath
 })
+
+if (program.tunnel && !process.env.DISABLE_TUNNEL) {
+  try {
+    const setupTunnel = require('../lib/tunnel')
+    setupTunnel(program.tunnel, program.port)
+  } catch (err) {
+    probot.logger.debug('Run `npm install --save-dev localtunnel` to enable localtunnel.')
+  }
+}
 
 pkgConf('probot').then(pkg => {
   probot.setup(program.args.concat(pkg.apps || pkg.plugins || []))

--- a/lib/tunnel.js
+++ b/lib/tunnel.js
@@ -1,5 +1,6 @@
 const https = require('https')
 const localtunnel = require('localtunnel')
+const logger = require('./logger')
 
 module.exports = function setupTunnel (subdomain, port, retries = 0) {
   if (typeof subdomain !== 'string') {
@@ -11,12 +12,16 @@ module.exports = function setupTunnel (subdomain, port, retries = 0) {
       if (err) {
         reject(err)
       } else {
-        testTunnel(subdomain).then(() => resolve(tunnel)).catch(() => {
+        testTunnel(subdomain).then(() => {
+          logger.info('Listening on ' + tunnel.url)
+          resolve(tunnel)
+        }).catch((err) => {
           if (retries < 3) {
-            console.warn(`Failed to connect to localtunnel.me. Trying again (tries: ${retries + 1})`)
+            logger.warn(`Could not connect to localtunnel.me. Trying again (tries: ${retries + 1})`)
             resolve(setupTunnel(subdomain, port, retries + 1))
           } else {
-            reject(new Error('Failed to connect to localtunnel.me. Giving up.'))
+            logger.warn(err, 'Failed to connect to localtunnel.me.')
+            reject(err)
           }
         })
       }


### PR DESCRIPTION
This updates the messages about localtunnel to use the built-in logger:

<img width="842" alt="screen shot 2017-11-25 at 4 34 25 pm" src="https://user-images.githubusercontent.com/173/33235472-8b476ad6-d1fe-11e7-9047-f5cfacb1f0ab.png">

cc #320 