### PR TITLE
Move details on development dependencies to development docs

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -6,6 +6,11 @@ next: docs/webhooks.md
 
 To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Probot uses the `async/await` keywords, so Node.js 7.6 is the minimum required version.
 
+To install Node.js (Mac OS X)
+
+ * Install [homebrew](https://brew.sh/)
+ * `brew install node`
+
 ## Generating a new app
 
 [create-probot-app](https://github.com/probot/create-probot-app) is the best way to start building a new app. It will generate a new app with everything you need to get started and run your app in production.

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -6,15 +6,6 @@ next: docs/development.md
 
 A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 
-To install Node.js (Mac OS X)
- * Install [homebrew](https://brew.sh/)
- * `brew install node`
-
-After installing Node:
- * `npm install probot`
-
-Integrate Probot into your awesome Node application:
-
 ```js
 module.exports = robot => {
   // your code here
@@ -36,8 +27,6 @@ module.exports = robot => {
 
 The `context` passed to the event handler includes everything about the event that was triggered, as well as some helpful properties for doing something useful in response to the event. `context.github` is an authenticated GitHub client that can be used to [make API calls](./github-api.md), and allows you to do almost anything programmatically that you can do through a web browser on GitHub.
 
-Unsure how to implement this into your application? Take a look at [`create-probot-app`](https://github.com/probot/create-probot-app), a sample application that you can use to get started right away!
-
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
@@ -53,7 +42,9 @@ module.exports = robot => {
   })
 }
 ```
-To get started, you can use the instructions for [Developing an App](https://probot.github.io/docs/development/) or remix this 'Hello World' project on Glitch.
+
+To get started, you can use the instructions for [Developing an App](https://probot.github.io/docs/development/) or remix this 'Hello World' project on Glitch:
+
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/probot-hello-world)
 
 Don't know what to build? Browse the [list of ideas](https://github.com/probot/ideas/issues) from the community for inspiration.


### PR DESCRIPTION
I've noticed lately there seems to be a lot of people that missed some pretty fundamental details about probot (receives webhooks, `context.github`, `context.issue`). I think one reason is because the conceptual hello world example starts of by explaining nitty gritty details of installing Node on a mac. 

This PR moves any discussion of dependencies to the development page.