### PR TITLE
Fixed error for installation event

### DIFF
--- a/lib/context.js
+++ b/lib/context.js
@@ -33,12 +33,12 @@ class Context {
 
     if (!repo) {
       throw new Error('context.repo() is not supported for this webhook event.')
-    } else {
-      return Object.assign({
-        owner: repo.owner.login || repo.owner.name,
-        repo: repo.name
-      }, object)
     }
+
+    return Object.assign({
+      owner: repo.owner.login || repo.owner.name,
+      repo: repo.name
+    }, object)
   }
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -31,10 +31,14 @@ class Context {
   repo (object) {
     const repo = this.payload.repository
 
-    return Object.assign({
-      owner: repo.owner.login || repo.owner.name,
-      repo: repo.name
-    }, object)
+    if (!repo) {
+      throw new Error('Sorry not available for this event')
+    } else {
+      return Object.assign({
+        owner: repo.owner.login || repo.owner.name,
+        repo: repo.name
+      }, object)
+    }
   }
 
   /**

--- a/lib/context.js
+++ b/lib/context.js
@@ -32,7 +32,7 @@ class Context {
     const repo = this.payload.repository
 
     if (!repo) {
-      throw new Error('Sorry not available for this event')
+      throw new Error('context.repo() is not supported for this webhook event.')
     } else {
       return Object.assign({
         owner: repo.owner.login || repo.owner.name,

--- a/test/__snapshots__/context.test.js.snap
+++ b/test/__snapshots__/context.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Context repo returns error for context.repo() 1`] = `"context.repo() is not supported for this webhook event."`;

--- a/test/__snapshots__/context.test.js.snap
+++ b/test/__snapshots__/context.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Context repo returns error for context.repo() 1`] = `"context.repo() is not supported for this webhook event."`;
+exports[`Context repo return error for context.repo() when repository doesn't exist 1`] = `"context.repo() is not supported for this webhook event."`;

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -50,7 +50,7 @@ describe('Context', function () {
       expect(context.repo()).toEqual({owner: 'bkeepers-inc', repo: 'test'})
     })
 
-    it('returns error for context.repo()', function () {
+    it('return error for context.repo() when repository doesn\'t exist', function () {
       delete context.payload.repository
       try {
         context.repo()

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -51,7 +51,7 @@ describe('Context', function () {
     })
 
     it('returns error for context.repo()', function () {
-      context.payload.repository = undefined
+      delete context.payload.repository
       try {
         context.repo()
       } catch (e) {

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -25,15 +25,6 @@ describe('Context', function () {
   })
 
   describe('repo', function () {
-    it('returns error for context.repo()', function () {
-      context.payload.repository = undefined
-      try {
-        context.repo()
-      } catch (e) {
-        expect(String(e)).toEqual('Error: Sorry not available for this event')
-      }
-    })
-
     it('returns attributes from repository payload', function () {
       expect(context.repo()).toEqual({owner: 'bkeepers', repo: 'probot'})
     })
@@ -57,6 +48,15 @@ describe('Context', function () {
 
       context = new Context(event)
       expect(context.repo()).toEqual({owner: 'bkeepers-inc', repo: 'test'})
+    })
+
+    it('returns error for context.repo()', function () {
+      context.payload.repository = undefined
+      try {
+        context.repo()
+      } catch (e) {
+        expect(e.message).toMatchSnapshot()
+      }
     })
   })
 

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -25,6 +25,15 @@ describe('Context', function () {
   })
 
   describe('repo', function () {
+    it('returns error for context.repo()', function () {
+      context.payload.repository = undefined
+      try {
+        context.repo()
+      } catch (e) {
+        expect(String(e)).toEqual('Error: Sorry not available for this event')
+      }
+    })
+
     it('returns attributes from repository payload', function () {
       expect(context.repo()).toEqual({owner: 'bkeepers', repo: 'probot'})
     })


### PR DESCRIPTION
fixes #506 . Throws error for events which are not in `context.repo()`