### PR TITLE
GitHub fixes

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -29,7 +29,7 @@ async function paginate (octokit, responsePromise, callback = defaultCallback) {
 
 function EnhancedGitHubClient (options) {
   const octokit = Octokit(options)
-  const limiter = new Bottleneck({ maxConcurrent: 1, minTime: 1000 })
+  const limiter = options.limiter || new Bottleneck({ maxConcurrent: 1, minTime: 1000 })
   const logger = options.logger
   const noop = () => Promise.resolve()
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -38,6 +38,7 @@ function EnhancedGitHubClient (options) {
     const {method, url, headers, ...params} = options
     const msg = `GitHub request: ${method} ${url} - ${error.code} ${error.status}`
     logger.debug({params}, msg)
+    throw error
   })
   octokit.hook.after('request', (result, options) => {
     const {method, url, headers, ...params} = options

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -11,10 +11,10 @@ describe('EnhancedGitHubClient', () => {
       trace: jest.fn()
     }
 
-    github = new EnhancedGitHubClient({ logger })
-
     // Set a shorter limiter, otherwise tests are _slow_
-    github.limiter = new Bottleneck({ maxConcurrent: 1, minTime: 1 })
+    const limiter = new Bottleneck({ maxConcurrent: 1, minTime: 1 })
+
+    github = new EnhancedGitHubClient({ logger, limiter })
   })
 
   describe('paginate', () => {

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -63,4 +63,9 @@ describe('EnhancedGitHubClient', () => {
       expect(spy).toHaveBeenCalledTimes(3)
     })
   })
+
+  test('properly returns 404 responses', () => {
+    nock('https://api.github.com').get('/user').reply(404, {message: 'nope'})
+    return expect(github.users.get({})).rejects.toThrow('nope')
+  })
 })


### PR DESCRIPTION
Errors and 4xx responses from GitHub are currently being obscured since #400 by this error:

```
    TypeError: Cannot read property 'meta' of undefined
        42 |   octokit.hook.after('request', (result, options) => {
        43 |     const {method, url, headers, ...params} = options
      > 44 |     const msg = `GitHub request: ${method} ${url} - ${result.meta.status}`
        45 |     logger.debug({params}, msg)
        46 |   })
        47 |   octokit.paginate = paginate.bind(null, octokit)

        at EnhancedGitHubClient.octokit.hook.after (lib/github.js:44:62)
        at invokeAfterHook (node_modules/before-after-hook/lib/register.js:96:12)
            at Array.map (<anonymous>)
        at node_modules/before-after-hook/lib/register.js:60:35
```

c69f2df updates the `error` hook to re-throw errors after logging them.

There's also a small tweak here to allow a customer limiter to be passed in at load time to prevent the tests from running very slowly.