### PR TITLE
Modified conflicting statement in docs

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -29,7 +29,7 @@ Use the `_extends` option in your configuration file to extend settings from ano
 For example, given `.github/test.yml`:
 
 ```yaml
-_extends: probot-settings
+_extends: github-settings
 # Override values from the extended config or define new values
 name: myrepo
 ```


### PR DESCRIPTION
In the current `docs/extensions.md`, on line 32, it's mentioned that config will be inherited from `probot-settings` repo, however in the following text describing it, the repo name given is `github-settings`. Of these only one can be correct. This PR intends to fix this discrepancy.