### PR TITLE
Issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -11,8 +11,8 @@ A clear and concise description of the behavior.
 ```js
   // Your code here
 module.exports = robot => {
-  robot.log('')
-})
+  robot.log('There is a bug')
+}
 ```
 
 **Expected behavior/code**

--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -1,0 +1,30 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+---
+
+## Bug Report
+
+**Current Behavior**
+A clear and concise description of the behavior.
+
+```js
+  // Your code here
+module.exports = robot => {
+  robot.log('')
+})
+```
+
+**Expected behavior/code**
+A clear and concise description of what you expected to happen (or code).
+
+**Environment**
+- Probot version(s): [e.g. v6.0.0]
+- Node/npm version: [e.g. Node 8/npm 5]
+- OS: [e.g. OSX 10.13.4, Windows 10]
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+
+**Additional context/Screenshots**
+Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/ISSUE_TEMPLATE/Feature_request.md
+++ b/.github/ISSUE_TEMPLATE/Feature_request.md
@@ -1,0 +1,19 @@
+---
+name: 🚀 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+---
+
+## Feature Request
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I have an issue when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen. Add any considered drawbacks.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Teachability, Documentation, Adoption, Migration Strategy**
+If you can, explain how users will be able to use this and possibly write out a version the docs.
+Maybe a screenshot or design?


### PR DESCRIPTION
Adds some issue templates, one for **Bug Reports** and one for **Feature Requests**. I've basically copy-pasted the templates [used by Babel](https://github.com/babel/babel/tree/master/.github/ISSUE_TEMPLATE); they fit well for us too, but feel free to suggest changes if you see something that needs tweaking.

cc @RichardLitt #522