### PR TITLE
docs: Add probot-attachments to extensions list

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -102,3 +102,22 @@ module.exports = robot => {
 ```
 
 Check out [stale](https://github.com/probot/stale) to see it in action.
+
+## Attachments
+
+[probot-attachments](https://github.com/probot/attachments) adds message attachments to comments on GitHub. This extension should be used any time an app is appending content to user comments.
+
+```js
+const attachments = require('probot-attachments')
+
+module.exports = robot => {
+  robot.on('issue_comment.created', context => {
+    return attachments(context).add({
+      'title': 'Hello World',
+      'title_link': 'https://example.com/hello'
+    })
+  })
+}
+```
+
+Check out [probot/unfurl](https://github.com/probot/unfurl) to see it in action.


### PR DESCRIPTION
This extension has been around for a while but I just realized it's not currently on the list.