### PR TITLE
Payload object explanation in documentation

### DIFF
--- a/docs/simulating-webhooks.md
+++ b/docs/simulating-webhooks.md
@@ -16,7 +16,9 @@ Next, simulate this event being delivered by running:
 
     $ node_modules/.bin/probot simulate <event-name> <path-to-fixture> <path-to-app>
 
-Note that `event-name` here is just the name of the event (like pull_request or issues) and not the action (like labeled). For example, to simulate the pull_request.labeled event, run:
+Note that `event-name` here is just the name of the event (like pull_request or issues) and not the action (like labeled). You can find it in the GitHub deliveries history under the `X-GitHub-Event` header. 
+
+For example, to simulate the pull_request.labeled event, run:
 
     $ node_modules/.bin/probot simulate pull_request test/fixtures/pull_request.labeled.json ./index.js
     

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,8 @@ describe('your-app', () => {
   describe('your functionality', () => {
     it('performs an action', async () => {
       // Simulates delivery of a payload
+      // payload.event is the X-GitHub-Event header sent by GitHub (for example "push")
+      // payload.payload is the actual payload body
       await robot.receive(payload)
       // This test would pass if in your main code you called `context.github.issues.createComment`
       expect(github.issues.createComment).toHaveBeenCalled()


### PR DESCRIPTION
Here is a little explanation about the `payload` object passed to `robot.receive` to simulate a webhook, that would have avoided me some trouble while writing unit tests in #407 😄 

Maybe some other changes can be relevant to make the docs clearer