### PR TITLE
Specify files to include in released package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,0 @@
-src
-test
-coverage

--- a/package.json
+++ b/package.json
@@ -21,6 +21,12 @@
     "postsemantic-release": "script/publish-docs",
     "prepublish": "npm run build"
   },
+  "files": [
+    "lib",
+    "bin",
+    "static",
+    "views"
+  ],
   "jest": {
     "setupFiles": [
       "<rootDir>/test/setup.js"


### PR DESCRIPTION
This is a PR against #372 

This switch from using an exclusive list of files in `.npmignore` to using the `files` property in `package.json`. From the [docs](https://docs.npmjs.com/files/package.json#files):

> The optional "files" field is an array of file patterns that describes the entries to be included when your package is installed as a dependency. 

…

> Certain files are always included, regardless of settings:
> - package.json
> - README
> - CHANGES / CHANGELOG / HISTORY
> - LICENSE / LICENCE
> - NOTICE
> - The file in the "main" field

The latest `probot-7.0.0.-typescript*` packages included some files that were included in `.gitignore`, but since the typescript branch added a `.npmignore`, those files were no longer excluded. Instead of trying to keep two separate exclusive lists up to date, this opts for specifying the list of files we want included in the package.

Here's what the package will include now:

```
$ ls
LICENSE      README.md    bin          lib          package.json static       views
```
