### PR TITLE
Update documentation to reflect now.sh private key issue

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -112,6 +112,10 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
 
+1. Due to an [ongoing issue](https://github.com/zeit/now-cli/issues/749) in `now.sh`, a workaround must be applied to the private key before it can be used.
+    * You can [modify `package.json`](https://github.com/probot/probot/issues/318#issuecomment-343010573) and base64 encode your private key.
+    * You can concatenate a `\n` onto each line of the private key, and then merge the private key onto a single line. Then, you can follow the deploy script without modifying `package.json`.
+
 1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the path for the `PRIVATE_KEY`:
 
         $ now -e APP_ID=aaa \


### PR DESCRIPTION
As discussed in https://github.com/probot/friction/issues/17, this pull request updates the documentation for deploying to Zeit Now to indicate that the current deployment steps will not work due to an issue with their deploy script. It also provides a couple of workarounds.

I'm hesitant about this. On one hand, I think that it's silly to have documentation that directly references an issue. On the other hand, this saves potential victims of the bug (like me) a headache of trying to figure out what's wrong with the deployment process.