### PR TITLE
TypeScript: tweaks to GitHub API

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,6 +1,6 @@
 import * as yaml from 'js-yaml'
 import * as path from 'path'
-import { OctokitWithPagination } from './github'
+import {GitHubAPI} from './github'
 import {LoggerWithTarget} from './wrap-logger'
 /**
  * Helpers for extracting information from the webhook event, which can be
@@ -12,11 +12,11 @@ import {LoggerWithTarget} from './wrap-logger'
  */
 export class Context {
   public id: number
-  public github: OctokitWithPagination
+  public github: GitHubAPI
   public log: LoggerWithTarget
   public payload!: WebhookPayloadWithRepository
 
-  constructor (event:any, github:OctokitWithPagination, log:LoggerWithTarget) {
+  constructor (event:any, github:GitHubAPI, log:LoggerWithTarget) {
     Object.assign(this, event)
     this.id = event.id
     this.github = github

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -26,6 +26,9 @@ async function graphql (octokit: OctokitWithPagination, query: string, variables
 }
 
 class GraphQLError extends Error {
+  public query: string
+  public variables: Variables
+
   constructor (errors, query: string, variables: Variables) {
     super(JSON.stringify(errors))
     this.name = 'GraphQLError'
@@ -36,9 +39,4 @@ class GraphQLError extends Error {
       Error.captureStackTrace(this, GraphQLError)
     }
   }
-}
-
-interface GraphQLError {
-  query: string
-  variables: Variables
 }

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,11 +1,11 @@
-import { Headers, OctokitWithPagination, Variables } from './'
+import {GitHubAPI, Headers, Variables} from './'
 
-export default function addGraphQL (octokit) {
-  octokit.query = graphql.bind(null, octokit)
+export default function addGraphQL (client) {
+  client.query = graphql.bind(null, client)
 }
 
-async function graphql (octokit: OctokitWithPagination, query: string, variables: Variables, headers: Headers = {}) {
-  const res = await octokit.request({
+async function graphql (client: GitHubAPI, query: string, variables: Variables, headers: Headers = {}) {
+  const res = await client.request({
     headers: {
       'accept': 'application/json',
       'content-type': 'application/json',

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,6 +1,6 @@
 import { Headers, OctokitWithPagination, Variables } from './'
 
-export const addGraphQL = (octokit) => {
+export default function addGraphQL (octokit) {
   octokit.query = graphql.bind(null, octokit)
 }
 

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,6 +1,6 @@
 import {GitHubAPI, Headers, Variables} from './'
 
-export default function addGraphQL (client) {
+export function addGraphQL (client) {
   client.query = graphql.bind(null, client)
 }
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -1,8 +1,8 @@
 import * as Octokit from '@octokit/rest'
-import addGraphQL from './graphql'
-import addLogging, { Logger } from './logging'
-import addPagination from './pagination'
-import addRateLimiting from './rate-limiting'
+import {addGraphQL} from './graphql'
+import {addLogging, Logger} from './logging'
+import {addPagination} from './pagination'
+import {addRateLimiting} from './rate-limiting'
 
 /**
  * the [@octokit/rest Node.js module](https://github.com/octokit/rest.js),

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -13,7 +13,7 @@ import addRateLimiting from './rate-limiting'
  * @see {@link https://github.com/octokit/rest.js}
  */
 export function GitHubAPI(options: Options = {} as any) {
-  const octokit = new Octokit(options) as OctokitWithPagination
+  const octokit = new Octokit(options) as GitHubAPI
 
   addRateLimiting(octokit, options.limiter)
   addLogging(octokit, options.logger)
@@ -48,7 +48,7 @@ export interface OctokitError {
   status: string
 }
 
-export interface OctokitWithPagination extends Octokit {
+export interface GitHubAPI extends Octokit {
   paginate: (res: Promise<Octokit.AnyResponse>, callback: (results: Octokit.AnyResponse) => void) => Promise<any[]>
   // The following are added because Octokit does not expose the hook.error, hook.before, and hook.after methods
   hook: {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -13,7 +13,7 @@ import { addGraphQL } from './graphql'
  * @typedef github
  * @see {@link https://github.com/octokit/rest.js}
  */
-export const EnhancedGitHubClient = (options: Options = {} as any) => {
+export function GitHubAPI(options: Options = {} as any) {
   const octokit = new Octokit(options) as OctokitWithPagination
 
   addRateLimiting(octokit, options.limiter)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -1,9 +1,8 @@
 import * as Octokit from '@octokit/rest'
+import { addGraphQL } from './graphql'
 import { addLogging, Logger  } from './logging'
 import { addPagination } from './pagination'
 import { addRateLimiting } from './rate-limiting'
-
-import { addGraphQL } from './graphql'
 
 /**
  * the [@octokit/rest Node.js module](https://github.com/octokit/rest.js),
@@ -30,7 +29,7 @@ export interface Options extends Octokit.Options {
   limiter?: any
 }
 
-export interface OctokitRequestOptions {
+export interface RequestOptions {
   method: string
   url: string
   headers: any
@@ -38,7 +37,7 @@ export interface OctokitRequestOptions {
   variables?: Variables
 }
 
-export interface OctokitResult {
+export interface Result {
   meta: {
     status: string
   }
@@ -53,11 +52,12 @@ export interface OctokitWithPagination extends Octokit {
   paginate: (res: Promise<Octokit.AnyResponse>, callback: (results: Octokit.AnyResponse) => void) => Promise<any[]>
   // The following are added because Octokit does not expose the hook.error, hook.before, and hook.after methods
   hook: {
-    error: (when: 'request', callback: (error: OctokitError, options: OctokitRequestOptions) => void) => void
-    before: (when: 'request', callback: (result: OctokitResult, options: OctokitRequestOptions) => void) => void
-    after: (when: 'request', callback: (result: OctokitResult, options: OctokitRequestOptions) => void) => void
+    error: (when: 'request', callback: (error: OctokitError, options: RequestOptions) => void) => void
+    before: (when: 'request', callback: (result: Result, options: RequestOptions) => void) => void
+    after: (when: 'request', callback: (result: Result, options: RequestOptions) => void) => void
   }
-  request: (OctokitRequestOptions) => Promise<Octokit.AnyResponse>
+
+  request: (RequestOptions) => Promise<Octokit.AnyResponse>
   query: (query: string, variables?: Variables, headers?: Headers) => Promise<Octokit.AnyResponse>
 }
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -1,8 +1,8 @@
 import * as Octokit from '@octokit/rest'
-import { addGraphQL } from './graphql'
-import { addLogging, Logger  } from './logging'
-import { addPagination } from './pagination'
-import { addRateLimiting } from './rate-limiting'
+import addGraphQL from './graphql'
+import addLogging, { Logger } from './logging'
+import addPagination from './pagination'
+import addRateLimiting from './rate-limiting'
 
 /**
  * the [@octokit/rest Node.js module](https://github.com/octokit/rest.js),

--- a/src/github/logging.ts
+++ b/src/github/logging.ts
@@ -1,7 +1,7 @@
 import * as Logger from 'bunyan'
 import {GitHubAPI} from './'
 
-export default function addLogging (client: GitHubAPI, logger: Logger) {
+export function addLogging (client: GitHubAPI, logger: Logger) {
   if (!logger) {
     return
   }

--- a/src/github/logging.ts
+++ b/src/github/logging.ts
@@ -1,7 +1,7 @@
 import * as Logger from 'bunyan'
 import {OctokitWithPagination} from './'
 
-export const addLogging = (octokit: OctokitWithPagination, logger: Logger) => {
+export default function addLogging (octokit: OctokitWithPagination, logger: Logger) {
   if (!logger) {
     return
   }

--- a/src/github/logging.ts
+++ b/src/github/logging.ts
@@ -1,18 +1,18 @@
 import * as Logger from 'bunyan'
-import {OctokitWithPagination} from './'
+import {GitHubAPI} from './'
 
-export default function addLogging (octokit: OctokitWithPagination, logger: Logger) {
+export default function addLogging (client: GitHubAPI, logger: Logger) {
   if (!logger) {
     return
   }
 
-  octokit.hook.error('request', (error, options) => {
+  client.hook.error('request', (error, options) => {
     const {method, url, headers, ...params} = options
     const msg = `GitHub request: ${method} ${url} - ${error.code} ${error.status}`
     logger.debug({params}, msg)
     throw error
   })
-  octokit.hook.after('request', (result, options) => {
+  client.hook.after('request', (result, options) => {
     const {method, url, headers, ...params} = options
     const msg = `GitHub request: ${method} ${url} - ${result.meta.status}`
     logger.debug({params}, msg)

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -1,4 +1,4 @@
-export default function addPagination (octokit) {
+export function addPagination (octokit) {
   octokit.paginate = paginate.bind(null, octokit)
 }
 

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -1,3 +1,7 @@
+export default function addPagination (octokit) {
+  octokit.paginate = paginate.bind(null, octokit)
+}
+
 const defaultCallback = (response, done?) => response
 
 async function paginate (octokit, responsePromise, callback = defaultCallback) {
@@ -18,8 +22,4 @@ async function paginate (octokit, responsePromise, callback = defaultCallback) {
     collection = collection.concat(await callback(response, done))
   }
   return collection
-}
-
-export const addPagination = (octokit) => {
-  octokit.paginate = paginate.bind(null, octokit)
 }

--- a/src/github/rate-limiting.ts
+++ b/src/github/rate-limiting.ts
@@ -1,6 +1,6 @@
 const Bottleneck = require('bottleneck')
 
-export const addRateLimiting = (octokit, limiter) => {
+export default function addRateLimiting (octokit, limiter) {
   if (!limiter) {
     limiter = new Bottleneck(1, 1000)
   }

--- a/src/github/rate-limiting.ts
+++ b/src/github/rate-limiting.ts
@@ -1,6 +1,6 @@
 const Bottleneck = require('bottleneck')
 
-export default function addRateLimiting (octokit, limiter) {
+export function addRateLimiting (octokit, limiter) {
   if (!limiter) {
     limiter = new Bottleneck(1, 1000)
   }

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -1,7 +1,7 @@
 import * as express from 'express'
 import {EventEmitter} from 'promise-events'
 import {Context} from './context'
-import {GitHubAPI, OctokitWithPagination} from './github'
+import {GitHubAPI} from './github'
 import {logger} from './logger'
 import {LoggerWithTarget, wrapLogger} from './wrap-logger'
 
@@ -160,7 +160,7 @@ export class Robot {
    * @private
    */
   public async auth (id?: number, log = this.log) {
-    const github: OctokitWithPagination = GitHubAPI({
+    const github = GitHubAPI({
       baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
       debug: process.env.LOG_LEVEL === 'trace',
       logger: log.child({name: 'github', installation: String(id)})

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -1,10 +1,9 @@
 import * as express from 'express'
+import {EventEmitter} from 'promise-events'
 import {Context} from './context'
+import {GitHubAPI, OctokitWithPagination} from './github'
 import {logger} from './logger'
 import {LoggerWithTarget, wrapLogger} from './wrap-logger'
-
-  import {EventEmitter} from 'promise-events'
-import {GitHubAPI, OctokitWithPagination} from './github'
 
 // Some events can't get an authenticated client (#382):
 function isUnauthenticatedEvent (context) {

--- a/src/robot.ts
+++ b/src/robot.ts
@@ -4,7 +4,7 @@ import {logger} from './logger'
 import {LoggerWithTarget, wrapLogger} from './wrap-logger'
 
   import {EventEmitter} from 'promise-events'
-import {EnhancedGitHubClient as GitHubApi, OctokitWithPagination} from './github'
+import {GitHubAPI, OctokitWithPagination} from './github'
 
 // Some events can't get an authenticated client (#382):
 function isUnauthenticatedEvent (context) {
@@ -161,7 +161,7 @@ export class Robot {
    * @private
    */
   public async auth (id?: number, log = this.log) {
-    const github: OctokitWithPagination = GitHubApi({
+    const github: OctokitWithPagination = GitHubAPI({
       baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
       debug: process.env.LOG_LEVEL === 'trace',
       logger: log.child({name: 'github', installation: String(id)})

--- a/test/github.test.js
+++ b/test/github.test.js
@@ -1,8 +1,8 @@
-const {EnhancedGitHubClient} = require('../src/github')
+const {GitHubAPI} = require('../src/github')
 const nock = require('nock')
 const Bottleneck = require('bottleneck')
 
-describe('EnhancedGitHubClient', () => {
+describe('GitHubAPI', () => {
   let github
 
   beforeEach(() => {
@@ -14,11 +14,11 @@ describe('EnhancedGitHubClient', () => {
     // Set a shorter limiter, otherwise tests are _slow_
     const limiter = new Bottleneck(1, 1)
 
-    github = new EnhancedGitHubClient({ logger, limiter })
+    github = new GitHubAPI({ logger, limiter })
   })
 
   test('works without options', async () => {
-    github = new EnhancedGitHubClient()
+    github = new GitHubAPI()
     const user = {login: 'ohai'}
 
     nock('https://api.github.com').get('/user').reply(200, user)

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -1,4 +1,4 @@
-const GitHub = require('../../src/github').EnhancedGitHubClient
+const { GitHubAPI } = require('../../src/github')
 const nock = require('nock')
 const Bottleneck = require('bottleneck')
 
@@ -18,7 +18,7 @@ describe('github/graphql', () => {
     // Set a shorter limiter, otherwise tests are _slow_
     const limiter = new Bottleneck(1, 1)
 
-    github = new GitHub({ logger, limiter })
+    github = new GitHubAPI({ logger, limiter })
   })
 
   describe('query', () => {


### PR DESCRIPTION
This makes a few naming tweaks to Probot's GitHub API.

- Renames `OctokitWithPagination` to `GitHubAPI` - This was bothering me because it adds more than just pagination to the octokit client. Ideally, we would just extend the `Octokit` definitions, but I couldn't figure out a good way to do that.

- Drops `EnhancedGitHubClient` function with `GitHubAPI` function - So now `GitHubAPI` is both the function exported from `./github`, and the Octokit+extensions interface.

I'm still getting comfortable with TypeScript, so I'd love a detailed review from folks that are more familiar.