### PR TITLE
Expose methods for creating internal modules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,6 @@ module.exports = (options = {}) => {
     id: options.id,
     cert: options.cert
   })
-  const server = createServer({webhook, logger})
 
   // Log all received webhooks
   webhook.on('*', event => {
@@ -40,6 +39,9 @@ module.exports = (options = {}) => {
 
   // Log all webhook errors
   webhook.on('error', logger.error.bind(logger))
+
+  const server = createServer({logger})
+  server.use(webhook)
 
   const robots = []
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,11 +1,11 @@
 const cacheManager = require('cache-manager')
 const createWebhook = require('github-webhook-handler')
 const createApp = require('./github-app')
+const createLogger = require('./logger')
 const createRobot = require('./robot')
 const createServer = require('./server')
 const createWebhookProxy = require('./webhook-proxy')
 const resolve = require('./resolver')
-const logger = require('./logger')
 const logRequestErrors = require('./middleware/log-request-errors')
 
 const cache = cacheManager.caching({
@@ -22,6 +22,8 @@ const defaultApps = [
 module.exports = (options = {}) => {
   options.webhookPath = options.webhookPath || '/'
   options.secret = options.secret || 'development'
+
+  const logger = createLogger()
 
   const webhook = createWebhook({path: options.webhookPath, secret: options.secret})
   const app = createApp({
@@ -97,4 +99,11 @@ module.exports = (options = {}) => {
   }
 }
 
-module.exports.createRobot = createRobot
+Object.assign(module.exports, {
+  createApp,
+  createLogger,
+  createRobot,
+  createServer,
+  createWebhook,
+  createWebhookProxy
+})

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -47,16 +47,16 @@ Logger.prototype.wrap = function () {
   fn.child = (attrs) => this.child(attrs, true).wrap()
 
   // Expose target logger
-  fn.target = logger
+  fn.target = this
 
   return fn
 }
 
-const logger = new Logger({
-  name: 'probot',
-  level: process.env.LOG_LEVEL || 'info',
-  stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
-  serializers
-})
-
-module.exports = logger
+module.exports = () => {
+  return new Logger({
+    name: 'probot',
+    level: process.env.LOG_LEVEL || 'info',
+    stream: bunyanFormat({outputMode: process.env.LOG_FORMAT || 'short'}),
+    serializers
+  })
+}

--- a/lib/robot.js
+++ b/lib/robot.js
@@ -1,7 +1,7 @@
 const {EventEmitter} = require('promise-events')
 const express = require('express')
 const Context = require('./context')
-const logger = require('./logger')
+const createLogger = require('./logger')
 const GitHubApi = require('./github')
 
 /**
@@ -10,12 +10,12 @@ const GitHubApi = require('./github')
  * @property {logger} log - A logger
  */
 class Robot {
-  constructor ({app, cache, router, catchErrors} = {}) {
+  constructor ({app, cache, router, catchErrors, logger} = {}) {
     this.events = new EventEmitter()
     this.app = app
     this.cache = cache
     this.router = router || new express.Router()
-    this.log = logger.wrap()
+    this.log = (logger || createLogger()).wrap()
     this.catchErrors = catchErrors
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,12 +6,11 @@ require('express-async-errors')
 
 const logging = require('./middleware/logging')
 
-module.exports = function ({webhook, logger}) {
+module.exports = function ({logger}) {
   const app = express()
 
   app.use(logging({logger}))
   app.use('/probot/static/', express.static(path.join(__dirname, '..', 'static')))
-  app.use(webhook)
   app.set('view engine', 'hbs')
   app.set('views', path.join(__dirname, '..', 'views'))
   app.get('/ping', (req, res) => res.end('PONG'))

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-const createProbot = require('..')
+const createProbot = require('probot')
 const request = require('supertest')
 const nock = require('nock')
 const helper = require('./plugins/helper')

--- a/test/middleware/logging.test.js
+++ b/test/middleware/logging.test.js
@@ -1,7 +1,10 @@
 const request = require('supertest')
 const express = require('express')
-const logger = require('../../lib/logger')
+const { createLogger } = require('probot')
+
 const logging = require('../../lib/middleware/logging')
+
+const logger = createLogger()
 
 describe('logging', () => {
   let server, output

--- a/test/plugins/helper.js
+++ b/test/plugins/helper.js
@@ -1,7 +1,7 @@
 // FIXME: move this to a test helper that can be used by other apps
 
 const cacheManager = require('cache-manager')
-const {createRobot} = require('../..')
+const { createRobot } = require('probot')
 
 const cache = cacheManager.caching({store: 'memory'})
 

--- a/test/robot.test.js
+++ b/test/robot.test.js
@@ -1,6 +1,7 @@
 const Context = require('../lib/context')
-const createRobot = require('../lib/robot')
-const logger = require('../lib/logger')
+const { createRobot, createLogger } = require('probot')
+
+const logger = createLogger()
 
 describe('Robot', function () {
   let robot
@@ -21,7 +22,7 @@ describe('Robot', function () {
     // Clear log output
     output = []
 
-    robot = createRobot()
+    robot = createRobot({logger})
     robot.auth = () => {}
 
     event = {

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -5,11 +5,9 @@ const logger = createLogger()
 
 describe('server', function () {
   let server
-  let webhook
 
   beforeEach(() => {
-    webhook = jest.fn((req, res, next) => next())
-    server = createServer({webhook, logger})
+    server = createServer({logger})
 
     // Error handler to avoid printing logs
     server.use(function (err, req, res, next) {
@@ -20,13 +18,6 @@ describe('server', function () {
   describe('GET /ping', () => {
     it('returns a 200 response', () => {
       return request(server).get('/ping').expect(200, 'PONG')
-    })
-  })
-
-  describe('webhook handler', () => {
-    it('should 500 on a webhook error', () => {
-      webhook.mockImplementation((req, res, callback) => callback(new Error('webhook error')))
-      return request(server).post('/').expect(500)
     })
   })
 

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,6 +1,7 @@
 const request = require('supertest')
-const createServer = require('../lib/server')
-const logger = require('../lib/logger')
+const { createServer, createLogger } = require('probot')
+
+const logger = createLogger()
 
 describe('server', function () {
   let server

--- a/test/webhook-proxy.test.js
+++ b/test/webhook-proxy.test.js
@@ -1,9 +1,9 @@
 const express = require('express')
 const sse = require('connect-sse')()
 const nock = require('nock')
-const createWebhookProxy = require('../lib/webhook-proxy')
-const logger = require('../lib/logger')
+const { createWebhookProxy, createLogger } = require('probot')
 
+const logger = createLogger()
 const targetPort = 999999
 
 describe('webhook-proxy', () => {


### PR DESCRIPTION
I often find (especially in tests) that I want to be able to set up an app using probot's internal modules without initializing all of probot.

This PR exposes a bunch of the internal modules that can be access with `require('probot')`:

```js
{
  createApp,
  createLogger,
  createRobot,
  createServer,
  createWebhook,
  createWebhookProxy
} = require('probot')
```