### PR TITLE
Add option to disable express server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ out
 tmp
 package-lock.json
 coverage
+.idea
+yarn.lock

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,6 @@ const cacheManager = require('cache-manager')
 const createWebhook = require('github-webhook-handler')
 const createApp = require('./github-app')
 const createRobot = require('./robot')
-const createServer = require('./server')
 const createWebhookProxy = require('./webhook-proxy')
 const resolve = require('./resolver')
 const logger = require('./logger')
@@ -18,13 +17,18 @@ const defaultApps = [
   require('./plugins/default')
 ]
 
-module.exports = (options = {}) => {
+module.exports = (options = {server: true}) => {
   const webhook = createWebhook({path: options.webhookPath || '/', secret: options.secret || 'development'})
   const app = createApp({
     id: options.id,
     cert: options.cert
   })
-  const server = createServer({webhook, logger})
+  let server
+
+  if (options.server !== false) {
+    const createServer = require('./server')
+    server = createServer({webhook, logger})
+  }
 
   // Log all received webhooks
   webhook.on('*', event => {
@@ -48,8 +52,10 @@ module.exports = (options = {}) => {
 
     const robot = createRobot({app, cache, logger, catchErrors: true})
 
-    // Connect the router from the robot to the server
-    server.use(robot.router)
+    if (options.server !== false) {
+      // Connect the router from the robot to the server
+      server.use(robot.router)
+    }
 
     // Initialize the plugin
     plugin(robot)
@@ -79,8 +85,12 @@ module.exports = (options = {}) => {
         createWebhookProxy({url: options.webhookProxy, webhook, logger})
       }
 
-      server.listen(options.port)
-      logger.trace('Listening on http://localhost:' + options.port)
+      if (options.server !== false) {
+        server.listen(options.port)
+        logger.trace('Listening on http://localhost:' + options.port)
+      } else {
+        logger.trace(`The server has been disabled`)
+      }
     }
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -106,10 +106,28 @@ describe('Probot', () => {
       await request(probot.server).post('/')
         .expect(400)
     })
+
+    it('can be disabled with option server set to false', async () => {
+      probot = createProbot({server: false})
+
+      expect(probot.server).toBeUndefined()
+    })
   })
 
   describe('receive', () => {
     it('forwards events to each plugin', async () => {
+      const spy = jest.fn()
+      const robot = probot.load(robot => robot.on('push', spy))
+      robot.auth = jest.fn().mockReturnValue(Promise.resolve({}))
+
+      await probot.receive(event)
+
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('should work if option server is set to false', async () => {
+      probot = createProbot({server: false})
+
       const spy = jest.fn()
       const robot = probot.load(robot => robot.on('push', spy))
       robot.auth = jest.fn().mockReturnValue(Promise.resolve({}))


### PR DESCRIPTION
You don't need the express server on AWS lambda or Firebase functions, and you don't need it in tests (usually).

I added this option to improve the performance in these environments.

The new option is `options.server` and only works if the value is `false` (so that we don't break existing implementations. If you prefer another name for the option, let me know.