### PR TITLE
Extract Sentry logging to a built-in plugin

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,7 +1,5 @@
-const sentryStream = require('bunyan-sentry-stream')
 const cacheManager = require('cache-manager')
 const createWebhook = require('github-webhook-handler')
-const Raven = require('raven')
 
 const createApp = require('./github-app')
 const createRobot = require('./robot')
@@ -15,6 +13,7 @@ const cache = cacheManager.caching({
 })
 
 const defaultApps = [
+  require('./plugins/sentry'),
   require('./plugins/stats'),
   require('./plugins/default')
 ]
@@ -35,16 +34,6 @@ module.exports = (options = {}) => {
 
   // Log all webhook errors
   webhook.on('error', logger.error.bind(logger))
-
-  // If sentry is configured, report all logged errors
-  if (process.env.SENTRY_DSN) {
-    Raven.disableConsoleAlerts()
-    Raven.config(process.env.SENTRY_DSN, {
-      autoBreadcrumbs: true
-    }).install({})
-
-    logger.addStream(sentryStream(Raven))
-  }
 
   const robots = []
 

--- a/lib/plugins/sentry.js
+++ b/lib/plugins/sentry.js
@@ -1,0 +1,15 @@
+const sentryStream = require('bunyan-sentry-stream')
+const Raven = require('raven')
+
+module.exports = robot => {
+  // If sentry is configured, report all logged errors
+  if (process.env.SENTRY_DSN) {
+    robot.log.debug(process.env.SENTRY_DSN, 'Errors will be reported to Sentry')
+    Raven.disableConsoleAlerts()
+    Raven.config(process.env.SENTRY_DSN, {
+      autoBreadcrumbs: true
+    }).install({})
+
+    robot.log.target.addStream(sentryStream(Raven))
+  }
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -117,21 +117,4 @@ describe('Probot', () => {
       expect(spy).toHaveBeenCalled()
     })
   })
-
-  describe('sentry', () => {
-    afterEach(() => {
-      // Clean up env variables
-      delete process.env.SENTRY_URL
-      delete process.env.SENTRY_DSN
-    })
-
-    describe('SENTRY_DSN', () => {
-      it('configures sentry via the SENTRY_DSN ', () => {
-        process.env.SENTRY_DSN = '1233'
-        expect(() => {
-          createProbot()
-        }).toThrow(/Invalid Sentry DSN: 1233/)
-      })
-    })
-  })
 })

--- a/test/plugins/sentry.test.js
+++ b/test/plugins/sentry.test.js
@@ -1,0 +1,44 @@
+const Raven = require('raven')
+
+const plugin = require('../../lib/plugins/sentry')
+
+const helper = require('./helper')
+
+describe('sentry', () => {
+  let robot
+
+  beforeEach(async () => {
+    robot = helper.createRobot()
+  })
+
+  beforeEach(() => {
+    // Clean up env variable
+    delete process.env.SENTRY_DSN
+  })
+
+  describe('with an invalid SENTRY_DSN', () => {
+    test('throws an error', () => {
+      process.env.SENTRY_DSN = 1233
+      expect(() => {
+        plugin(robot)
+      }).toThrow(/Invalid Sentry DSN: 1233/)
+    })
+  })
+
+  describe('with an invalid SENTRY_DSN', () => {
+    beforeEach(() => {
+      process.env.SENTRY_DSN = 'https://user:pw@sentry.io/123'
+      plugin(robot)
+      Raven.captureException = jest.fn()
+    })
+
+    test('sends reported errors to sentry', () => {
+      const err = new Error('test message')
+      robot.log.error(err)
+
+      expect(Raven.captureException).toHaveBeenCalledWith(err, expect.objectContaining({
+        extra: expect.anything()
+      }))
+    })
+  })
+})

--- a/test/plugins/sentry.test.js
+++ b/test/plugins/sentry.test.js
@@ -25,7 +25,7 @@ describe('sentry', () => {
     })
   })
 
-  describe('with an invalid SENTRY_DSN', () => {
+  describe('with a SENTRY_DSN', () => {
     beforeEach(() => {
       process.env.SENTRY_DSN = 'https://user:pw@sentry.io/123'
       plugin(robot)


### PR DESCRIPTION
While doing a sweep for #320 I decided to extract the current sentry support to a built-in plugin, which makes it easier to test, and isolates it from the core of Probot. Someday this will likely be extracted into an extension that is configured at deploy-time, but this is at least a step in that direction.