### PR TITLE
Added documentation for available npm run scripts

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -57,7 +57,6 @@ To run your app in development, you will need to configure a GitHub App to deliv
     - **Permissions & events** is located lower down the page and will depend on what data you want your app to have access to. Note: if, for example, you only enable issue events, you will not be able to listen on pull request webhooks with your app. However, for development we recommend enabling everything.
 1. Download the private key and move it to your project's directory. As long as it's in the root of your project, Probot will find it automatically regardless of the filename.
 1. Edit `.env` and set `APP_ID` to the ID of the app you just created. The App ID can be found in your app settings page here <img width="1048" alt="screen shot 2017-08-20 at 8 31 31 am" src="https://user-images.githubusercontent.com/13410355/29496168-044b9a48-8582-11e7-8be4-39cc75090647.png">
-1. 
 
 ## Installing the app on a repo
 
@@ -86,6 +85,10 @@ Yay, the plugin was loaded!
 ```
 
 The `dev` script will start your app using [nodemon](https://github.com/remy/nodemon#nodemon), which will watch for any files changes in your local development environment and automatically restart the server.
+
+**Other available scripts**
+* `$ npm start` to start your app without watching files.
+* `$ npm run lint` to lint your code using [standard](https://www.npmjs.com/package/standard).
 
 ## Debugging
 


### PR DESCRIPTION
with the availability of `npm run lint` there is a need for some documentation. As other useful scripts like `test:watch` are being added, I think making a small subsection about them is good.