### PR TITLE
Lock to express-async-errors on master

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commander": "^2.11.0",
     "dotenv": "~5.0.0",
     "express": "^4.16.2",
-    "express-async-errors": "^2.1.0",
+    "express-async-errors": "2.1.1",
     "github-webhook-handler": "^0.7.0",
     "hbs": "^4.0.1",
     "js-yaml": "^3.9.1",


### PR DESCRIPTION
This copies the #432, which was a hotfix for v5, over to master. We need to find a better solution to https://github.com/probot/probot/issues/433 long-term, but this will do for now.