### PR TITLE
Missing `break` statement in "Early exit" example

### DIFF
--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -51,6 +51,7 @@ module.exports = robot => {
           if (issue.body.includes('something')) {
             console.log('found it:', issue)
             done()
+            break
           }
         }
       }


### PR DESCRIPTION
 In current example, the `for` loop won't exit unless the missing `break` statement is added.