### PR TITLE
Updated Node.js minimum  version required

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ next: docs/webhooks.md
 
 # Developing an App
 
-To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Probot uses the `async/await` keywords, so Node.js 7.6 is the minimum required version.
+To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Probot uses object rest/spread properties, so Node.js 8.3.0 is the minimum required version.
 
 ## Generating a new app
 


### PR DESCRIPTION
Updated Node.js Minimum version required from 7.6 to 8.3.0.
The is because Probot now uses object rest/spread properties, e.g., the rest spread operator: `{ foo, bar, ..., rest } = myObject`
This is available in version 8.3.0 (ES2018). See: [NodeJS ES2018 object rest/spread properties](http://node.green/#ES2018-features-object-rest-spread-properties)