### PR TITLE
Consider removing Now from deployment docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,6 @@ Every app can either be deployed stand-alone, or combined with other apps in one
 1. [Deploy the app](#deploy-the-app)
     1. [Glitch](#glitch)
     1. [Heroku](#heroku)
-    1. [Now](#now)
 1. [Combining apps](#combining-apps)
 
 ## Create the GitHub App
@@ -103,28 +102,6 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
 
         $ heroku config:set LOG_LEVEL=trace
         $ heroku logs --tail
-
-### Now
-
-Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After [creating the GitHub App](#create-the-github-app):
-
-1. Install the now CLI with `npm i -g now`
-
-1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
-
-1. Due to an [ongoing issue](https://github.com/zeit/now-cli/issues/749) in `now.sh`, a workaround must be applied to the private key before it can be used.
-    * You can [modify `package.json`](https://github.com/probot/probot/issues/318#issuecomment-343010573) and base64 encode your private key.
-    * You can concatenate a `\n` onto each line of the private key, and then merge the private key onto a single line. Then, you can follow the deploy script without modifying `package.json`.
-
-1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the path for the `PRIVATE_KEY`:
-
-        $ now -e APP_ID=aaa \
-            -e WEBHOOK_SECRET=bbb \
-            -e PRIVATE_KEY="$(cat ~/Downloads/*.private-key.pem)"
-
-1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
-
-Your app should be up and running!
 
 ## Combining apps
 


### PR DESCRIPTION
I've noticed that most of the questions we get about running an app in production are from people trying to deploy to Now. A few recent examples: https://github.com/probot/friction/issues/17, #318, https://github.com/probot/friction/issues/5#issuecomment-350198880.

I personally don't use Now, and I don't have time to dig in and improve the docs. Does someone else that's more familiar with Now? cc @gr2m @rtsao

If not, I suggest we remove it from the docs to dissuade people from using it.

closes https://github.com/probot/friction/issues/17
closes #246 
cc #94 