### PR TITLE
[WIP] Add internal serverless method to support lambda and gcf

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -98,3 +98,4 @@ module.exports = (options = {}) => {
 }
 
 module.exports.createRobot = createRobot
+module.exports.serverless = require('./serverless')

--- a/lib/serverless.js
+++ b/lib/serverless.js
@@ -1,0 +1,103 @@
+require('dotenv').config()
+const {findPrivateKey} = require('./private-key')
+const createProbot = require('./');
+const resolve = require('./resolver')
+
+const loadProbot = (plugin) => {
+  const probot = createProbot({
+    id: process.env.APP_ID,
+    secret: process.env.WEBHOOK_SECRET,
+    cert: findPrivateKey()
+  })
+
+  if (typeof plugin === 'string') {
+    plugin = resolve(plugin)
+  }
+
+  probot.load(plugin)
+
+  return probot
+}
+
+module.exports = (plugin, provider) => {
+
+  const lambdaInstance = (event, context, callback) => {
+    const probot = loadProbot(plugin)
+
+    // Ends function immediately after callback
+    context.callbackWaitsForEmptyEventLoop = false
+
+    // Determine incoming webhook event type
+    // Checking for different cases in case the http server is lowercasing everything
+    const e = event.headers['x-github-event'] || event.headers['X-GitHub-Event']
+    const id = event.headers['x-github-delivery'] || event.headers['X-GitHub-Delivery']
+
+    // Convert the payload to an Object if API Gateway stringifies it
+    event.body = (typeof event.body === 'string') ? JSON.parse(event.body) : event.body
+
+    // Do the thing
+    console.log(`Received event ${e}${event.body.action ? ('.' + event.body.action) : ''}`)
+    if (event) {
+      try {
+        probot.receive({
+          event: e,
+          payload: event.body
+        }).then(() => {
+          const res = {
+            statusCode: 200,
+            body: JSON.stringify({
+              message: 'Executed on Lambda'
+            })
+          }
+          return callback(null, res)
+        })
+      } catch (err) {
+        console.error(err)
+        callback(err)
+      }
+    } else {
+      console.error({ event, context })
+      callback('unknown error')
+    }
+  }
+
+  const gcfInstance = (request, response) => {
+    const probot = loadProbot(plugin)
+
+    const event = request.get('x-github-event') || request.get('X-GitHub-Event')
+    const id = request.get('x-github-delivery') || request.get('X-GitHub-Delivery')
+    console.log(`Received event ${event}${request.body.action ? ('.' + request.body.action) : ''}`)
+    if (event) {
+      try {
+        probot.receive({
+          event: event,
+          id: id,
+          payload: request.body
+        }).then(() => {
+          response.send({
+            statusCode: 200,
+            body: JSON.stringify({
+              message: 'Executed'
+            })
+          })
+        })
+      } catch (err) {
+        console.error(err)
+        response.sendStatus(500)
+      }
+    } else {
+      console.error(request)
+      response.sendStatus(400)
+    }
+  }
+
+  switch (provider) {
+    case 'aws':
+      return lambdaInstance
+    case 'gcf':
+      return gcfInstance
+    default:
+      throw new Error('Please specify a serverless provider (Options: \'aws\' | \'gcf\')')
+  }
+
+}

--- a/test/serverless.test.js
+++ b/test/serverless.test.js
@@ -4,8 +4,6 @@ const plugin = require('./fixtures/plugin/stub-plugin')
 
 describe('Serverless', function () {
   let probot
-  let provider
-  let lambdaInstance
 
   beforeEach(function () {
     probot = createProbot()
@@ -14,12 +12,12 @@ describe('Serverless', function () {
   describe('providers', function () {
     it('Responds with Lambda function signature when \'aws\' is specified', function () {
       lambdaInstance = (event, context, callback) => {}
-      expect(serverless(plugin, 'aws')).toBeInstanceOf(lambdaInstance)
+      expect(serverless(plugin, 'aws')).toEqual(lambdaInstance)
     })
 
     it('Responds with GCF function signature when \'gcf\' is specified', function () {
       gcfInstance = (request, response) => {}
-      expect(serverless(plugin, 'gcf')).toBeInstanceOf(gcfInstance)
+      expect(serverless(plugin, 'gcf')).toEqual(gcfInstance)
     })
 
     it('Throw an error when no provider is specified', function () {

--- a/test/serverless.test.js
+++ b/test/serverless.test.js
@@ -1,0 +1,31 @@
+const serverless = require('../lib/serverless')
+const createProbot = require('../lib')
+const plugin = require('./fixtures/plugin/stub-plugin')
+
+describe('Serverless', function () {
+  let probot
+  let provider
+  let lambdaInstance
+
+  beforeEach(function () {
+    probot = createProbot()
+  })
+
+  describe('providers', function () {
+    it('Responds with Lambda function signature when \'aws\' is specified', function () {
+      lambdaInstance = (event, context, callback) => {}
+      expect(serverless(plugin, 'aws')).toBeInstanceOf(lambdaInstance)
+    })
+
+    it('Responds with GCF function signature when \'gcf\' is specified', function () {
+      gcfInstance = (request, response) => {}
+      expect(serverless(plugin, 'gcf')).toBeInstanceOf(gcfInstance)
+    })
+
+    it('Throw an error when no provider is specified', function () {
+      expect(() => {
+        serverless(plugin)
+      }).toThrow()
+    })
+  })
+})


### PR DESCRIPTION
After much discussion and exploration in #149 and thanks to @JasonEtco trying out GCF support in [ci-reporter](https://github.com/JasonEtco/ci-reporter/blob/master/index.js), this is an initial idea for a native serverless API for Probot. This deliberately avoids the express server and any routing, instead choosing to leave those parts of the implementation up to the FaaS provider. If express/routing is preferred, you can already pretty easily wrap the entire server in something like [aws-serverless-express](https://github.com/awslabs/aws-serverless-express/), but this effectively proxies all API Gateway routes to the express router.

Pulling some inspiration from [middy](https://github.com/middyjs/middy), this API wraps a single Probot plugin in an instance of a function handler, providing a 1:1 mapping between an API Gateway route and the logic in your Probot plugin. This also has a second argument that lets you specify the FaaS provider. AWS (Lambda) and GCF are the only ones supported for now.

The simplest API looks like this:
```js
// index.js
const { serverless } = require('probot')

const bot = (robot) => {
  robot.on('issues.opened', async context => {
    const params = context.issue({
      body: 'Hello World!'
    })
    context.github.issues.createComment(params);
  })
}

module.exports.probot = serverless(bot, 'aws')
```

Then you define your function handler as `index.probot`. An example yaml using the serverless framework looks like this:
```yaml
# serverless.yml
service: lambda-probot

provider:
  name: aws
  runtime: nodejs6.10

functions:
  probot:
    handler: index.probot
    environment:
      WEBHOOK_SECRET: development
      APP_ID: 0000
    events:
      - http:
         path: /probot
         method: post
```

Because you map the probot handler directly to an API Gateway POST route (which is the webhook URL), and because each handler has its own environment, you could actually deploy multiple bots from a single repo by doing something nifty like this:

```javascript
const { serverless } = require('probot')

const plugin1 = require('./plugins/probot1')
const plugin2 = require('./plugins/probot2')
const plugin3 = require('./plugins/probot3')

module.exports.probot1 = serverless(plugin1, 'aws')
// deployed to https://xxxxxx123456.execute-api.us-east-1.amazonaws.com/<stage>/probot1
module.exports.probot2 = serverless(plugin2, 'aws')
// deployed to https://xxxxxx123456.execute-api.us-east-1.amazonaws.com/<stage>/probot2
module.exports.probot3 = serverless(plugin3, 'aws')
// deployed to https://xxxxxx123456.execute-api.us-east-1.amazonaws.com/<stage>/probot3
```

Technically, each function can be its own independent GitHub App with its own settings and logic, while still deploying them all from a single repo.

Want to switch to GCF? Just change the provider argument and it will return the appropriate function for that environment.

---
So that's the idea right now. I need to figure out how to properly test this, and we also need to land #372 first before this will truly work. I've been deploying using the ES5 compiled version from that branch to test this out, but I wanted to get feedback on the implementation so far so we can land this PR shortly after.