### PR TITLE
Add example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@
 
 If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you right there. Most features can actually be added via [GitHub Apps](https://developer.github.com/apps/), which extend GitHub and can be installed directly on organizations and user accounts and granted access to specific repositories. They come with granular permissions and built-in webhooks. Apps are first class actors within GitHub.
 
-**Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. Check out some of the [featured apps](https://probot.github.io/apps) or [read the docs](https://probot.github.io/docs/) to learn more about writing a new app.
-
 ## How it works
 
-GitHub Apps can listen to webhook events sent by a repository or organization. Probot uses its internal event emitter to perform actions based on those events. A simple Probot App might look like this:
+**Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. GitHub Apps can listen to webhook events sent by a repository or organization. Probot uses its internal event emitter to perform actions based on those events. A simple Probot App might look like this:
 
 ```js
 module.exports = robot => {
@@ -18,6 +16,7 @@ module.exports = robot => {
   })
 }
 ```
+Check out some of the [featured apps](https://probot.github.io/apps) or [read the docs](https://probot.github.io/docs/) to learn more about writing a new app.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; imma stop you 
 
 **Probot is a framework for building [GitHub Apps](http://developer.github.com/apps) in [Node.js](https://nodejs.org/)**. Check out some of the [featured apps](https://probot.github.io/apps) or [read the docs](https://probot.github.io/docs/) to learn more about writing a new app.
 
+## How it works
+
+GitHub Apps can listen to webhook events sent by a repository or organization. Probot uses its internal event emitter to perform actions based on those events. A simple Probot App might look like this:
+
+```js
+module.exports = robot => {
+  robot.on('issues.opened', async context => {
+    const issueComment = context.issue({ body: 'Thanks for opening this issue!' })
+    return context.github.issues.createComment(issueComment)
+  })
+}
+```
+
 ## Contributing
 
 Probot is built by people just like you! Most of the interesting things are built _with_ Probot, so consider starting by [writing a new app](https://probot.github.io/docs/) or improving one of the [existing ones](https://github.com/search?q=topic%3Aprobot-app&type=Repositories), and check out our [contributing docs](CONTRIBUTING.md) for other ways to get started.


### PR DESCRIPTION
Looking at the README today (and marveling at the beautiful green coverage badge), it occurred to me that people coming to this repository for the first time (and not the website) may not have any idea what Probot looks like in practice. This PR adds a short example to show visitors the basics of a Probot app. I find that seeing code in any framework or project is vital in my understanding of it.

Please feel free to nitpick the text or example. If you don't think this is valuable, that's ok too! Just thought I'd open up the conversation.