### PR TITLE
Fix typescript linting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
     "start": "node ./bin/probot run",
-    "test": "jest --coverage && standard && npm run doc-lint",
+    "lint": "tslint --project .",
+    "test": "jest --coverage && npm run lint && npm run doc-lint",
     "doc-lint": "standard docs/**/*.md",
     "doc": "jsdoc -c .jsdoc.json",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
       "<rootDir>/test/setup.js",
       "<rootDir>/test/fixtures/",
       "<rootDir>/test/plugins/helper.js"
-    ]
+    ],
+    "globals": {
+      "ts-jest": {
+        "skipBabel": true,
+        "enableTsDiagnostics": true
+      }
+    }
   },
   "author": "Brandon Keepers",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "build": "rimraf lib && tsc -p tsconfig.json",
     "start": "node ./bin/probot run",
     "lint": "tslint --project .",
-    "test": "jest --coverage && npm run lint && npm run doc-lint",
+    "test": "tsc --noEmit -p . && jest --coverage && npm run lint && npm run doc-lint",
     "doc-lint": "standard docs/**/*.md",
     "doc": "jsdoc -c .jsdoc.json",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",

--- a/src/github-app.ts
+++ b/src/github-app.ts
@@ -1,7 +1,7 @@
 import * as jwt from 'jsonwebtoken'
 
-export const createApp = function (options: AppOptions) {
-  return function () {
+export const createApp = (options: AppOptions) => {
+  return () => {
     const payload = {
       exp: Math.floor(Date.now() / 1000) + 60,  // JWT expiration time
       iat: Math.floor(Date.now() / 1000),       // Issued at time

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,6 +1,6 @@
 import { OctokitWithPagination, Variables } from './'
 
-export const addGraphQL = function (octokit) {
+export const addGraphQL = (octokit) => {
   octokit.query = graphql.bind(null, octokit)
 }
 

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,10 +1,10 @@
 import { OctokitWithPagination, Variables } from './'
 
 export const addGraphQL = function (octokit) {
-  octokit.query = query.bind(null, octokit)
+  octokit.query = graphql.bind(null, octokit)
 }
 
-async function query (octokit: OctokitWithPagination, query: string, variables: Variables, headers = {}) {
+async function graphql (octokit: OctokitWithPagination, query: string, variables: Variables, headers = {}) {
   const res = await octokit.request({
     headers: {
       'accept': 'application/json',

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -64,4 +64,4 @@ export interface Headers {
   [key: string]: string
 }
 
-export type Variables = { [key: string]: any }
+export interface Variables { [key: string]: any }

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -14,7 +14,7 @@ import { addGraphQL } from './graphql'
  * @see {@link https://github.com/octokit/rest.js}
  */
 export const EnhancedGitHubClient = function (options: Options = {} as any) {
-  const octokit = <OctokitWithPagination> new Octokit(options)
+  const octokit = new Octokit(options) as OctokitWithPagination
 
   addRateLimiting(octokit, options.limiter)
   addLogging(octokit, options.logger)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -13,7 +13,7 @@ import { addGraphQL } from './graphql'
  * @typedef github
  * @see {@link https://github.com/octokit/rest.js}
  */
-export const EnhancedGitHubClient = function (options: Options = {} as any) {
+export const EnhancedGitHubClient = (options: Options = {} as any) => {
   const octokit = new Octokit(options) as OctokitWithPagination
 
   addRateLimiting(octokit, options.limiter)

--- a/src/github/logging.ts
+++ b/src/github/logging.ts
@@ -1,11 +1,11 @@
 import * as Logger from 'bunyan'
 import {OctokitWithPagination} from './'
 
-export const addLogging = function (octokit: OctokitWithPagination, logger: Logger) {
+export const addLogging = (octokit: OctokitWithPagination, logger: Logger) => {
   if (!logger) {
     return
   }
-  
+
   octokit.hook.error('request', (error, options) => {
     const {method, url, headers, ...params} = options
     const msg = `GitHub request: ${method} ${url} - ${error.code} ${error.status}`

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -20,6 +20,6 @@ async function paginate (octokit, responsePromise, callback = defaultCallback) {
   return collection
 }
 
-export const addPagination = function (octokit) {
+export const addPagination = (octokit) => {
   octokit.paginate = paginate.bind(null, octokit)
 }

--- a/src/github/rate-limiting.ts
+++ b/src/github/rate-limiting.ts
@@ -1,6 +1,6 @@
 const Bottleneck = require('bottleneck')
 
-export const addRateLimiting = function (octokit, limiter) {
+export const addRateLimiting = (octokit, limiter) => {
   if (!limiter) {
     limiter = new Bottleneck(1, 1000)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,7 @@ export const createProbot = (options: Options) => {
 
   function load (plugin: string | Plugin) {
     if (typeof plugin === 'string') {
-      plugin = <Plugin> resolve(plugin)
+      plugin = resolve(plugin) as Plugin
     }
 
     const robot = createRobot({app, cache, catchErrors: true})

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,8 +29,8 @@ export const createProbot = (options: Options) => {
 
   const webhook = new Webhooks({path: options.webhookPath, secret: options.secret})
   const app = createApp({
+    cert: options.cert,
     id: options.id,
-    cert: options.cert
   })
   const server: express.Application = createServer({webhook: webhook.middleware, logger})
 
@@ -102,20 +102,20 @@ export const createProbot = (options: Options) => {
   }
 
   return {
-    server,
-    webhook,
-    receive,
-    logger,
     load,
+    logger,
+    receive,
+    server,
     setup,
+    webhook,
 
     start () {
       if (options.webhookProxy) {
         createWebhookProxy({
-          url: options.webhookProxy,
-          port: options.port,
+          logger,
           path: options.webhookPath,
-          logger
+          port: options.port,
+          url: options.webhookProxy,
         })
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export const createProbot = (options: Options) => {
     process.on('unhandledRejection', errorHandler)
 
     // Load the given apps along with the default apps
-    apps.concat(defaultApps).forEach(app => load(app))
+    apps.concat(defaultApps).forEach(load)
 
     // Register error handler as the last middleware
     server.use(logRequestErrors)

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -59,8 +59,8 @@ function toBunyanFormat (format: string) {
 }
 
 export const logger = new Logger({
-  name: 'probot',
   level: toBunyanLogLevel(process.env.LOG_LEVEL || 'info'),
+  name: 'probot',
+  serializers,
   stream: new bunyanFormat({outputMode: toBunyanFormat(process.env.LOG_FORMAT || 'short')}),
-  serializers
 })

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -4,8 +4,8 @@ export const resolve = function (app: string, opts?: ResolveOptions) {
   opts = opts || defaultOptions
   // These are mostly to ease testing
   const basedir = opts.basedir || process.cwd()
-  const resolve = opts.resolver || require('resolve').sync
-  return require(resolve(app, {basedir}))
+  const resolver = opts.resolver || require('resolve').sync
+  return require(resolver(app, {basedir}))
 }
 
 export interface ResolveOptions {

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,6 +1,6 @@
 const defaultOptions: ResolveOptions = {}
 
-export const resolve = function (app: string, opts?: ResolveOptions) {
+export const resolve = (app: string, opts?: ResolveOptions) => {
   opts = opts || defaultOptions
   // These are mostly to ease testing
   const basedir = opts.basedir || process.cwd()

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -148,8 +148,8 @@ export class Robot {
    */
   public async auth (id?: string, log = this.log) {
     const github: OctokitWithPagination = GitHubApi({
-      debug: process.env.LOG_LEVEL === 'trace',
       baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
+      debug: process.env.LOG_LEVEL === 'trace',
       logger: log.child({name: 'github', installation: id})
     })
 

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -3,7 +3,7 @@ import {Context} from './context'
 import {logger} from './logger'
 import {LoggerWithTarget, wrapLogger} from './wrap-logger'
 
-import {EventEmitter} from 'promise-events'
+  import {EventEmitter} from 'promise-events'
 import {EnhancedGitHubClient as GitHubApi, OctokitWithPagination} from './github'
 
 /**
@@ -93,10 +93,10 @@ export class Robot {
    *   // An issue was just opened.
    * });
    */
-  public on (event: string | string[], callback: (context: Context) => void) {
-    if (typeof event === 'string') {
+  public on (eventName: string | string[], callback: (context: Context) => void) {
+    if (typeof eventName === 'string') {
 
-      const [name, action] = event.split('.')
+      const [name, action] = eventName.split('.')
 
       return this.events.on(name, async (event: Context) => {
         if (!action || action === event.payload.action) {
@@ -116,7 +116,7 @@ export class Robot {
         }
       })
     } else {
-      event.forEach(e => this.on(e, callback))
+      eventName.forEach(e => this.on(e, callback))
     }
   }
 

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -4,7 +4,6 @@ import {PayloadRepository} from './context'
 
 export const serializers: bunyan.StdSerializers = {
 
-  repository: (repository: PayloadRepository) => repository.full_name,
   event: (event: any) => {
     if (typeof event !== 'object' || !event.payload) {
       return event
@@ -15,10 +14,10 @@ export const serializers: bunyan.StdSerializers = {
       }
 
       return {
-        id: event.id,
         event: name,
+        id: event.id,
+        installation: event.payload.installation && event.payload.installation.id,
         repository: event.payload.repository && event.payload.repository.full_name,
-        installation: event.payload.installation && event.payload.installation.id
       }
     }
   },
@@ -32,6 +31,8 @@ export const serializers: bunyan.StdSerializers = {
 
   err: bunyan.stdSerializers.err,
 
+  repository: (repository: PayloadRepository) => repository.full_name,
+
   req: bunyan.stdSerializers.req,
 
   // Same as buyan's standard serializers, but gets headers as an object
@@ -43,8 +44,8 @@ export const serializers: bunyan.StdSerializers = {
     } else {
       return {
         duration: res.duration,
+        headers: res.getHeaders(),
         statusCode: res.statusCode,
-        headers: res.getHeaders()
       }
     }
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,7 +7,7 @@ require('express-async-errors')
 
 import {logRequest} from './middleware/logging'
 
-export const createServer = function (args: ServerArgs): express.Application {
+export const createServer = (args: ServerArgs) => {
   const app:express.Application = express()
 
   app.use(logRequest({logger: args.logger}))

--- a/src/webhook-proxy.ts
+++ b/src/webhook-proxy.ts
@@ -6,9 +6,9 @@ export const createWebhookProxy = (opts: WebhookProxyOptions) => {
     const SmeeClient = require('smee-client')
 
     const smee = new SmeeClient({
+      logger: opts.logger,
       source: opts.url,
       target: `http://localhost:${opts.port}${opts.path}`,
-      logger: opts.logger
     })
     return smee.start()
   } catch (err) {

--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -6,7 +6,7 @@ import * as Logger from 'bunyan'
 //     robot.log("info")
 //     robot.log.trace("verbose details");
 //
-export const wrapLogger = function (logger: Logger, baseLogger?: Logger): LoggerWithTarget {
+export const wrapLogger = (logger: Logger, baseLogger?: Logger): LoggerWithTarget => {
   const fn = logger.info.bind(logger)
 
   // Add level methods on the logger

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "rules": {
       "interface-name": [true, "never-prefix"],
       "no-var-requires": false,
-      "interface-over-type-literal": false,
       "prefer-object-spread": false,
       "object-literal-sort-keys": false
     }

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "rules": {
       "interface-name": [true, "never-prefix"],
       "no-var-requires": false,
-      "no-angle-bracket-type-assertion": false,
       "interface-over-type-literal": false,
       "only-arrow-functions": false,
       "prefer-object-spread": false,

--- a/tslint.json
+++ b/tslint.json
@@ -7,7 +7,6 @@
       "interface-name": [true, "never-prefix"],
       "no-var-requires": false,
       "interface-over-type-literal": false,
-      "only-arrow-functions": false,
       "prefer-object-spread": false,
       "object-literal-sort-keys": false
     }

--- a/tslint.json
+++ b/tslint.json
@@ -4,7 +4,6 @@
         "tslint-config-prettier"
     ],
     "rules": {
-      "no-shadowed-variable": false,
       "interface-name": [true, "never-prefix"],
       "no-var-requires": false,
       "no-angle-bracket-type-assertion": false,

--- a/tslint.json
+++ b/tslint.json
@@ -6,7 +6,6 @@
     "rules": {
       "interface-name": [true, "never-prefix"],
       "no-var-requires": false,
-      "prefer-object-spread": false,
-      "object-literal-sort-keys": false
+      "prefer-object-spread": false
     }
 }


### PR DESCRIPTION
This PR is against #372

- `npm run lint` and run it as part of the tests instead of running `standard`
- Removes customizations to `tslint.json` and fix resulting linter warnings