### PR TITLE
Replaced myapp.yml with config.yml

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -24,8 +24,8 @@ class Context {
    *
    * @example
    *
-   * const params = context.repo({path: '.github/stale.yml'})
-   * // Returns: {owner: 'username', repo: 'reponame', path: '.github/stale.yml'}
+   * const params = context.repo({path: '.github/config.yml'})
+   * // Returns: {owner: 'username', repo: 'reponame', path: '.github/config.yml'}
    *
    */
   repo (object) {
@@ -68,15 +68,15 @@ class Context {
    * Reads the app configuration from the given YAML file in the `.github`
    * directory of the repository.
    *
-   * @example <caption>Contents of <code>.github/myapp.yml</code>.</caption>
+   * @example <caption>Contents of <code>.github/config.yml</code>.</caption>
    *
    * close: true
    * comment: Check the specs on the rotary girder.
    *
-   * @example <caption>App that reads from <code>.github/myapp.yml</code>.</caption>
+   * @example <caption>App that reads from <code>.github/config.yml</code>.</caption>
    *
-   * // Load config from .github/myapp.yml in the repository
-   * const config = await context.config('myapp.yml')
+   * // Load config from .github/config.yml in the repository
+   * const config = await context.config('config.yml')
    *
    * if (config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}))
@@ -85,8 +85,8 @@ class Context {
    *
    * @example <caption>Using a <code>defaultConfig</code> object.</caption>
    *
-   * // Load config from .github/myapp.yml in the repository and combine with default config
-   * const config = await context.config('myapp.yml', {comment: 'Make sure to check all the specs.'})
+   * // Load config from .github/config.yml in the repository and combine with default config
+   * const config = await context.config('config.yml', {comment: 'Make sure to check all the specs.'})
    *
    * if (config.close) {
    *   context.github.issues.comment(context.issue({body: config.comment}));


### PR DESCRIPTION
Replaced `myapp.yml` and `stale.yml` with `config.yml` as it is a recommended naming-convention applied in many Probot applications.