### PR TITLE
Added Wildcard Event detail

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -50,4 +50,4 @@ module.exports = robot => {
 }
 ```
 
-Explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) to see what events are available for your app to use.
+Explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) to see what events are available to use in your app.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -45,9 +45,7 @@ You can also use the wildcard event (`*`) to listen for any event that your app 
 ```js
 module.exports = robot => {
   robot.on(`*`, async context => {
-    // Something happened at GitHub, what should I do?
-    robot.log(context.event) // Logs the event details
-    robot.log(context.payload.action) // Logs the related action details
+    context.log({event: context.event, action: context.payload.action})
   })
 }
 ```

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -39,7 +39,9 @@ module.exports = robot => {
   })
 }
 ```
-You can also use [GitHub wildcard event (`*`)](https://developer.github.com/webhooks/#wildcard-event) to receive all the possible webhook for the events to which your applications is subscribed to:
+
+You can also use the wildcard event (`*`) to listen for any event that your app is subscribed to:
+
 ```js
 module.exports = robot => {
   robot.on(`*`, async context => {
@@ -49,7 +51,5 @@ module.exports = robot => {
   })
 }
 ```
-When you add the wildcard event (`*`), the app will replace any existing events you have configured with the wildcard event and send you payloads for all supported events. You'll also automatically get any new events that GitHub might might add in the future.
 
-Explore all the GitHub events here : [GitHub Webhook Events](https://developer.github.com/webhooks/#events)
-
+Explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) to see what events are available for your app to use.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -39,4 +39,17 @@ module.exports = robot => {
   })
 }
 ```
+You can also use [GitHub wildcard event (`*`)](https://developer.github.com/webhooks/#wildcard-event) to receive all the possible webhook for the events to which your applications is subscribed to:
+```js
+module.exports = robot => {
+  robot.on(`*`, async context => {
+    // Something happened at GitHub, what should I do?
+    robot.log(context.event) // Logs the event details
+    robot.log(context.payload.action) // Logs the related action details
+  })
+}
+```
+When you add the wildcard event (`*`), the app will replace any existing events you have configured with the wildcard event and send you payloads for all supported events. You'll also automatically get any new events that GitHub might might add in the future.
+
+Explore all the GitHub events here : [GitHub Webhook Events](https://developer.github.com/webhooks/#events)
 


### PR DESCRIPTION
Added details about how one can use wildcard event details. Added this because just like one recommends new developers building apps on Probot to subscribe to all the GitHub events for testing purpose, similarly, the GitHub wild card event will help developers to take actions for all the possible webhooks.