### PR TITLE
fix: avoid referencing installion.id if it's undefined

### DIFF
--- a/lib/robot.js
+++ b/lib/robot.js
@@ -96,7 +96,7 @@ class Robot {
         const log = this.log.child({id: event.id})
 
         try {
-          const github = await this.auth(event.payload.installation.id, log)
+          const github = await this.auth(event.payload.installation && event.payload.installation.id, log)
           const context = new Context(event, github, log)
 
           await callback(context)


### PR DESCRIPTION
Following the Getting Started Guide and running my first webhook test, I got `Cannot read property 'id' of undefined` error. This avoids referencing `event.payload.installation.id` if `event.payload.installation` is undefined.