### PR TITLE
Spike out OAuth integration for Probot

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -17,6 +17,8 @@ program
   .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
   .parse(process.argv)
 
+process.env.AUTH_METHOD = 'githubapp'
+
 if (!program.app) {
   console.warn('Missing GitHub App ID.\nUse --app flag or set APP_ID environment variable.')
   program.help()

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -31,11 +31,11 @@ if (!program.privateKey) {
 const createProbot = require('../')
 
 const probot = createProbot({
-  id: program.app,
-  secret: program.secret,
-  cert: program.privateKey,
   port: program.port,
-  webhookPath: program.webhookPath
+  webhookPath: program.webhookPath,
+  secret: program.secret,
+  id: program.app,
+  cert: program.privateKey
 })
 
 if (program.tunnel && !process.env.DISABLE_TUNNEL) {

--- a/bin/probot-runoauth.js
+++ b/bin/probot-runoauth.js
@@ -15,6 +15,9 @@ program
   .option('-s, --secret <secret>', 'Webhook secret', process.env.WEBHOOK_SECRET)
   .option('-s, --clientsecret <secret>', 'OAuth token secert for your application', process.env.CLIENT_SECRET)
   .parse(process.argv)
+
+process.env.AUTH_METHOD = 'oauth'
+
 if (!program.oauthtoken) {
   console.warn('Missing GitHub OAuth Token.\nUse --oauthtoken flag or set TOKEN environment variable.')
   program.help()

--- a/bin/probot-runoauth.js
+++ b/bin/probot-runoauth.js
@@ -2,3 +2,41 @@
 
 require('dotenv').config()
 
+const pkgConf = require('pkg-conf')
+const program = require('commander')
+
+program
+  .usage('[options] <apps...>')
+  .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
+  .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV !== 'production')
+  .option('-w, --webhook-path <path>', 'URL path which receives webhooks. Ex: `/webhook`', process.env.WEBHOOK_PATH)
+  .option('-o, --oauthtoken <token>', 'OAuth token for your application', process.env.TOKEN)
+  .option('-c, --clientid <id>', 'OAuth token id for your application', process.env.CLIENT_ID)
+  .option('-s, --secret <secret>', 'Webhook secret', process.env.WEBHOOK_SECRET)
+  .option('-s, --clientsecret <secret>', 'OAuth token secert for your application', process.env.CLIENT_SECRET)
+  .parse(process.argv)
+if (!program.oauthtoken) {
+  console.warn('Missing GitHub OAuth Token.\nUse --oauthtoken flag or set TOKEN environment variable.')
+  program.help()
+}
+
+const createProbot = require('../')
+
+const probot = createProbot({
+  clientid: program.clientid,
+  clientsecret: program.clientsecret
+})
+
+if (program.tunnel && !process.env.DISABLE_TUNNEL) {
+  try {
+    const setupTunnel = require('../lib/tunnel')
+    setupTunnel(program.tunnel, program.port)
+  } catch (err) {
+    probot.logger.debug('Run `npm install --save-dev localtunnel` to enable localtunnel.')
+  }
+}
+
+pkgConf('probot').then(pkg => {
+  probot.setup(program.args.concat(pkg.apps || pkg.plugins || []))
+  probot.start()
+})

--- a/bin/probot-runoauth.js
+++ b/bin/probot-runoauth.js
@@ -26,6 +26,9 @@ if (!program.oauthtoken) {
 const createProbot = require('../')
 
 const probot = createProbot({
+  port: program.port,
+  webhookPath: program.webhookPath,
+  secret: program.secret,
   clientid: program.clientid,
   clientsecret: program.clientsecret
 })

--- a/bin/probot-runoauth.js
+++ b/bin/probot-runoauth.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+
+require('dotenv').config()
+

--- a/bin/probot.js
+++ b/bin/probot.js
@@ -11,6 +11,7 @@ if (!semver.satisfies(process.version, version)) {
 require('commander')
   .version(require('../package').version)
   .usage('<command> [options]')
-  .command('run', 'run the bot')
+  .command('run', 'run the bot with GitHub App integration')
+  .command('runoauth', 'run the bot with OAuth App integration')
   .command('simulate', 'simulate a webhook being delivered')
   .parse(process.argv)

--- a/lib/index.js
+++ b/lib/index.js
@@ -20,10 +20,10 @@ const defaultApps = [
 
 module.exports = (options = {}) => {
   const webhook = createWebhook({path: options.webhookPath || '/', secret: options.secret || 'development'})
-  const app = createApp({
+  const app = (process.env.AUTH_METHOD === 'githubapp') ? createApp({
     id: options.id,
     cert: options.cert
-  })
+  }) : null
   const server = createServer({webhook, logger})
 
   // Log all received webhooks

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -96,7 +96,7 @@ class Robot {
         const log = this.log.child({id: event.id})
 
         try {
-          const github = await this.auth(event.payload.installation.id, log)
+          const github = await this.auth('installation' in event.payload ? event.payload.installation.id : null, log)
           const context = new Context(event, github, log)
 
           await callback(context)

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -144,19 +144,44 @@ class Robot {
       logger: log.child({installation: id})
     })
 
-    if (id) {
-      const res = await this.cache.wrap(`app:${id}:token`, () => {
-        log.trace(`creating token for installation`)
+    if (process.env.AUTH_METHOD === 'githubapp') {
+      if (id) {
+        const res = await this.cache.wrap(`app:${id}:token`, () => {
+          log.trace(`creating token for installation`)
+          github.authenticate({type: 'integration', token: this.app()})
+
+          return github.apps.createInstallationToken({installation_id: id})
+        }, {ttl: 60 * 59}) // Cache for 1 minute less than GitHub expiry
+
+        github.authenticate({type: 'token', token: res.data.token})
+      } else {
         github.authenticate({type: 'integration', token: this.app()})
-
-        return github.apps.createInstallationToken({installation_id: id})
-      }, {ttl: 60 * 59}) // Cache for 1 minute less than GitHub expiry
-
-      github.authenticate({type: 'token', token: res.data.token})
+      }
     } else {
-      github.authenticate({type: 'integration', token: this.app()})
-    }
+      github = new GitHubApi({
+        debug: process.env.LOG_LEVEL === 'trace'
+      })
+      await this.cache.wrap(`app:oauth${process.env.CLIENT_ID}:token`, () => {
+        this.log.trace(`creating token for oauth client ${process.env.CLIENT_ID}`)
+        return github.authenticate({
+          type: 'oauth',
+          key: process.env.CLIENT_ID,
+          secret: process.env.CLIENT_SECRET
+        })
+      }, {
+        ttl: 60 * 60
+      })
 
+      /*
+      TODO: GitHubApi additional config for:
+      host: 'github.com', pathPrefix: '/api/v3'
+      */
+
+      github.authenticate({
+        type: 'oauth',
+        token: process.env.TOKEN
+      })
+    }
     return github
   }
 }

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -172,11 +172,6 @@ class Robot {
         ttl: 60 * 60
       })
 
-      /*
-      TODO: GitHubApi additional config for:
-      host: 'github.com', pathPrefix: '/api/v3'
-      */
-
       github.authenticate({
         type: 'oauth',
         token: process.env.TOKEN

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -158,9 +158,6 @@ class Robot {
         github.authenticate({type: 'integration', token: this.app()})
       }
     } else {
-      github = new GitHubApi({
-        debug: process.env.LOG_LEVEL === 'trace'
-      })
       await this.cache.wrap(`app:oauth${process.env.CLIENT_ID}:token`, () => {
         this.log.trace(`creating token for oauth client ${process.env.CLIENT_ID}`)
         return github.authenticate({


### PR DESCRIPTION
This PR adds capabilities to probot to execute as an **OAuth integration**, not just a **GitHub App.**

This is helpful for those use cases that are more generic/user-centric in nature (think Notifications and Inbox-style apps).

/to @bkeepers @JasonEtco 


## Changes
- Adds a `probot-runoauth.js`file to handle oauth configuration. This mirrors the existing `probot-run.js` file which remains in it's current form for easier backwards compatibility. A symlink of `probot-rungithubapp.js` would make my :heart: 😄 , but isn't required.
- Rearrange params in the `createProbot` method to be stable across authentication methods.
- Introduce an environment variable (`AUTH_METHOD`) to allow for switching elsewhere in the application.
- Handle use cases where assumptions were made about GitHub Apps, or how GitHub responds to items with apps vs more generic use cases.
- `lib/robot.js` now includes a conditional around authenticating with GitHub based on the preferred authentication method. 

## Concerns
- `probot-run` & `probot-runoauth` could probably be abstracted a bit so they can share code. The issue is how to handle the different parse commands. I couldn't find an easy way to do it, but this is a maintenance headache as written.
- Should the router expose OAuth commands to allow users to follow the oauth webflow? Right now users are required to get their own tokens, and is only easily done by PATs, not by an oauth app flow.
- Do OAuth apps likely have more multi-user problems than GitHub Apps do? Do we need to store tokens in some sort of secure store? I haven't even thought about this problem yet.
- What about using the OAuth authentication already available via GitHub Apps? Would that make some of my assumptions (no app id, no private key, etc) about oauth integrations invalid?

Open for thoughts/discussions.
