### PR TITLE
Add GraphQL support

### DIFF
--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -34,8 +34,7 @@ See the [full API docs](https://octokit.github.io/rest.js/) to see all the ways 
 
 > **Heads Up!** GraphQL support in Probot is currently a preview feature and this interface could change in a future releases without notice. [Let us know]() if you have any feedback or ideas to improve GraphQL support.
 
-The [GitHub GraphQL API](https://developer.github.com/v4/) is an alternative
-
+Use `context.github.query` to make requests to the [GitHub GraphQL API](https://developer.github.com/v4/).
 
 Here is an example of the same autoresponder app from above that comments on opened issues, but this time with GraphQL:
 

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -6,7 +6,11 @@ next: docs/http.md
 
 Probot uses [GitHub Apps](https://developer.github.com/apps/). An app is a first-class actor on GitHub, like a user (e.g. [@defunkt](https://github.com/defunkt)) or an organization (e.g. [@github](https://github.com/github)). The app is given access to a repository or repositories by being "installed" on a user or organization account and can perform actions through the API like [commenting on an issue](https://developer.github.com/v3/issues/comments/#create-a-comment) or [creating a status](https://developer.github.com/v3/repos/statuses/#create-a-status).
 
-`context.github` is an authenticated GitHub client that can be used to make API calls. It is an instance of the [`@octokit/rest` Node.js module](https://github.com/octokit/rest.js), which wraps the [GitHub REST API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
+Your app has access to an authenticated GitHub client that can be used to make API calls. It supports both the [GitHub REST API](https://developer.github.com/v3/), and the [GitHub GraphQL API](https://developer.github.com/v4/).
+
+## REST API
+
+`context.github` is an instance of the [`@octokit/rest` Node.js module](https://github.com/octokit/rest.js), which wraps the [GitHub REST API](https://developer.github.com/v3/) and allows you to do almost anything programmatically that you can do through a web browser.
 
 Here is an example of an autoresponder app that comments on opened issues:
 
@@ -25,6 +29,54 @@ module.exports = robot => {
 ```
 
 See the [full API docs](https://octokit.github.io/rest.js/) to see all the ways you can interact with GitHub. Some API endpoints are not available on GitHub Apps yet, so check [which ones are available](https://developer.github.com/v3/apps/available-endpoints/) first.
+
+## GraphQL API
+
+> **Heads Up!** GraphQL support in Probot is currently a preview feature and this interface could change in a future releases without notice. [Let us know]() if you have any feedback or ideas to improve GraphQL support.
+
+The [GitHub GraphQL API](https://developer.github.com/v4/) is an alternative
+
+
+Here is an example of the same autoresponder app from above that comments on opened issues, but this time with GraphQL:
+
+```js
+// GraphQL query to get Node id for any resource, which is needed for mutations
+const getResource = `
+  query getResource($url: URI!) {
+    resource(url: $url) {
+      ... on Node {
+        id
+      }
+    }
+  }
+`
+
+// GraphQL query to add a comment
+const addComment = `
+  mutation comment($id: ID!, $body: String!) {
+    addComment(input: {subjectId: $id, body: $body}) {
+      clientMutationId
+    }
+  }
+`
+
+module.exports = robot => {
+  robot.on('issues.opened', async context => {
+    // Get the node id of the issue
+    const { resource } = await context.github.query(getResource, {
+      url: context.payload.issue.html_url
+    })
+
+    // Post a comment on the issue
+    await context.github.query(addComment, {
+      id: resource.id,
+      body: 'Hello World'
+    })
+  })
+}
+```
+
+Check out the [GitHub GraphQL API docs](https://developer.github.com/v4/) to learn more.
 
 ## GitHub Enterprise
 

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -32,7 +32,7 @@ See the [full API docs](https://octokit.github.io/rest.js/) to see all the ways 
 
 ## GraphQL API
 
-> **Heads Up!** GraphQL support in Probot is currently a preview feature and this interface could change in a future releases without notice. [Let us know]() if you have any feedback or ideas to improve GraphQL support.
+> **Heads Up!** GraphQL support in Probot is currently a preview feature and this interface could change in a future releases without notice. [Let us know](https://github.com/probot/probot/issues/476) if you have any feedback or ideas to improve GraphQL support.
 
 Use `context.github.query` to make requests to the [GitHub GraphQL API](https://developer.github.com/v4/).
 

--- a/lib/github/graphql.js
+++ b/lib/github/graphql.js
@@ -1,0 +1,37 @@
+module.exports = addGraphQL
+
+function addGraphQL (octokit) {
+  octokit.query = query.bind(null, octokit)
+}
+
+async function query (octokit, query, variables = undefined) {
+  const res = await octokit.request({
+    method: 'POST',
+    url: '/graphql',
+    headers: {
+      'content-type': 'application/json',
+      'accept': 'application/json'
+    },
+    query,
+    variables
+  })
+
+  if (res.data.errors) {
+    throw new GraphQLError(res.data.errors, query, variables)
+  }
+
+  return res.data.data
+}
+
+class GraphQLError extends Error {
+  constructor (errors, query, variables) {
+    super(JSON.stringify(errors))
+    this.name = 'GraphQLError'
+    this.query = query
+    this.variables = variables
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, GraphQLError)
+    }
+  }
+}

--- a/lib/github/graphql.js
+++ b/lib/github/graphql.js
@@ -4,13 +4,14 @@ function addGraphQL (octokit) {
   octokit.query = query.bind(null, octokit)
 }
 
-async function query (octokit, query, variables = undefined) {
+async function query (octokit, query, variables = undefined, headers = {}) {
   const res = await octokit.request({
     method: 'POST',
     url: '/graphql',
     headers: {
       'content-type': 'application/json',
-      'accept': 'application/json'
+      'accept': 'application/json',
+      ...headers
     },
     query,
     variables

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -19,7 +19,7 @@ function EnhancedGitHubClient (options) {
   addRateLimiting(octokit, options.limiter)
   addLogging(octokit, options.logger)
   addPagination(octokit)
-  addGraphQL(octokit, options.baseUrl)
+  addGraphQL(octokit)
 
   return octokit
 }

--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -3,6 +3,7 @@ const Octokit = require('@octokit/rest')
 const addPagination = require('./pagination')
 const addRateLimiting = require('./rate-limiting')
 const addLogging = require('./logging')
+const addGraphQL = require('./graphql')
 
 /**
  * the [@octokit/rest Node.js module](https://github.com/octokit/rest.js),
@@ -18,6 +19,7 @@ function EnhancedGitHubClient (options) {
   addRateLimiting(octokit, options.limiter)
   addLogging(octokit, options.logger)
   addPagination(octokit)
+  addGraphQL(octokit, options.baseUrl)
 
   return octokit
 }

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -1,0 +1,70 @@
+const GitHub = require('../../lib/github')
+const nock = require('nock')
+const Bottleneck = require('bottleneck')
+
+describe('github/graphql', () => {
+  let github
+
+  // Expect there are no more pending nock requests
+  beforeEach(async () => nock.cleanAll())
+  afterEach(() => expect(nock.pendingMocks()).toEqual([]))
+
+  beforeEach(() => {
+    const logger = {
+      debug: jest.fn(),
+      trace: jest.fn()
+    }
+
+    // Set a shorter limiter, otherwise tests are _slow_
+    const limiter = new Bottleneck({ maxConcurrent: 1, minTime: 1 })
+
+    github = new GitHub({ logger, limiter })
+  })
+
+  describe('query', () => {
+    let query
+    let data
+
+    test('makes a graphql query', async () => {
+      query = 'query { viewer { login } }'
+      data = { viewer: { login: 'bkeepers' } }
+
+      nock('https://api.github.com', {
+        reqheaders: { 'content-type': 'application/json' }
+      }).post('/graphql', {query})
+        .reply(200, { data })
+
+      expect(await github.query(query)).toEqual(data)
+    })
+
+    test('makes a graphql query with variables', async () => {
+      const variables = {owner: 'probot', repo: 'test'}
+
+      nock('https://api.github.com', {
+        reqheaders: { 'content-type': 'application/json' }
+      }).post('/graphql', {query, variables})
+        .reply(200, { data })
+
+      expect(await github.query(query, variables)).toEqual(data)
+    })
+    test('uses authentication', async () => {
+      github.authenticate({type: 'token', token: 'testing'})
+
+      nock('https://api.github.com', {
+        reqheaders: { authorization: 'token testing' }
+      }).post('/graphql', {query})
+        .reply(200, { data })
+
+      await github.query(query)
+    })
+
+    test('raises errors', async () => {
+      const response = {'data': null, 'errors': [{'message': 'Unexpected end of document'}]}
+
+      nock('https://api.github.com').post('/graphql', {query})
+        .reply(200, response)
+
+      await expect(github.query(query)).rejects.toThrow('Unexpected end of document')
+    })
+  })
+})

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -59,6 +59,15 @@ describe('github/graphql', () => {
       await github.query(query)
     })
 
+    test('allows custom headers', async () => {
+      nock('https://api.github.com', {
+        reqheaders: { 'foo': 'bar' }
+      }).post('/graphql', {query})
+        .reply(200, { data })
+
+      await github.query(query, undefined, {foo: 'bar'})
+    })
+
     test('raises errors', async () => {
       const response = {'data': null, 'errors': [{'message': 'Unexpected end of document'}]}
 

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -47,6 +47,7 @@ describe('github/graphql', () => {
 
       expect(await github.query(query, variables)).toEqual(data)
     })
+
     test('uses authentication', async () => {
       github.authenticate({type: 'token', token: 'testing'})
 

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -22,11 +22,10 @@ describe('github/graphql', () => {
   })
 
   describe('query', () => {
-    let query
+    const query = 'query { viewer { login } }'
     let data
 
     test('makes a graphql query', async () => {
-      query = 'query { viewer { login } }'
       data = { viewer: { login: 'bkeepers' } }
 
       nock('https://api.github.com', {


### PR DESCRIPTION
After playing around with #467 and looking at the source for `graphql-request`, I decided it'd be a lot easier and cleaner to just use `octokit.request` to make the GraphQL request. This branch adds `context.github.query` for making GraphQL requests.

I just ran this app to test it out, which uses GraphQL to fetch the body of an issue:

```js
module.exports = robot => {
  robot.on('issue_comment.created', async context => {
    const query = `
      query repoId($owner: String!, $repo: String!, $number: Int!) {
        repository(owner: $owner, name: $repo) {
          issue(number: $number) { bodyHTML }
        }
      }
    `

    const data = await context.github.query(query, context.issue())

    context.log(data.repository.issue.bodyHTML, 'Issue body')
  })
}
```

FYI @koddsson