### PR TITLE
webhook proxy experiment

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -42,7 +42,6 @@ if (!program.webhookProxy && program.tunnel && !process.env.DISABLE_TUNNEL) {
   try {
     const setupTunnel = require('../lib/tunnel')
     setupTunnel(program.tunnel, program.port)
-    console.warn('[DEPRECATED] localtunnel support will removed in 5.0. TODO: LINK')
   } catch (err) {
     probot.logger.debug('Run `npm install --save-dev localtunnel` to enable localtunnel.')
   }

--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -45,6 +45,8 @@ if (program.tunnel && !process.env.DISABLE_TUNNEL) {
   }
 }
 
+require('../lib/webhook-proxy')(probot)
+
 pkgConf('probot').then(pkg => {
   probot.setup(program.args.concat(pkg.apps || pkg.plugins || []))
   probot.start()

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,9 @@
 const cacheManager = require('cache-manager')
 const createWebhook = require('github-webhook-handler')
-
 const createApp = require('./github-app')
 const createRobot = require('./robot')
 const createServer = require('./server')
+const createWebhookProxy = require('./webhook-proxy')
 const resolve = require('./resolver')
 const logger = require('./logger')
 
@@ -75,6 +75,10 @@ module.exports = (options = {}) => {
     setup,
 
     start () {
+      if (options.webhookProxy) {
+        createWebhookProxy({url: options.webhookProxy, webhook, logger})
+      }
+
       server.listen(options.port)
       logger.trace('Listening on http://localhost:' + options.port)
     }

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -1,14 +1,25 @@
 const EventSource = require('eventsource')
 
-module.exports = probot => {
-  const events = new EventSource(process.env.WEBHOOK_PROXY_URL)
+module.exports = ({logger, receive, url = process.env.WEBHOOK_PROXY_URL}) => {
+  const events = new EventSource(url)
+
+  // Reconnect immediately
+  events.reconnectInterval = 0
+
+  events.onerror = (err) => {
+    if (events.readyState === EventSource.CONNECTING) {
+      logger.trace({url, err}, 'Reconnecting to webhook proxy')
+    } else if (err.status) {
+      logger.error(err, 'Webhook proxy error')
+    }
+  }
 
   events.onmessage = (msg) => {
-    probot.logger.trace(msg, 'Message from webhook proxy')
+    logger.trace(msg, 'Message from webhook proxy')
 
     const data = JSON.parse(msg.data)
 
-    // TODO: verify x-hug-signature
+    // TODO: verify x-hub-signature
 
     const event = {
       event: data['x-github-event'],
@@ -18,8 +29,9 @@ module.exports = probot => {
       host: data['host']
     }
 
-    probot.logger.debug({event}, 'Webhook received from proxy')
+    logger.debug({event}, 'Webhook received from proxy')
 
-    probot.receive(event)
+    receive(event)
   }
+
 }

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -4,17 +4,6 @@ module.exports = ({url, logger, webhook}) => {
   logger.trace({url}, 'Setting up webhook proxy')
   const events = new EventSource(url)
 
-  // Reconnect immediately
-  events.reconnectInterval = 0
-
-  events.onerror = (err) => {
-    if (events.readyState === EventSource.CONNECTING) {
-      logger.trace({url, err}, 'Reconnecting to webhook proxy')
-    } else if (err.status) {
-      logger.error(err, 'Webhook proxy error')
-    }
-  }
-
   events.onmessage = (msg) => {
     logger.trace(msg, 'Message from webhook proxy')
 
@@ -38,6 +27,23 @@ module.exports = ({url, logger, webhook}) => {
       webhook.emit('error', err, msg.data)
     }
   }
+
+  // Reconnect immediately
+  events.reconnectInterval = 0
+
+  events.addEventListener('error', err => {
+    if (!err.status) {
+      // Errors are randomly re-emitted for no reason
+      // See https://github.com/EventSource/eventsource/pull/85
+    } else if (err.status >= 400 && err.status < 500) {
+      // Nothing we can do about it
+      logger.error(err, 'Webhook proxy error')
+    } else if (events.readyState === EventSource.CONNECTING) {
+      logger.trace({url, err}, 'Reconnecting to webhook proxy')
+    } else {
+      logger.error(err, 'Webhook proxy error')
+    }
+  })
 
   return events
 }

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -1,6 +1,7 @@
 const EventSource = require('eventsource')
 
-module.exports = ({logger, receive, url = process.env.WEBHOOK_PROXY_URL}) => {
+module.exports = ({url, logger, webhook}) => {
+  logger.trace({url}, 'Setting up webhook proxy')
   const events = new EventSource(url)
 
   // Reconnect immediately
@@ -18,20 +19,25 @@ module.exports = ({logger, receive, url = process.env.WEBHOOK_PROXY_URL}) => {
     logger.trace(msg, 'Message from webhook proxy')
 
     const data = JSON.parse(msg.data)
+    const sig = data['x-hub-signature']
 
-    // TODO: verify x-hub-signature
+    if (sig && webhook.verify(sig, JSON.stringify(data.body))) {
+      const event = {
+        event: data['x-github-event'],
+        id: data['x-github-delivery'],
+        payload: data.body,
+        protocol: data['x-forwarded-proto'],
+        host: data['host']
+      }
 
-    const event = {
-      event: data['x-github-event'],
-      id: data['x-github-delivery'],
-      payload: data.body,
-      protocol: data['x-forwarded-proto'],
-      host: data['host']
+      logger.debug({event}, 'Webhook received from proxy')
+      webhook.emit(event.event, event)
+      webhook.emit('*', event)
+    } else {
+      const err = new Error('X-Hub-Signature does not match blob signature')
+      webhook.emit('error', err, msg.data)
     }
-
-    logger.debug({event}, 'Webhook received from proxy')
-
-    receive(event)
   }
 
+  return events
 }

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -19,7 +19,6 @@ module.exports = ({url, logger, webhook}) => {
         host: data['host']
       }
 
-      logger.debug({event}, 'Webhook received from proxy')
       webhook.emit(event.event, event)
       webhook.emit('*', event)
     } else {

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -4,7 +4,7 @@ module.exports = ({url, logger, webhook}) => {
   logger.trace({url}, 'Setting up webhook proxy')
   const events = new EventSource(url)
 
-  events.onmessage = (msg) => {
+  events.addEventListener('message', (msg) => {
     logger.trace(msg, 'Message from webhook proxy')
 
     const data = JSON.parse(msg.data)
@@ -14,7 +14,7 @@ module.exports = ({url, logger, webhook}) => {
       const event = {
         event: data['x-github-event'],
         id: data['x-github-delivery'],
-        payload: data.body,
+        payload: data['body'],
         protocol: data['x-forwarded-proto'],
         host: data['host']
       }
@@ -25,7 +25,7 @@ module.exports = ({url, logger, webhook}) => {
       const err = new Error('X-Hub-Signature does not match blob signature')
       webhook.emit('error', err, msg.data)
     }
-  }
+  })
 
   // Reconnect immediately
   events.reconnectInterval = 0
@@ -36,11 +36,11 @@ module.exports = ({url, logger, webhook}) => {
       // See https://github.com/EventSource/eventsource/pull/85
     } else if (err.status >= 400 && err.status < 500) {
       // Nothing we can do about it
-      logger.error(err, 'Webhook proxy error')
+      logger.error({url, err}, 'Webhook proxy error')
     } else if (events.readyState === EventSource.CONNECTING) {
       logger.trace({url, err}, 'Reconnecting to webhook proxy')
     } else {
-      logger.error(err, 'Webhook proxy error')
+      logger.error({url, err}, 'Webhook proxy error')
     }
   })
 

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -1,0 +1,25 @@
+const EventSource = require('eventsource')
+
+module.exports = probot => {
+  const events = new EventSource(process.env.WEBHOOK_PROXY_URL)
+
+  events.onmessage = (msg) => {
+    probot.logger.trace(msg, 'Message from webhook proxy')
+
+    const data = JSON.parse(msg.data)
+
+    // TODO: verify x-hug-signature
+
+    const event = {
+      event: data['x-github-event'],
+      id: data['x-github-delivery'],
+      payload: data.body,
+      protocol: data['x-forwarded-proto'],
+      host: data['host']
+    }
+
+    probot.logger.debug({event}, 'Webhook received from proxy')
+
+    probot.receive(event)
+  }
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "cache-manager": "^2.4.0",
     "commander": "^2.11.0",
     "dotenv": "~4.0.0",
+    "eventsource": "^1.0.5",
     "express": "^4.16.2",
     "github": "^12.0.3",
     "github-webhook-handler": "github:rvagg/github-webhook-handler#v0.6.1",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eventsource": "^1.0.5",
     "express": "^4.16.2",
     "github": "^12.0.3",
-    "github-webhook-handler": "github:rvagg/github-webhook-handler#v0.6.1",
+    "github-webhook-handler": "^0.7.0",
     "hbs": "^4.0.1",
     "jest": "^21.2.1",
     "js-yaml": "^3.9.1",
@@ -45,6 +45,7 @@
     "semver": "^5.4.1"
   },
   "devDependencies": {
+    "connect-sse": "^1.2.0",
     "eslint": "^4.6.1",
     "eslint-plugin-markdown": "^1.0.0-beta.6",
     "jsdoc": "^3.5.5",

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -50,11 +50,10 @@ describe('webhook-proxy', () => {
       done()
     })
 
-    const body = {action: 'foo'}
-
     emit({
       'x-github-event': 'test',
-      body
+      'x-hub-signature': 'lolnope',
+      body: {action: 'foo'}
     })
   })
 })

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -1,0 +1,60 @@
+const express = require('express')
+const sse = require('connect-sse')()
+const createWebhook = require('github-webhook-handler')
+const createWebhookProxy = require('../lib/webhook-proxy')
+const logger = require('../lib/logger')
+
+describe('webhook-proxy', () => {
+  let app, server, proxy, webhook, url, emit
+
+  beforeEach((done) => {
+    app = express()
+
+    app.get('/events', sse, function (req, res) {
+      res.json({}, 'ready')
+      emit = res.json
+    })
+
+    webhook = createWebhook({path: '/', secret: 'test'})
+    server = app.listen(0, () => {
+      url = `http://127.0.0.1:${server.address().port}/events`
+      proxy = createWebhookProxy({url, logger, webhook})
+
+      // Wait for proxy to be ready
+      proxy.addEventListener('ready', () => done())
+    })
+  })
+
+  afterEach(() => {
+    server.close()
+    proxy.close()
+  })
+
+  test('emits events with a valid signature', (done) => {
+    // This test will be done when the webhook is emitted
+    webhook.on('test', () => done())
+
+    const body = {action: 'foo'}
+
+    emit({
+      'x-github-event': 'test',
+      'x-hub-signature': webhook.sign(JSON.stringify(body)),
+      body
+    })
+  })
+
+  test('does not emit events with an invalid signature', (done) => {
+    // This test will be done when the webhook is emitted
+    webhook.on('error', (err) => {
+      expect(err.message).toEqual('X-Hub-Signature does not match blob signature')
+      done()
+    })
+
+    const body = {action: 'foo'}
+
+    emit({
+      'x-github-event': 'test',
+      body
+    })
+  })
+})

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -75,7 +75,7 @@ describe('webhook-proxy', () => {
 
     proxy.on('error', err => {
       expect(err.status).toBe(404)
-      expect(log.error).toHaveBeenCalledWith(err, 'Webhook proxy error')
+      expect(log.error).toHaveBeenCalledWith({err, url}, 'Webhook proxy error')
       done()
     })
   })


### PR DESCRIPTION
localtunnel has long been a point of friction for developing Probot apps (https://github.com/probot/friction/issues/5). It's been down even more in the last week, which prompted a lot of discussion in Slack about looking more earnestly for a replacement.

I hacked together a [proof-of-concept](http://github.com/bkeepers/webhook-proxy) for a server that proxies webhooks using [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events). 

How it works:

1. Go to http://github-webhook-proxy.herokuapp.com/, which will redirect you to a URL for a new channel. Use that URL as your **Webhook URL**
1. Any clients connected to that channel will receive the webhook events. Using this branch, set `WEBHOOK_PROXY_URL` to that URL and run `probot run…` as normal and it will connect to the proxy.

Unlike localtunnel/ngrok/etc, this only proxies one URL, so it's a lot lighter weight to run and support. It's also not a bi-directional channel, so clients can't serve up responses to the webhook request, which also makes it less of a security risk for other users and whoever is hosting the service.

Lot's TODO here, but wanted to open this up to get some feedback.

```
$ LOG_LEVEL=debug WEBHOOK_PROXY_URL=http://github-webhook-proxy.herokuapp.com/abcxyz npm start

…

22:07:48.983Z DEBUG probot: Webhook received from proxy
  event: {
    "id": "4ff063a0-d417-11e7-9b60-72f484488df8",
    "event": "issues.closed",
    "repository": "robotland/test",
    "installation": 13055
  }
```

cc @JasonEtco @tcbyrd @gr2m @mcolyer 