### PR TITLE
Hardcode smee.io

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -11,7 +11,7 @@ program
   .usage('[options] <apps...>')
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
   .option('-t, --tunnel <subdomain>', 'Expose your local bot to the internet', process.env.SUBDOMAIN || process.env.NODE_ENV !== 'production')
-  .option('-W, --webhook-proxy <url>', 'URL of the webhook proxy service.`', process.env.WEBHOOK_PROXY_URL)
+  .option('-c, --channel <channel>', 'Channel from smee.io', process.env.SMEE_CHANNEL)
   .option('-w, --webhook-path <path>', 'URL path which receives webhooks. Ex: `/webhook`', process.env.WEBHOOK_PATH)
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
   .option('-s, --secret <secret>', 'Webhook secret of the GitHub App', process.env.WEBHOOK_SECRET)
@@ -35,7 +35,7 @@ const probot = createProbot({
   cert: program.privateKey,
   port: program.port,
   webhookPath: program.webhookPath,
-  webhookProxy: program.webhookProxy
+  channel: program.channel
 })
 
 if (!program.webhookProxy && program.tunnel && !process.env.DISABLE_TUNNEL) {

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -1,6 +1,7 @@
 const EventSource = require('eventsource')
 
-module.exports = ({url, logger, webhook}) => {
+module.exports = ({url: host, channel, logger, webhook}) => {
+  const url = (host || 'https://smee.io/') + channel
   logger.trace({url}, 'Setting up webhook proxy')
   const events = new EventSource(url)
 

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -8,7 +8,7 @@ const logger = require('../lib/logger')
 const webhook = createWebhook({path: '/', secret: 'test'})
 
 describe('webhook-proxy', () => {
-  let app, server, proxy, url, emit
+  let app, server, proxy, url, emit, channel
 
   afterEach(() => {
     server && server.close()
@@ -25,8 +25,9 @@ describe('webhook-proxy', () => {
       })
 
       server = app.listen(0, () => {
-        url = `http://127.0.0.1:${server.address().port}/events`
-        proxy = createWebhookProxy({url, logger, webhook})
+        channel = 'events'
+        url = `http://127.0.0.1:${server.address().port}/`
+        proxy = createWebhookProxy({url, channel, logger, webhook})
 
         // Wait for proxy to be ready
         proxy.addEventListener('ready', () => done())
@@ -64,14 +65,14 @@ describe('webhook-proxy', () => {
     })
   })
 
-  test('logs an error when the proxy server that is not found', (done) => {
-    const url = 'http://bad.proxy/events'
-    nock('http://bad.proxy').get('/events').reply(404)
+  test('logs an error when the proxy server is not found', (done) => {
+    const url = 'https://bad.proxy/events'
+    nock('https://bad.proxy').get('/events').reply(404)
 
     const log = logger.child()
     log.error = jest.fn()
 
-    proxy = createWebhookProxy({url, webhook, logger: log})
+    proxy = createWebhookProxy({url: 'https://bad.proxy/', channel, webhook, logger: log})
 
     proxy.on('error', err => {
       expect(err.status).toBe(404)

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -66,13 +66,13 @@ describe('webhook-proxy', () => {
   })
 
   test('logs an error when the proxy server is not found', (done) => {
-    const url = 'https://bad.proxy/events'
-    nock('https://bad.proxy').get('/events').reply(404)
+    const url = 'http://bad.proxy/events'
+    nock('http://bad.proxy').get('/events').reply(404)
 
     const log = logger.child()
     log.error = jest.fn()
 
-    proxy = createWebhookProxy({url: 'https://bad.proxy/', channel, webhook, logger: log})
+    proxy = createWebhookProxy({url: 'http://bad.proxy/', channel, webhook, logger: log})
 
     proxy.on('error', err => {
       expect(err.status).toBe(404)


### PR DESCRIPTION
Now that we have [smee.io](https://smee.io) set up, I think it makes sense to simplify setting the channel by hardcoding `https://smee.io` as the webhook proxy URL, then providing a `SMEE_CHANNEL` environment variable.

For ease of testing, I've kept the `url` property passed to `createWebhookProxy` - this can also be used to enable another environment variable to set a custom webhook proxy host. I haven't included that yet; I don't want to add more env vars to the system unless necessary. Let me know what y'all think about that.

I'd like to write docs that instruct on how to do all of this, but I'll wait until this PR is resolved since it will change the instructions.