### PR TITLE
Remove the now obsolete step

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -114,10 +114,6 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
 
-1. Due to an [ongoing issue](https://github.com/zeit/now-cli/issues/749) in `now.sh`, a workaround must be applied to the private key before it can be used.
-    * You can [modify `package.json`](https://github.com/probot/probot/issues/318#issuecomment-343010573) and base64 encode your private key.
-    * You can concatenate a `\n` onto each line of the private key, and then merge the private key onto a single line. Then, you can follow the deploy script without modifying `package.json`.
-
 1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the path for the `PRIVATE_KEY`:
 
         $ now -e APP_ID=aaa \


### PR DESCRIPTION
Due to Zeit fixing the issue with the private key, this step is no longer needed.