### PR TITLE
chore: relax version for express-async-errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "commander": "^2.11.0",
     "dotenv": "~5.0.0",
     "express": "^4.16.2",
-    "express-async-errors": "2.1.1",
+    "express-async-errors": "^2.1.0",
     "hbs": "^4.0.1",
     "js-yaml": "^3.9.1",
     "jsonwebtoken": "^8.1.0",


### PR DESCRIPTION
The underlying issue here as fixed by switching from `github-webhook-handler` to `@octokit/webhooks` in #462.

Fixes https://github.com/probot/probot/issues/433