### PR TITLE
Update @octokit/rest to ^15.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "15.2.0",
+    "@octokit/rest": "15.6.0",
     "@octokit/webhooks": "^3.1.1",
     "bottleneck": "^2.2.0",
     "bunyan": "^1.8.12",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "15.6.0",
+    "@octokit/rest": "^15.6.0",
     "@octokit/webhooks": "^3.1.1",
     "bottleneck": "^2.2.0",
     "bunyan": "^1.8.12",


### PR DESCRIPTION
Closes #465. I’ll make sure we don’t break probot with 15.x.x versions despite probot using internal APIs