### PR TITLE
WIP: Allow specifying some settings in package.json

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -51,7 +51,6 @@ pkgConf('probot').then(defaults => {
     }
   }
 
-
   probot.setup(program.args.concat(defaults.apps || defaults.plugins || []))
   probot.start()
 })


### PR DESCRIPTION
I'm working on a project where I want to permanently change `WEBHOOK_PATH`. I could set an environment variable, but that's brittle for multiple deployments. Some settings are not likely to change for an application, so it might be nice to allow setting them in `package.json`

I'm not in love with the implementation here, but thought I would get a PR open to start the discussion and see if anyone has suggestions.

- [ ] What other settings should be exposed? `LOG_LEVEL`? …?
- [ ] Tests