### PR TITLE
Use smee-client instead of EventSource directly

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,10 @@ const defaultApps = [
 ]
 
 module.exports = (options = {}) => {
-  const webhook = createWebhook({path: options.webhookPath || '/', secret: options.secret || 'development'})
+  options.webhookPath = options.webhookPath || '/'
+  options.secret = options.secret || 'development'
+
+  const webhook = createWebhook({path: options.webhookPath, secret: options.secret})
   const app = createApp({
     id: options.id,
     cert: options.cert

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,12 @@ module.exports = (options = {}) => {
 
     start () {
       if (options.webhookProxy) {
-        createWebhookProxy({url: options.webhookProxy, webhook, logger})
+        createWebhookProxy({
+          url: options.webhookProxy,
+          port: options.port,
+          path: options.webhookPath,
+          logger
+        })
       }
 
       server.listen(options.port)

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -1,48 +1,13 @@
-const EventSource = require('eventsource')
+module.exports = ({url, port, path, logger}) => {
+  try {
+    const SmeeClient = require('smee-client')
 
-module.exports = ({url, logger, webhook}) => {
-  logger.trace({url}, 'Setting up webhook proxy')
-  const events = new EventSource(url)
-
-  events.addEventListener('message', (msg) => {
-    logger.trace(msg, 'Message from webhook proxy')
-
-    const data = JSON.parse(msg.data)
-    const sig = data['x-hub-signature']
-
-    if (sig && webhook.verify(sig, JSON.stringify(data.body))) {
-      const event = {
-        event: data['x-github-event'],
-        id: data['x-github-delivery'],
-        payload: data['body'],
-        protocol: data['x-forwarded-proto'],
-        host: data['host']
-      }
-
-      webhook.emit(event.event, event)
-      webhook.emit('*', event)
-    } else {
-      const err = new Error('X-Hub-Signature does not match blob signature')
-      webhook.emit('error', err, msg.data)
-    }
-  })
-
-  // Reconnect immediately
-  events.reconnectInterval = 0
-
-  events.addEventListener('error', err => {
-    if (!err.status) {
-      // Errors are randomly re-emitted for no reason
-      // See https://github.com/EventSource/eventsource/pull/85
-    } else if (err.status >= 400 && err.status < 500) {
-      // Nothing we can do about it
-      logger.error({url, err}, 'Webhook proxy error')
-    } else if (events.readyState === EventSource.CONNECTING) {
-      logger.trace({url, err}, 'Reconnecting to webhook proxy')
-    } else {
-      logger.error({url, err}, 'Webhook proxy error')
-    }
-  })
-
-  return events
+    const smee = new SmeeClient({
+      source: url,
+      target: `http://localhost:${port}${path}`
+    })
+    return smee.start()
+  } catch (err) {
+    logger.warn('Run `npm install --save-dev smee-client` to proxy webhooks to localhost.')
+  }
 }

--- a/lib/webhook-proxy.js
+++ b/lib/webhook-proxy.js
@@ -4,7 +4,8 @@ module.exports = ({url, port, path, logger}) => {
 
     const smee = new SmeeClient({
       source: url,
-      target: `http://localhost:${port}${path}`
+      target: `http://localhost:${port}${path}`,
+      logger
     })
     return smee.start()
   } catch (err) {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "minami": "^1.1.1",
     "nock": "^9.0.19",
     "semantic-release": "^8.0.3",
-    "smee-client": "^1.0.0",
+    "smee-client": "^1.0.1",
     "standard": "^10.0.3",
     "supertest": "^3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "minami": "^1.1.1",
     "nock": "^9.0.19",
     "semantic-release": "^8.0.3",
+    "smee-client": "^1.0.0",
     "standard": "^10.0.3",
     "supertest": "^3.0.0"
   },

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -1,11 +1,10 @@
 const express = require('express')
 const sse = require('connect-sse')()
 const nock = require('nock')
-const createWebhook = require('github-webhook-handler')
 const createWebhookProxy = require('../lib/webhook-proxy')
 const logger = require('../lib/logger')
 
-const webhook = createWebhook({path: '/', secret: 'test'})
+const targetPort = 999999
 
 describe('webhook-proxy', () => {
   let app, server, proxy, url, emit
@@ -26,56 +25,39 @@ describe('webhook-proxy', () => {
 
       server = app.listen(0, () => {
         url = `http://127.0.0.1:${server.address().port}/events`
-        proxy = createWebhookProxy({url, logger, webhook})
+        proxy = createWebhookProxy({url, port: targetPort, path: '/test', logger})
 
         // Wait for proxy to be ready
         proxy.addEventListener('ready', () => done())
       })
     })
 
-    afterEach(() => {
-    })
-
-    test('emits events with a valid signature', (done) => {
-      // This test will be done when the webhook is emitted
-      webhook.on('test', () => done())
+    test('forwards events to server', (done) => {
+      nock(`http://localhost:${targetPort}`).post('/test').reply(200, () => {
+        done()
+      })
 
       const body = {action: 'foo'}
 
       emit({
         'x-github-event': 'test',
-        'x-hub-signature': webhook.sign(JSON.stringify(body)),
         body
-      })
-    })
-
-    test('does not emit events with an invalid signature', (done) => {
-      // This test will be done when the webhook is emitted
-      webhook.on('error', (err) => {
-        expect(err.message).toEqual('X-Hub-Signature does not match blob signature')
-        done()
-      })
-
-      emit({
-        'x-github-event': 'test',
-        'x-hub-signature': 'lolnope',
-        body: {action: 'foo'}
       })
     })
   })
 
-  test('logs an error when the proxy server that is not found', (done) => {
+  test('logs an error when the proxy server is not found', (done) => {
     const url = 'http://bad.proxy/events'
     nock('http://bad.proxy').get('/events').reply(404)
 
     const log = logger.child()
     log.error = jest.fn()
 
-    proxy = createWebhookProxy({url, webhook, logger: log})
+    proxy = createWebhookProxy({url, logger: log})
 
     proxy.on('error', err => {
       expect(err.status).toBe(404)
-      expect(log.error).toHaveBeenCalledWith({err, url}, 'Webhook proxy error')
+      expect(log.error).toHaveBeenCalledWith(err)
       done()
     })
   })


### PR DESCRIPTION
cc https://github.com/probot/smee/pull/28

Since Smee will likely evolve as features are added, this switches to using the smee client class (which was extracted from this code) to proxy webhooks. The biggest difference is that SmeeClient will forward requests at the HTTP layer, so it posts the event to `localhost:3000` instead of manually calling `probot.receive`. This has the advantage of using the same code path in development and production.

- [x] Get tests passing