### PR TITLE
Log full requests as trace

### DIFF
--- a/lib/middleware/logging.js
+++ b/lib/middleware/logging.js
@@ -27,7 +27,7 @@ module.exports = function logRequest ({logger}) {
       const message = `${req.method} ${req.url} ${res.statusCode} - ${res.duration} ms`
 
       req.log.info(message)
-      req.log.debug({req, res})
+      req.log.trace({res})
     })
 
     next()


### PR DESCRIPTION
After using this for a day or so, I don't think there's a lot of value in having the request/response headers in `debug`. The request headers are already logged with `trace` above when the request starts, so this removes the request headers from and switches logging of response headers to `trace`.

cc #320 