### PR TITLE
Add `.env.example` template info

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,8 @@ The most important files note here are `index.js`, which is where the code for y
 
 To run your app in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
 
-1. Go to [smee.io](https://smee.io) and click **Start a new channel**. On your local machine, copy `.env.example` to `.env`, then set `WEBHOOK_PROXY_URL` to the URL that you are redirected to.
+1. On your local machine, copy `.env.example` to `.env`.
+1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` in `.env` to the URL that you are redirected to.
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
     - **Webhook Secret:** `development`

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,7 @@ The most important files note here are `index.js`, which is where the code for y
 
 To run your app in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
 
-1. Go to [smee.io](https://smee.io) and click **Start a new channel**. On your local, copy `.env.example` to `.env`, then set `WEBHOOK_PROXY_URL` to the URL that you are redirected to.
+1. Go to [smee.io](https://smee.io) and click **Start a new channel**. On your local machine, copy `.env.example` to `.env`, then set `WEBHOOK_PROXY_URL` to the URL that you are redirected to.
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
     - **Webhook Secret:** `development`

--- a/docs/development.md
+++ b/docs/development.md
@@ -56,7 +56,7 @@ The most important files note here are `index.js`, which is where the code for y
 
 To run your app in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
 
-1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` in your `.env` to the URL that you are redirected to (you can use `.env.example` as a template).
+1. Go to [smee.io](https://smee.io) and click **Start a new channel**. On your local, copy `.env.example` to `.env`, then set `WEBHOOK_PROXY_URL` to the URL that you are redirected to.
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
     - **Webhook Secret:** `development`


### PR DESCRIPTION
This pull request adds a note about the `.env.example` file that can be used as a template when following [Configure a GitHub App](https://probot.github.io/docs/development/#configure-a-github-app) to set the `WEBHOOK_PROXY_URL`.

Original issue: https://github.com/probot/friction/issues/20