### PR TITLE
Add Summer of Code section to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,7 @@ Want to chat with Probot users and contributors? [Join us in Slack](https://prob
 ## Ideas
 
 Have an idea for a cool new GitHub App (built with Probot)? That's great! If you want feedback, help, or just to share it with the world you can do so by [creating an issue in the `probot/ideas` repository](https://github.com/probot/ideas/issues/new)!
+
+## Summer of Code
+
+Probot is super excited to be participating in RailsGirls Summer of Code & Google Summer of Code! We've written [some documentation on how to get started](https://probot.github.io/docs/summmer-of-code) if you're part of one of these programs.

--- a/README.md
+++ b/README.md
@@ -30,4 +30,4 @@ Have an idea for a cool new GitHub App (built with Probot)? That's great! If you
 
 ## Summer of Code
 
-Probot is super excited to be participating in RailsGirls Summer of Code & Google Summer of Code! We've written [some documentation on how to get started](https://probot.github.io/docs/summmer-of-code) if you're part of one of these programs.
+Probot is super excited to be participating in Rails Girls Summer of Code & Google Summer of Code! We've written [some documentation on how to get started](https://probot.github.io/docs/summmer-of-code) if you're part of one of these programs.

--- a/docs/summer-of-code.md
+++ b/docs/summer-of-code.md
@@ -37,7 +37,7 @@ Amazing! Be sure to include it in your application.
         <br>
         <a href="https://github.com/gr2m">Gregor Martynus</a>
       </td>
-      <td align="center" width="20%" valign="top">
+      <td align="center" valign="top">
         <img width="150" height="150" src="https://github.com/JasonEtco.png?s=150">
         <br>
         <a href="https://github.com/JasonEtco">Jason Etcovitch</a>


### PR DESCRIPTION
Adds a section for Summer of Code, linking to [our doc on our website](https://probot.github.io/docs/summer-of-code). I also fixed a weird bug where my cell on the website was squished - not sure how that got in there 🤷‍♂️ 

Closes #446 