### PR TITLE
Improve GHE Docs

### DIFF
--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -34,5 +34,5 @@ If you want to run a Probot App against a GitHub Enterprise instance, you'll nee
 GHE_HOST=fake.github-enterprise.com
 ```
 
-> GitHub Apps are only enabled in Enterprise 2.12 and later!
+> GitHub Apps are enabled in GitHub Enterprise 2.12 as an [early access technical preview](https://developer.github.com/enterprise/2.12/apps/).
 


### PR DESCRIPTION
Link out to the official GHE API docs where it mentions that GitHub Apps are enabled via an early access preview. [See here](https://developer.github.com/enterprise/2.12/apps/) for that link.