### PR TITLE
chore: Remove github-webhook-handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "dotenv": "~5.0.0",
     "express": "^4.16.2",
     "express-async-errors": "2.1.1",
-    "github-webhook-handler": "^0.7.0",
     "hbs": "^4.0.1",
     "js-yaml": "^3.9.1",
     "jsonwebtoken": "^8.1.0",


### PR DESCRIPTION
I forgot to remove this in #462.