### PR TITLE
Add "next" front matter to Persistence docs

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,5 @@
 ---
-next: docs/best-practices.md
+next: docs/persistence.md
 ---
 
 # Deployment

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -1,3 +1,7 @@
+---
+next: docs/best-practices.md
+---
+
 # Persistence
 
 Generally speaking, adding database storage or persistence to your Probot App will greatly complicate your life. It's perfectly doable, but for most use-cases you'll be able to manage relevant data within GitHub issues, pull requests and your app's configuration file.


### PR DESCRIPTION
Adds the require front matter to the new persistence docs. I've placed it after Deployment but before Best Practices. Let me know if you think it should go somewhere else!