### PR TITLE
Lock to express-async-errors 2.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "commander": "^2.11.0",
     "dotenv": "~4.0.0",
     "express": "^4.16.2",
-    "express-async-errors": "^2.1.0",
+    "express-async-errors": "2.1.1",
     "github": "^12.0.3",
     "github-webhook-handler": "^0.7.0",
     "hbs": "^4.0.1",


### PR DESCRIPTION
https://github.com/davidbanham/express-async-errors/pull/4 is the cause
for https://github.com/gr2m/wip-bot/issues/42

Locking to 2.1.1 and will push out 5.0.1 release while we investigate of it's something probot is doing wrong, or if the PR to express-async-errors needs to be fixed.