### PR TITLE
WIP: `probot token` command to get API token

### DIFF
--- a/bin/probot-token.js
+++ b/bin/probot-token.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+require('dotenv').config()
+
+const program = require('commander')
+
+const {findPrivateKey} = require('../lib/private-key')
+const createApp = require('../lib/github-app')
+
+program
+  .usage('[options] <apps...>')
+  .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
+  .option('-P, --private-key <file>', 'Path to certificate of the GitHub App', findPrivateKey)
+  .parse(process.argv)
+
+if (!program.app) {
+  console.warn('Missing GitHub App ID.\nUse --app flag or set APP_ID environment variable.')
+  program.help()
+}
+
+if (!program.privateKey) {
+  program.privateKey = findPrivateKey()
+}
+
+const app = createApp({
+  id: program.app,
+  cert: program.privateKey
+})
+
+const jwt = app()
+console.log(jwt)


### PR DESCRIPTION
@wilhelmklopp put together a [really cool CLI](https://github.com/integrations/jsonwebtokenydoo) a couple weeks ago to make it easier to get tokens for GitHub Apps. Which reminded me…

I've had the code in this PR stashed on my computer for a few months now. There's still a lot of work to do, but I thought I would get it open to start a conversation about how we make it easier for people to get get a token that they can use to experiment with.

Here's how I was imagining this CLI would work:

- `probot token` - return a JWT token that can be used to make requests as the application
- `probot token <installation-id>` or `probot token <account-name>` - return an installation token that can be used to make requests as an installation

So, for the discussion: should this be built into Probot itself, or should we encourage people to just use `jsonwebtokenydoo`?