### PR TITLE
Change test to __tests__ (default location of tests)

### DIFF
--- a/docs/simulating-webhooks.md
+++ b/docs/simulating-webhooks.md
@@ -6,7 +6,7 @@ next: docs/testing.md
 
 As you are developing your app, you will likely want to test it by repeatedly trigging the same webhook. You can simulate a webhook being delivered by saving the payload to a file, and then calling `probot simulate` from the command line.
 
-To save a copy of the payload, go to the  [settings](https://github.com/settings/apps) page for your App, and go to the **Advanced** tab. Click on one of the **Recent Deliveries** to expand it and see the details of the webhook event. Copy the JSON from the the **Payload** and save it to a new file. (`test/fixtures/issues.labeled.json` in this example).
+To save a copy of the payload, go to the  [settings](https://github.com/settings/apps) page for your App, and go to the **Advanced** tab. Click on one of the **Recent Deliveries** to expand it and see the details of the webhook event. Copy the JSON from the the **Payload** and save it to a new file. (`__tests__/fixtures/issues.labeled.json` in this example).
 
 **Note**: This will only simulate the JSON payload, not the headers that are also sent by GitHub webhooks.
 


### PR DESCRIPTION
Using `create-probot-app`, we get a folder named `__tests__` which is the central location for all tests. I think it's better if we encourage developers to save their fixtures their only.