### PR TITLE
Fix typo

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -8,7 +8,7 @@ While Probot doesn't have an official extension API (yet), there are a handful o
 
 ## Config
 
-[probot-config](https://github.com/getsentry/probot-config) is an extension for sharing configs between between repositories.
+[probot-config](https://github.com/getsentry/probot-config) is an extension for sharing configs between repositories.
 
 
 ```js


### PR DESCRIPTION
This is regarding the typo in https://probot.github.io/docs/extensions/#config