### PR TITLE
add ignore spammy/abusive user option for stats endpoint

### DIFF
--- a/lib/plugins/stats.js
+++ b/lib/plugins/stats.js
@@ -14,6 +14,9 @@ module.exports = async robot => {
   // Refresh the stats on an interval
   setInterval(refresh, REFRESH_INTERVAL)
 
+  // Check for accounts (typically spammy or abusive) to ignore
+  const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').toLowerCase().split(',')
+
   // Setup /probot/stats endpoint to return cached stats
   robot.router.get('/probot/stats', async (req, res) => {
     // ensure stats are loaded
@@ -39,15 +42,21 @@ module.exports = async robot => {
       const github = await robot.auth(installation.id)
 
       const req = github.apps.getInstallationRepositories({per_page: 100})
+
       const repositories = await github.paginate(req, res => {
         return res.data.repositories.filter(repository => !repository.private)
       })
-      const account = installation.account
 
-      account.stars = repositories.reduce((stars, repository) => {
-        return stars + repository.stargazers_count
-      }, 0)
+     if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
+       robot.log.debug({installation}, 'Installation is ignored')
+       return
+     } else {
+        const account = installation.account
 
+        account.stars = repositories.reduce((stars, repository) => {
+          return stars + repository.stargazers_count
+        }, 0)
+      }
       return account
     }))
 

--- a/lib/plugins/stats.js
+++ b/lib/plugins/stats.js
@@ -42,7 +42,6 @@ module.exports = async robot => {
       const github = await robot.auth(installation.id)
 
       const req = github.apps.getInstallationRepositories({per_page: 100})
-
       const repositories = await github.paginate(req, res => {
         return res.data.repositories.filter(repository => !repository.private)
       })

--- a/lib/plugins/stats.js
+++ b/lib/plugins/stats.js
@@ -46,17 +46,17 @@ module.exports = async robot => {
       const repositories = await github.paginate(req, res => {
         return res.data.repositories.filter(repository => !repository.private)
       })
+      const account = installation.account
 
-     if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
-       robot.log.debug({installation}, 'Installation is ignored')
-       return
-     } else {
-        const account = installation.account
-
+      if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
+        account.stars = 0
+        robot.log.debug({installation}, 'Installation is ignored')
+      } else {
         account.stars = repositories.reduce((stars, repository) => {
           return stars + repository.stargazers_count
         }, 0)
       }
+
       return account
     }))
 

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -54,4 +54,27 @@ describe('stats', function () {
       return request(server).get('/probot/stats').expect(404)
     })
   })
+
+  describe('it ignores spammy users', () => {
+    beforeEach(async () => {
+      process.env.IGNORED_ACCOUNTS = 'hiimbex,spammyUser'
+      nock('https://api.github.com')
+        .defaultReplyHeaders({'Content-Type': 'application/json'})
+        .post('/installations/1/access_tokens').reply(200, {token: 'test'})
+        .get('/app/installations?per_page=100').reply(200, [{id: 2, account: {login: 'spammyUser'}}])
+        .get('/installation/repositories?per_page=100').reply(200, {repositories: [{private: false, stargazers_count: 2}]})
+
+      robot = helper.createRobot()
+
+      await plugin(robot)
+
+      server = express()
+      server.use(robot.router)
+    })
+
+    it('returns installation count and popular accounts while exclusing spammy users', () => {
+      return request(server).get('/probot/stats')
+        .expect(200, {'installations': 1, 'popular': []})
+    })
+  })
 })

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -61,8 +61,11 @@ describe('stats', function () {
       nock('https://api.github.com')
         .defaultReplyHeaders({'Content-Type': 'application/json'})
         .post('/installations/1/access_tokens').reply(200, {token: 'test'})
-        .get('/app/installations?per_page=100').reply(200, [{id: 2, account: {login: 'spammyUser'}}])
-        .get('/installation/repositories?per_page=100').reply(200, {repositories: [{private: false, stargazers_count: 2}]})
+        .get('/app/installations?per_page=100').reply(200, [{id: 1, account: {login: 'spammyUser'}}])
+        .get('/installation/repositories?per_page=100').reply(200, {repositories: [
+          {private: true, stargazers_count: 1},
+          {private: false, stargazers_count: 2}
+        ]})
 
       robot = helper.createRobot()
 

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -79,6 +79,7 @@ describe('stats', function () {
       return request(server).get('/probot/stats')
         .expect(200, {'installations': 1, 'popular': []})
     })
+
     afterEach(async () => {
       delete process.env.IGNORED_ACCOUNTS
     })

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -79,5 +79,8 @@ describe('stats', function () {
       return request(server).get('/probot/stats')
         .expect(200, {'installations': 1, 'popular': []})
     })
+    afterEach(async () => {
+      delete process.env.IGNORED_ACCOUNTS
+    })
   })
 })


### PR DESCRIPTION
Prompted by https://github.com/probot/probot.github.io/pull/171 which has our site tests failing due to a spammy user being returned from the API.

cc/ https://github.com/probot/scheduler/pull/17 for prior art 

I think we shouldn't alter the total number of installations to remove spammy users and just not list them individually. I wasn't sure the best approach for this and obviously the test that already existed and the one I wrote are failing, so I could use some help!! 