### PR TITLE
Test Node 9 and 10 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,15 @@ language: node_js
 node_js:
   - "8"
   - "10"
-  
+
+env:
+matrix:
+  include:
+    - node_js: "10"
+  allow_failures:
+    - node_js: "10"
+
+
 notifications:
   disabled: true
   

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 
 node_js:
   - "8"
-  - "10"
 
 env:
 matrix:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: node_js
 
 node_js:
   - "8"
-  - "9"
   - "10"
   
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: node_js
 
 node_js:
   - "8"
+  - "9"
+  - "10"
   
 notifications:
   disabled: true


### PR DESCRIPTION
This PR adds Node.js `9.x.x` and `10.x.x` to the TravisCI builds.

## Why?

I'm not saying that we should support every bleeding edge version of Node (that'd be great, I just don't think we have the bandwidth). However, we should be aware of what is and is not supported, and what will straight up not work.

## How?

TravisCI will run our existing tests in Node.js 9 and 10, always using the latest `minor/patch` version of those respective major versions.

---

_Note: Everything here passes 🎉 that means that we can now tell people that if they want to use Node 9/10, they **totally can**. That was the original goal of this PR._