### PR TITLE
Add option to disable stats

### DIFF
--- a/lib/plugins/stats.js
+++ b/lib/plugins/stats.js
@@ -1,5 +1,8 @@
 // Built-in plugin to expose stats about the deployment
 module.exports = async robot => {
+  if (process.env.DISABLE_STATS) {
+    return
+  }
   const REFRESH_INTERVAL = 60 * 60 * 1000
 
   // Cache of stats that get reported

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -8,28 +8,50 @@ const helper = require('./helper')
 describe('stats', function () {
   let robot, server
 
-  beforeEach(async () => {
-    nock('https://api.github.com')
-     .defaultReplyHeaders({'Content-Type': 'application/json'})
-     .post('/installations/1/access_tokens').reply(200, {token: 'test'})
-     .get('/app/installations?per_page=100').reply(200, [{id: 1, account: {login: 'testing'}}])
-     .get('/installation/repositories').reply(200, {repositories: [
-       {private: true, stargazers_count: 1},
-       {private: false, stargazers_count: 2}
-     ]})
-
-    robot = helper.createRobot()
-
-    await plugin(robot)
-
-    server = express()
-    server.use(robot.router)
+  beforeEach(() => {
+    // Clean up env variable
+    delete process.env.DISABLE_STATS
   })
 
   describe('GET /probot/stats', () => {
+    beforeEach(async () => {
+      nock('https://api.github.com')
+       .defaultReplyHeaders({'Content-Type': 'application/json'})
+       .post('/installations/1/access_tokens').reply(200, {token: 'test'})
+       .get('/app/installations?per_page=100').reply(200, [{id: 1, account: {login: 'testing'}}])
+       .get('/installation/repositories').reply(200, {repositories: [
+         {private: true, stargazers_count: 1},
+         {private: false, stargazers_count: 2}
+       ]})
+
+      robot = helper.createRobot()
+
+      await plugin(robot)
+
+      server = express()
+      server.use(robot.router)
+    })
+
     it('returns installation count and popular accounts', () => {
       return request(server).get('/probot/stats')
         .expect(200, {'installations': 1, 'popular': [{login: 'testing', stars: 2}]})
+    })
+  })
+
+  describe('can be disabled', () => {
+    beforeEach(async () => {
+      process.env.DISABLE_STATS = 'true'
+
+      robot = helper.createRobot()
+
+      await plugin(robot)
+
+      server = express()
+      server.use(robot.router)
+    })
+
+    it('/probot/stats returns 404', () => {
+      return request(server).get('/probot/stats').expect(404)
     })
   })
 })


### PR DESCRIPTION
As discussed in office hours yesterday, the stats plugin isn't very scalable after a certain point.

You can now set the environment variable `DISABLE_STATS`, and the stats plugin won't load

cc @JasonEtco @bkeepers 