### PR TITLE
Enable typescript diagnostics in ts-jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,13 @@
       "<rootDir>/test/setup.js",
       "<rootDir>/test/fixtures/",
       "<rootDir>/test/plugins/helper.js"
-    ]
+    ],
+    "globals": {
+      "ts-jest": {
+        "skipBabel": true,
+        "enableTsDiagnostics": true
+      }
+    }
   },
   "author": "Brandon Keepers",
   "license": "ISC",


### PR DESCRIPTION
This enables 2 configs in ts-jest…


1. [enableTsDiagnostics](https://github.com/kulshekhar/ts-jest#ts-compiler--error-reporting)
    > If you want to enable Syntactic & Semantic TypeScript error reporting you can enable this through `enableTsDiagnostics` flag
2. [skipBabel](https://github.com/kulshekhar/ts-jest#skipping-babel)
    > If you don't use mocks, or synthetic default imports you can skip the babel-transpilation step.

The first one fixes the issue I was running into in https://github.com/probot/probot/pull/494#issuecomment-379957336 where the tests were passing with `npm test` but failing with `npm run build`. The second just removes a step we likely don't need.
