### PR TITLE
Improve Now documentation with scaling and aliases

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -125,7 +125,13 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
 
-Your app should be up and running!
+1. Your app should be up and running! For long term use, create an alias for your robot. After making an alias, you can swap to new deploy URLs with no downtime.
+
+        $ now alias set https://your-generated-url.now.sh https://a-fancier-url.now.sh
+
+1. You can also keep your app running forever, with instant response to webhooks with:
+
+        $ now scale https://a-fancier-url.now.sh 1
 
 ## Combining apps
 


### PR DESCRIPTION
My hope with this pull request is to provide a good solution to the discussion in #366. I think that in general, as long as `now` is a stable platform, people are content with keeping it. With this in mind, I've done a lot of digging today. This pull request summarizes the research I did working with ZEIT staff. It also adds helpful documentation on how to make living with `now` way better in the long run.

### Problems with private keys
This is an [undisputed problem](https://github.com/zeit/now-cli/issues/749), but we have two good workarounds in the docs so far, and with the amount of commotion I've drawn towards that issue, I think it might get resolved sooner, rather than later.

### Problems with `NODE_ENV` not being set
Resolved in a prior pull request.

### Problems with app sleeping
In #366, I mentioned that `now` apps sleep automatically. This is true, by default. As shown in this PR, it can be avoided through `now scale`. Two employees in the ZEIT community confirmed that this is expected behavior, and that their documentation is wrong. I've attached screenshots for these conversations to aid in supplementing this.

![screen shot 2017-12-10 at 01 30 45](https://user-images.githubusercontent.com/532647/33803298-c8a259f8-dd49-11e7-9113-0428d0a24f28.png)
![screen shot 2017-12-10 at 01 32 48](https://user-images.githubusercontent.com/532647/33803316-1bacb724-dd4a-11e7-887a-c6ff66db6fd9.png)

### Are aliases free?
Yes (confirmed by employees).

### tl;dr
ZEIT Now provides a modern alternative to Heroku without the downsides of app sleeping, provided one command is run. My [earlier](https://github.com/probot/probot/pull/366#issuecomment-350285474) [comments](https://github.com/probot/probot/pull/366#issuecomment-350400141) [on now](https://github.com/probot/probot/pull/366#issuecomment-350477563) were pretty ill informed. There's a lesson here about how I shouldn't be so hasty in what I say, because `now` is a pretty awesome platform once properly understood. I'm sorry.