### PR TITLE
TypeScript: convert Context tests

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -43,7 +43,7 @@ export interface Result {
   }
 }
 
-export interface OctokitError {
+export interface OctokitError extends Error {
   code: number
   status: string
 }

--- a/test/__snapshots__/context.test.js.snap
+++ b/test/__snapshots__/context.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Context repo return error for context.repo() when repository doesn't exist 1`] = `"context.repo() is not supported for this webhook event."`;

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,41 +1,44 @@
 const fs = require('fs')
 const path = require('path')
-const {Context} = require('../src/context')
 
-describe('Context', function () {
+import {Context} from '../src/context'
+import {OctokitError} from '../src/github'
+
+describe('Context', () => {
   let event
   let context
 
-  beforeEach(function () {
+  beforeEach(() => {
     event = {
       event: 'push',
       payload: {
+        issue: {number: 4},
         repository: {
+          name: 'probot',
           owner: {login: 'bkeepers'},
-          name: 'probot'
         },
-        issue: {number: 4}
       }
     }
-    context = new Context(event)
+
+    context = new Context(event, {} as any, {} as any)
   })
 
   it('inherits the payload', () => {
     expect(context.payload).toBe(event.payload)
   })
 
-  describe('repo', function () {
-    it('returns attributes from repository payload', function () {
+  describe('repo', () => {
+    it('returns attributes from repository payload', () => {
       expect(context.repo()).toEqual({owner: 'bkeepers', repo: 'probot'})
     })
 
-    it('merges attributes', function () {
+    it('merges attributes', () => {
       expect(context.repo({foo: 1, bar: 2})).toEqual({
-        owner: 'bkeepers', repo: 'probot', foo: 1, bar: 2
+        bar: 2, foo: 1, owner: 'bkeepers', repo: 'probot',
       })
     })
 
-    it('overrides repo attributes', function () {
+    it('overrides repo attributes', () => {
       expect(context.repo({owner: 'muahaha'})).toEqual({
         owner: 'muahaha', repo: 'probot'
       })
@@ -43,42 +46,42 @@ describe('Context', function () {
 
     // The `repository` object on the push event has a different format than the other events
     // https://developer.github.com/v3/activity/events/types/#pushevent
-    it('properly handles the push event', function () {
+    it('properly handles the push event', () => {
       event.payload = require('./fixtures/webhook/push')
 
-      context = new Context(event)
+      context = new Context(event, {} as any, {} as any)
       expect(context.repo()).toEqual({owner: 'bkeepers-inc', repo: 'test'})
     })
 
-    it('return error for context.repo() when repository doesn\'t exist', function () {
+    it('return error for context.repo() when repository doesn\'t exist', () => {
       delete context.payload.repository
       try {
         context.repo()
       } catch (e) {
-        expect(e.message).toMatchSnapshot()
+        expect(e.message).toMatch('context.repo() is not supported')
       }
     })
   })
 
-  describe('issue', function () {
-    it('returns attributes from repository payload', function () {
+  describe('issue', () => {
+    it('returns attributes from repository payload', () => {
       expect(context.issue()).toEqual({owner: 'bkeepers', repo: 'probot', number: 4})
     })
 
-    it('merges attributes', function () {
+    it('merges attributes', () => {
       expect(context.issue({foo: 1, bar: 2})).toEqual({
-        owner: 'bkeepers', repo: 'probot', number: 4, foo: 1, bar: 2
+        bar: 2, foo: 1, number: 4, owner: 'bkeepers', repo: 'probot',
       })
     })
 
-    it('overrides repo attributes', function () {
+    it('overrides repo attributes', () => {
       expect(context.issue({owner: 'muahaha', number: 5})).toEqual({
-        owner: 'muahaha', repo: 'probot', number: 5
+        number: 5, owner: 'muahaha', repo: 'probot'
       })
     })
   })
 
-  describe('config', function () {
+  describe('config', () => {
     let github
 
     function readConfig (fileName) {
@@ -87,54 +90,64 @@ describe('Context', function () {
       return {data: {content: Buffer.from(content).toString('base64')}}
     }
 
-    beforeEach(function () {
+    beforeEach(() => {
       github = {
         repos: {
           getContent: jest.fn()
         }
       }
 
-      context = new Context(event, github)
+      context = new Context(event, github, {} as any)
     })
 
-    it('gets a valid configuration', async function () {
+    it('gets a valid configuration', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('basic.yml')))
       const config = await context.config('test-file.yml')
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
+        path: '.github/test-file.yml',
         repo: 'probot',
-        path: '.github/test-file.yml'
       })
       expect(config).toEqual({
-        foo: 5,
         bar: 7,
-        baz: 11
+        baz: 11,
+        foo: 5,
       })
     })
 
-    it('returns null when the file is missing', async function () {
-      const error = new Error('An error occurred')
-      error.code = 404
+    it('returns null when the file is missing', async () => {
+      const error: OctokitError = {
+        code: 404,
+        message: 'An error occurred',
+        name: 'OctokitError',
+        status: 'Not Found',
+      };
+
       github.repos.getContent = jest.fn().mockReturnValue(Promise.reject(error))
 
       expect(await context.config('test-file.yml')).toBe(null)
     })
 
-    it('returns the default config when the file is missing and default config is passed', async function () {
-      const error = new Error('An error occurred')
-      error.code = 404
+    it('returns the default config when the file is missing and default config is passed', async () => {
+      const error: OctokitError = {
+        code: 404,
+        message: 'An error occurred',
+        name: 'OctokitError',
+        status: 'Not Found',
+      };
+
       github.repos.getContent = jest.fn().mockReturnValue(Promise.reject(error))
       const defaultConfig = {
-        foo: 5,
         bar: 7,
-        baz: 11
+        baz: 11,
+        foo: 5,
       }
       const contents = await context.config('test-file.yml', defaultConfig)
       expect(contents).toEqual(defaultConfig)
     })
 
-    it('throws when the configuration file is malformed', async function () {
+    it('throws when the configuration file is malformed', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('malformed.yml')))
 
       let e
@@ -150,7 +163,7 @@ describe('Context', function () {
       expect(e.message).toMatch(/^end of the stream or a document separator/)
     })
 
-    it('throws when loading unsafe yaml', async function () {
+    it('throws when loading unsafe yaml', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(readConfig('evil.yml'))
 
       let e
@@ -166,7 +179,7 @@ describe('Context', function () {
       expect(e.message).toMatch(/unknown tag/)
     })
 
-    it('returns an empty object when the file is empty', async function () {
+    it('returns an empty object when the file is empty', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(readConfig('empty.yml'))
 
       const contents = await context.config('test-file.yml')
@@ -174,35 +187,35 @@ describe('Context', function () {
       expect(contents).toEqual({})
     })
 
-    it('overwrites default config settings', async function () {
+    it('overwrites default config settings', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('basic.yml')))
       const config = await context.config('test-file.yml', {foo: 10})
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
+        path: '.github/test-file.yml',
         repo: 'probot',
-        path: '.github/test-file.yml'
       })
       expect(config).toEqual({
-        foo: 5,
         bar: 7,
-        baz: 11
+        baz: 11,
+        foo: 5,
       })
     })
 
-    it('uses default settings to fill in missing options', async function () {
+    it('uses default settings to fill in missing options', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('missing.yml')))
       const config = await context.config('test-file.yml', {bar: 7})
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
+        path: '.github/test-file.yml',
         repo: 'probot',
-        path: '.github/test-file.yml'
       })
       expect(config).toEqual({
-        foo: 5,
         bar: 7,
-        baz: 11
+        baz: 11,
+        foo: 5,
       })
     })
   })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "allowJs": false,
-    "lib": ["es2017"],
+    "lib": ["es2015", "es2017"],
     "module": "commonjs",
     "moduleResolution": "node",
     "target": "es5",


### PR DESCRIPTION
This converts `test/context.test.js` to TypeScript. There's not really any other significant changes to get it passing besides adjusting where `OctokitError` extends `Error`. 