### PR TITLE
Serializer tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 out
 tmp
 package-lock.json
+coverage

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -1,6 +1,25 @@
 const serializers = require('../lib/serializers')
 
 describe('serializers', () => {
+  describe('repository', () => {
+    it('returns the repository\'s full name', () => {
+      const repo = { full_name: 'probot/JasonEtco' }
+      expect(serializers.repository(repo)).toBe('probot/JasonEtco')
+    })
+  })
+
+  describe('installation', () => {
+    it('returns the installation\'s account login', () => {
+      const inst = { account: { login: 'JasonEtco' } }
+      expect(serializers.installation(inst)).toBe('JasonEtco')
+    })
+
+    it('returns the installation if no account exists', () => {
+      const inst = { foo: true, bar: false }
+      expect(serializers.installation(inst)).toEqual(inst)
+    })
+  })
+
   describe('event', () => {
     it('works with a legit event', () => {
       const event = {id: 1,
@@ -37,6 +56,17 @@ describe('serializers', () => {
 
     it('works empty object', () => {
       expect(serializers.event({})).toEqual({})
+    })
+  })
+
+  describe('res', () => {
+    it('returns the provided object if no status exists', () => {
+      const res = { foo: true, bar: false }
+      expect(serializers.res(res)).toEqual(res)
+    })
+
+    it('returns nothing when passed nothing', () => {
+      expect(serializers.res()).toBe(undefined)
     })
   })
 })


### PR DESCRIPTION
Adds some tests to the serializer methods for that sweet, sweet code coverage. Also for reliability and all that. Also adds `coverage/` to `.gitignore` so that no one commits that by mistake.