### PR TITLE
Add NODE_ENV to Zeit Now boot command

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -120,6 +120,7 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
         $ now -e APP_ID=aaa \
             -e WEBHOOK_SECRET=bbb \
+            -e NODE_ENV=production \
             -e PRIVATE_KEY="$(cat ~/Downloads/*.private-key.pem)"
 
 1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).


### PR DESCRIPTION
Following the note at https://github.com/probot/friction/issues/5#issuecomment-350199754, this pull request addresses the start up command for Zeit Now not setting `NODE_ENV`. Without setting `NODE_ENV`, localtunnel issues are more noticeable when it goes down during deployment. Since localtunnel isn't even needed, and it's disabled with a production environment, the startup command should reflect this and set it manually.