### PR TITLE
Remove semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "probot",
-  "version": "0.0.0-development",
+  "version": "4.0.0",
   "description": "a trainable robot that responds to activity on GitHub",
   "repository": "https://github.com/probot/probot",
   "main": "lib/index.js",
@@ -12,8 +12,7 @@
     "test": "jest --coverage && standard && npm run doc-lint",
     "doc-lint": "standard docs/**/*.md",
     "doc": "jsdoc -c .jsdoc.json",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post",
-    "postsemantic-release": "script/publish-docs"
+    "postpublish": "script/publish-docs"
   },
   "jest": {
     "setupFiles": [
@@ -52,7 +51,6 @@
     "jsdoc-strip-async-await": "^0.1.0",
     "minami": "^1.1.1",
     "nock": "^9.0.19",
-    "semantic-release": "^8.0.3",
     "standard": "^10.0.3",
     "supertest": "^3.0.0"
   },

--- a/test/plugins/__snapshots__/default.test.js.snap
+++ b/test/plugins/__snapshots__/default.test.js.snap
@@ -16,7 +16,7 @@ exports[`default plugin GET /probot get info from package.json returns the corre
       <div class=\\"box-shadow rounded-2 border p-6 bg-white\\">
         <h1>
           Welcome to probot
-            <span class=\\"Label Label--outline v-align-middle ml-2 text-gray-light\\">v0.0.0-development</span>
+            <span class=\\"Label Label--outline v-align-middle ml-2 text-gray-light\\">v4.0.0</span>
         </h1>
 
           <p>a trainable robot that responds to activity on GitHub</p>


### PR DESCRIPTION
We stopped using semantic release in #341. I tried using it locally to manually release 4.0, but couldn't figure out the incantation of environment variables to make it think it was running on Travis after a merge.

I personally don't plan on going back to it. Anyone opposed to just removing it for now?