### PR TITLE
fix: allow initializing the GitHub client without options

### DIFF
--- a/lib/github/index.js
+++ b/lib/github/index.js
@@ -13,7 +13,7 @@ const addGraphQL = require('./graphql')
  * @typedef github
  * @see {@link https://github.com/octokit/rest.js}
  */
-function EnhancedGitHubClient (options) {
+function EnhancedGitHubClient (options = {}) {
   const octokit = Octokit(options)
 
   addRateLimiting(octokit, options.limiter)

--- a/lib/github/logging.js
+++ b/lib/github/logging.js
@@ -1,6 +1,10 @@
 module.exports = addLogging
 
 function addLogging (octokit, logger) {
+  if (!logger) {
+    return
+  }
+
   octokit.hook.error('request', (error, options) => {
     const {method, url, headers, ...params} = options
     const msg = `GitHub request: ${method} ${url} - ${error.code} ${error.status}`

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -17,6 +17,14 @@ describe('EnhancedGitHubClient', () => {
     github = new EnhancedGitHubClient({ logger, limiter })
   })
 
+  test('works without options', async () => {
+    github = new EnhancedGitHubClient()
+    const user = {login: 'ohai'}
+
+    nock('https://api.github.com').get('/user').reply(200, user)
+    expect((await github.users.get({})).data).toEqual(user)
+  })
+
   describe('paginate', () => {
     beforeEach(() => {
       // Prepare an array of issue objects


### PR DESCRIPTION
Really minor tweak to allow this to work:

```js
const GitHub = require('probot/lib/github')
const github = new GitHub()
```