### PR TITLE
Rename robot to app

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -17,7 +17,7 @@ Now that we agree that nobody will get hurt, here are some tips to make your app
 
 ## Empathy
 
-Understanding and being aware of the what another person is thinking or feeling is critical to healthy relationships. This is true for interactions with humans as well as bots, and it works both ways. Empathy enhances our [ability to receive and process information](http://5a5f89b8e10a225a44ac-ccbed124c38c4f7a3066210c073e7d55.r9.cf1.rackcdn.com/files/pdfs/news/Empathy_on_the_Edge.pdf), and it helps us communicate more effectively.
+Understanding and being aware of the what another person is thinking or feeling is critical to healthy relationships. This is true for interactions with humans as well as apps, and it works both ways. Empathy enhances our [ability to receive and process information](http://5a5f89b8e10a225a44ac-ccbed124c38c4f7a3066210c073e7d55.r9.cf1.rackcdn.com/files/pdfs/news/Empathy_on_the_Edge.pdf), and it helps us communicate more effectively.
 
 Think about how how people will experience the interactions with your app.
 
@@ -27,7 +27,7 @@ The [uncanny valley](https://en.wikipedia.org/wiki/Uncanny_valley) is the hypoth
 
 ![uncanny valley](https://upload.wikimedia.org/wikipedia/commons/f/f0/Mori_Uncanny_Valley.svg)
 
-Your bot should be empathetic, but it shouldn't pretend to be human. It is a bot and everyone that interacts with it knows that.
+Your app should be empathetic, but it shouldn't pretend to be human. It is an app and everyone that interacts with it knows that.
 
 > - :smile: "Latest build failures: _{listing of build failures}_…"
 > - :cry: "Hey there! You asked for the build failures, so I went and dug them up for you:  _{listing of build failures}_ … Have a fantastic day!"

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -30,7 +30,7 @@ The [uncanny valley](https://en.wikipedia.org/wiki/Uncanny_valley) is the hypoth
 Your app should be empathetic, but it shouldn't pretend to be human. It is an app and everyone that interacts with it knows that.
 
 > - :smile: "Latest build failures: _{listing of build failures}_…"
-> - :cry: "Hey there! You asked for the build failures, so I went and dug them up for you:  _{listing of build failures}_ … Have a fantastic day!"
+> - :cry: "Hey there! You asked for the build failures, so I went and dug them up for you: _{listing of build failures}_ … Have a fantastic day!"
 
 ## Autonomy
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -51,7 +51,7 @@ And one of:
 Glitch lets you host node applications for free and edit them directly in your browser. It’s great for experimentation and entirely sufficient for simple apps.
 
 1. [Create a new app on Glitch](https://glitch.com/edit/#!/new-project).
-2. Click on your app name on the top-right, press on advanced options and then on `Import from GitHub` (You will need to login with your GitHub account to enable that option). Enter the full repository name you want to import, e.g. for the [welcome bot](https://github.com/behaviorbot/new-issue-welcome) it would be `behaviorbot/new-issue-welcome`. The `new-issue-welcome` bot is a great template to get started with your own bot, too!
+2. Click on your app name on the top-right, press on advanced options and then on `Import from GitHub` (You will need to login with your GitHub account to enable that option). Enter the full repository name you want to import, e.g. for the [welcome app](https://github.com/behaviorbot/new-issue-welcome) it would be `behaviorbot/new-issue-welcome`. The `new-issue-welcome` app is a great template to get started with your own app, too!
 3. Next open the `.env` file and replace its content with
    ```
    APP_ID=<your app id>
@@ -61,7 +61,7 @@ Glitch lets you host node applications for free and edit them directly in your b
    ```
    Replace the two `<...>` placeholders with the values from your app. The `.env` file cannot be accessed or seen by others.
 4. Press the `New File` button and enter `.data/private-key.pem`. Paste the content of your GitHub App’s `private-key.pem` in there and save it. Files in the `.data` folder cannot be seen or accessed by others, so your private key is safe.
-5. That’s it, your app should have already started :thumbsup: Press on the `Show` button on top and paste the URL as the value of `Webhook URL`. Ensure that you remove `/probot` from the end of the `Webhook URL` that was just pasted. 
+5. That’s it, your app should have already started :thumbsup: Press on the `Show` button on top and paste the URL as the value of `Webhook URL`. Ensure that you remove `/probot` from the end of the `Webhook URL` that was just pasted.
 
 Enjoy!
 
@@ -128,7 +128,7 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
 
-1. Your app should be up and running! For long term use, create an alias for your robot. After making an alias, you can swap to new deploy URLs with no downtime.
+1. Your app should be up and running! For long term use, create an alias for your app. After making an alias, you can swap to new deploy URLs with no downtime.
 
         $ now alias set https://your-generated-url.now.sh https://a-fancier-url.now.sh
 
@@ -143,11 +143,11 @@ The Probot website includes a list of [featured apps](https://probot.github.io/a
 
 ## Combining apps
 
-To deploy a bot that includes multiple apps, create a new app that has the apps listed as dependencies in `package.json`:
+To deploy multiple apps in one instance, create a new app that has the existing apps listed as dependencies in `package.json`:
 
 ```json
 {
-  "name": "my-probot",
+  "name": "my-probot-app",
   "private": true,
   "dependencies": {
     "probot-autoresponder": "probot/autoresponder",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -14,8 +14,8 @@ While Probot doesn't have an official extension API (yet), there are a handful o
 ```js
 const getConfig = require('probot-config')
 
-module.exports = robot => {
-  robot.on('push', async context => {
+module.exports = app => {
+  app.on('push', async context => {
     // Will look for 'test.yml' inside the '.github' folder
     const config = await getConfig(context, 'test.yml')
 
@@ -52,9 +52,9 @@ For example, users could add labels from comments by typing `/label in-progress`
 ```js
 const commands = require('probot-commands')
 
-module.exports = robot => {
+module.exports = app => {
   // Type `/label foo, bar` in a comment box for an Issue or Pull Request
-  commands(robot, 'label', (context, command) => {
+  commands(app, 'label', (context, command) => {
     const labels = command.arguments.split(/, */)
     return context.github.issues.addLabels(context.issue({labels}))
   })
@@ -70,13 +70,13 @@ For example, here is a contrived app that stores the number of times that commen
 ```js
 const metadata = require('probot-metadata')
 
-module.exports = robot => {
-  robot.on(['issues.edited', 'issue_comment.edited'], async context => {
+module.exports = app => {
+  app.on(['issues.edited', 'issue_comment.edited'], async context => {
     const kv = await metadata(context)
     kv.set('edits', kv.get('edits') || 1)
   })
 
-  robot.on('issues.closed', async context => {
+  app.on('issues.closed', async context => {
     const edits = await metadata(context).get('edits')
     context.github.issues.createComment(context.issue({
       body: `There were ${edits} edits to issues in this thread.`
@@ -92,10 +92,10 @@ module.exports = robot => {
 ```js
 const createScheduler = require('probot-scheduler')
 
-module.exports = robot => {
-  createScheduler(robot)
+module.exports = app => {
+  createScheduler(app)
 
-  robot.on('schedule.repository', context => {
+  app.on('schedule.repository', context => {
     // this event is triggered on an interval, which is 1 hr by default
   })
 }
@@ -110,8 +110,8 @@ Check out [stale](https://github.com/probot/stale) to see it in action.
 ```js
 const attachments = require('probot-attachments')
 
-module.exports = robot => {
-  robot.on('issue_comment.created', context => {
+module.exports = app => {
+  app.on('issue_comment.created', context => {
     return attachments(context).add({
       'title': 'Hello World',
       'title_link': 'https://example.com/hello'

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -15,8 +15,8 @@ Your app has access to an authenticated GitHub client that can be used to make A
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:
     //   {owner: 'yourname', repo: 'yourrepo', number: 123, body: 'Hello World!}
@@ -48,8 +48,8 @@ const addComment = `
   }
 `
 
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // Post a comment on the issue
     context.github.query(addComment, {
       id: context.payload.issue.node_id,

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -7,18 +7,18 @@ next: docs/development.md
 A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 
 ```js
-module.exports = robot => {
+module.exports = app => {
   // your code here
 }
 ```
 
-The `robot` parameter is an instance of [`Robot`](https://probot.github.io/api/latest/Robot.html) and gives you access to all of the bot goodness.
+The `app` parameter is an instance of [`Application`](https://probot.github.io/api/latest/Application.html) and gives you access to all of the GitHub goodness.
 
-`robot.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
+`app.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // A new issue was opened, what should we do with it?
     context.log(context.payload)
   })
@@ -30,8 +30,8 @@ The `context` passed to the event handler includes everything about the event th
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:
     //   {owner: 'yourname', repo: 'yourrepo', number: 123, body: 'Hello World!}

--- a/docs/http.md
+++ b/docs/http.md
@@ -4,18 +4,18 @@ next: docs/simulating-webhooks.md
 
 # HTTP Routes
 
-Calling `robot.route('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
+Calling `app.route('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
 
 ```js
-module.exports = robot => {
+module.exports = app => {
   // Get an express router to expose new HTTP endpoints
-  const app = robot.route('/my-app')
+  const route = app.route('/my-app')
 
   // Use any middleware
-  app.use(require('express').static('public'))
+  route.use(require('express').static('public'))
 
   // Add a new route
-  app.get('/hello-world', (req, res) => {
+  route.get('/hello-world', (req, res) => {
     res.end('Hello World')
   })
 }
@@ -23,6 +23,6 @@ module.exports = robot => {
 
 Visit https://localhost:3000/my-app/hello-world to access the endpoint.
 
-It is strongly encouraged to use the name of your package as the prefix so none of your routes or middleware conflict with other apps. For example, if [`probot/owners`](https://github.com/probot/owners) exposed an endpoint, the app would call `robot.route('/owners')` to prefix all endpoints with `/owners`.
+It is strongly encouraged to use the name of your package as the prefix so none of your routes or middleware conflict with other apps. For example, if [`probot/owners`](https://github.com/probot/owners) exposed an endpoint, the app would call `app.route('/owners')` to prefix all endpoints with `/owners`.
 
 See the [express documentation](http://expressjs.com/en/guide/routing.html) for more information.

--- a/docs/http.md
+++ b/docs/http.md
@@ -9,13 +9,13 @@ Calling `app.route('/my-app')` will return an [express](http://expressjs.com/) r
 ```js
 module.exports = app => {
   // Get an express router to expose new HTTP endpoints
-  const route = app.route('/my-app')
+  const router = app.route('/my-app')
 
   // Use any middleware
-  route.use(require('express').static('public'))
+  router.use(require('express').static('public'))
 
   // Add a new route
-  route.get('/hello-world', (req, res) => {
+  router.get('/hello-world', (req, res) => {
     res.end('Hello World')
   })
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -6,13 +6,13 @@ next: docs/pagination.md
 
 A good logger is a good developer's secret weapon. Probot comes with [bunyan](https://github.com/trentm/node-bunyan), which is a simple and fast logging library that supports some pretty sophisticated logging if you need it (hint: you will).
 
-`robot.log`, `context.log` in an event handler, and `req.log` in an HTTP request are all loggers that you can use to get more information about what your app is doing.
+`app.log`, `context.log` in an event handler, and `req.log` in an HTTP request are all loggers that you can use to get more information about what your app is doing.
 
 ```js
-module.exports = robot => {
-  robot.log('Yay, my app is loaded')
+module.exports = app => {
+  app.log('Yay, my app is loaded')
 
-  robot.on('issues.opened', context => {
+  app.on('issues.opened', context => {
     if (context.payload.issue.body.match(/bacon/)) {
       context.log('This issue is about bacon')
     } else {
@@ -20,7 +20,7 @@ module.exports = robot => {
     }
   })
 
-  robot.route().get('/hello-world', (req, res) => {
+  app.route().get('/hello-world', (req, res) => {
     req.log('Someone is saying hello')
   })
 }
@@ -30,19 +30,19 @@ When you start up your app with `npm start`, You should see your log message app
 
 <img width="753" alt="" src="https://user-images.githubusercontent.com/173/33234904-d43e7f14-d1f3-11e7-8dcb-6c47e58bd56b.png">
 
-`robot.log` will log messages at the `info` level, which is what your app should use for most relevant messages. Occasionally you will want to log more detailed information that is useful for debugging, but you might not want to see it all the time.
+`app.log` will log messages at the `info` level, which is what your app should use for most relevant messages. Occasionally you will want to log more detailed information that is useful for debugging, but you might not want to see it all the time.
 
 ```js
-module.exports = robot => {
+module.exports = app => {
   // …
-  robot.log.trace('Really low-level logging')
-  robot.log.debug({data: 'here'}, 'End-line specs on the rotary girder')
-  robot.log.info('Same as using `robot.log`')
+  app.log.trace('Really low-level logging')
+  app.log.debug({data: 'here'}, 'End-line specs on the rotary girder')
+  app.log.info('Same as using `app.log`')
 
   const err = new Error('Some error')
-  robot.log.warn(err, 'Uh-oh, this may not be good')
-  robot.log.error(err, 'Yeah, it was bad')
-  robot.log.fatal(err, 'Goodbye, cruel world!')
+  app.log.warn(err, 'Uh-oh, this may not be good')
+  app.log.error(err, 'Yeah, it was bad')
+  app.log.fatal(err, 'Goodbye, cruel world!')
 }
 ```
 
@@ -62,8 +62,8 @@ Set `LOG_FORMAT=json` to show log messages as structured JSON, which can then be
 For example, given this log:
 
 ```js
-module.exports = robot => {
-  robot.on('issue_comment.created', context => {
+module.exports = app => {
+  app.on('issue_comment.created', context => {
     context.log('Comment created')
   })
 }

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -7,8 +7,8 @@ next: docs/extensions.md
 Many GitHub API endpoints are paginated. The `github.paginate` method can be used to get each page of the results.
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', context => {
+module.exports = app => {
+  app.on('issues.opened', context => {
     context.github.paginate(
       context.github.issues.getAll(context.repo()),
       res => {
@@ -26,8 +26,8 @@ module.exports = robot => {
 The return value of the `github.paginate` callback will be used to accumulate results.
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     const allIssues = await context.github.paginate(
       context.github.issues.getAll(context.repo()),
       res => res.data
@@ -42,8 +42,8 @@ module.exports = robot => {
 Sometimes it is desirable to stop fetching pages after a certain condition has been satisfied. A second argument, `done`, is provided to the callback and can be used to stop pagination. After `done` is invoked, no additional pages will be fetched.
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', context => {
+module.exports = app => {
+  app.on('issues.opened', context => {
     context.github.paginate(
       context.github.issues.getAll(context.repo()),
       (res, done) => {

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -63,8 +63,8 @@ mongoose.connect(mongoUri, {
 // Register the mongoose model
 const People = require('./PeopleSchema')
 
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // Find all the people in the database
     const people = await People.find().exec()
 
@@ -115,8 +115,8 @@ function performQuery (query) {
   })
 }
 
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // Find all the people in the database
     const people = await performQuery('SELECT * FROM `people`')
 
@@ -154,8 +154,8 @@ firebase.initializeApp(config)
 
 const database = firebase.database()
 
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // Find all the people in the database
     const people = await database.ref('/people').once('value').then((snapshot) => {
       return snapshot.val()

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -6,26 +6,26 @@ next: docs/logging.md
 
 We highly recommend working in the style of [test-driven development](http://agiledata.org/essays/tdd.html) when creating probot apps. It is frustrating to constantly create real GitHub events in order to test an app. Redelivering webhooks is possible and can be accessed in your app's [settings](https://github.com/settings/apps) page under the **Advanced** tab. We do offer the above documented `simulate` method to help make this easier; however, by writing your tests first, you can avoid repeatedly recreating actual events from GitHub to check if your code is working.
 
-For our testing examples, we use [jest](https://facebook.github.io/jest/), but there are other options that can perform similar operations. Here's an example of creating a robot instance and mocking out the GitHub API:
+For our testing examples, we use [jest](https://facebook.github.io/jest/), but there are other options that can perform similar operations. Here's an example of creating an app instance and mocking out the GitHub API:
 
 ```js
-// Requiring probot allows us to mock out a robot instance
-const {createRobot} = require('probot')
+// Requiring probot allows us to get an Application instance
+const {Application} = require('probot')
 // Requiring our app
-const app = require('')
+const plugin = require('')
 // Create a fixtures folder in your test folder
 // Then put any larger testing payloads in there
 const payload = require('./fixtures/payload')
 
 describe('your-app', () => {
-  let robot
+  let app
   let github
 
   beforeEach(() => {
-    // Here we create a robot instance
-    robot = createRobot()
-    // Here we initialize the app on the robot instance
-    app(robot)
+    // Here we create an Application instance
+    app = new Application()
+    // Here we initialize the app
+    plugin(app)
     // This is an easy way to mock out the GitHub API
     github = {
       issues: {
@@ -34,8 +34,8 @@ describe('your-app', () => {
         }))
       }
     }
-    // Passes the mocked out GitHub API into out robot instance
-    robot.auth = () => Promise.resolve(github)
+    // Passes the mocked out GitHub API into out app instance
+    app.auth = () => Promise.resolve(github)
   })
 
   describe('your functionality', () => {
@@ -43,7 +43,7 @@ describe('your-app', () => {
       // Simulates delivery of a payload
       // payload.event is the X-GitHub-Event header sent by GitHub (for example "push")
       // payload.payload is the actual payload body
-      await robot.receive(payload)
+      await app.receive(payload)
       // This test would pass if in your main code you called `context.github.issues.createComment`
       expect(github.issues.createComment).toHaveBeenCalled()
     })

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -9,9 +9,9 @@ We highly recommend working in the style of [test-driven development](http://agi
 For our testing examples, we use [jest](https://facebook.github.io/jest/), but there are other options that can perform similar operations. Here's an example of creating an app instance and mocking out the GitHub API:
 
 ```js
-// Requiring probot allows us to get an Application instance
+// Requiring probot allows us to initialize an application
 const {Application} = require('probot')
-// Requiring our app
+// Requiring our app implementation
 const plugin = require('')
 // Create a fixtures folder in your test folder
 // Then put any larger testing payloads in there
@@ -22,7 +22,7 @@ describe('your-app', () => {
   let github
 
   beforeEach(() => {
-    // Here we create an Application instance
+    // Here we create an `Application` instance
     app = new Application()
     // Here we initialize the app
     plugin(app)

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -6,36 +6,36 @@ next: docs/github-api.md
 
 [GitHub webhooks](https://developer.github.com/webhooks/) are fired for almost every significant action that users take on GitHub, whether it's pushes to code, opening or closing issues, opening or merging pull requests, or commenting on a discussion.
 
-Many robots will spend their entire day responding to these actions. `robot.on` will listen for any GitHub webhook events:
+Many apps will spend their entire day responding to these actions. `app.on` will listen for any GitHub webhook events:
 
 ```js
-module.exports = robot => {
-  robot.on('push', async context => {
+module.exports = app => {
+  app.on('push', async context => {
     // Code was pushed to the repo, what should we do with it?
-    robot.log(context)
+    app.log(context)
   })
 }
 ```
 
-The robot can listen to any of the [GitHub webhook events](https://developer.github.com/webhooks/#events). The `context` object includes everything about the event that was triggered, and `context.payload` has the payload delivered by GitHub.
+The app can listen to any of the [GitHub webhook events](https://developer.github.com/webhooks/#events). The `context` object includes everything about the event that was triggered, and `context.payload` has the payload delivered by GitHub.
 
-Most events also include an "action". For example, the [`issues`](https://developer.github.com/v3/activity/events/types/#issuesevent) event has actions of `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `milestoned`, `demilestoned`, `closed`, and `reopened`. Often, your bot will only care about one type of action, so you can append it to the event name with a `.`:
+Most events also include an "action". For example, the [`issues`](https://developer.github.com/v3/activity/events/types/#issuesevent) event has actions of `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `milestoned`, `demilestoned`, `closed`, and `reopened`. Often, your app will only care about one type of action, so you can append it to the event name with a `.`:
 
 ```js
-module.exports = robot => {
-  robot.on('issues.opened', async context => {
+module.exports = app => {
+  app.on('issues.opened', async context => {
     // An issue was just opened.
   })
 }
 ```
 
-Sometimes you want to handle multiple webhook events the same way. `robot.on` can listen to a list of events and run the same callback:
+Sometimes you want to handle multiple webhook events the same way. `app.on` can listen to a list of events and run the same callback:
 
 ```js
-module.exports = robot => {
-  robot.on(['issues.opened', 'issues.edited'], async context => {
+module.exports = app => {
+  app.on(['issues.opened', 'issues.edited'], async context => {
     // An issue was opened or edited, what should we do with it?
-    robot.log(context)
+    app.log(context)
   })
 }
 ```
@@ -43,8 +43,8 @@ module.exports = robot => {
 You can also use the wildcard event (`*`) to listen for any event that your app is subscribed to:
 
 ```js
-module.exports = robot => {
-  robot.on(`*`, async context => {
+module.exports = app => {
+  app.on(`*`, async context => {
     context.log({event: context.event, action: context.payload.action})
   })
 }

--- a/src/application.ts
+++ b/src/application.ts
@@ -12,19 +12,19 @@ function isUnauthenticatedEvent (context) {
 }
 
 /**
- * The `robot` parameter available to apps
+ * The `app` parameter available to apps
  *
  * @property {logger} log - A logger
  */
-export class Robot {
+export class Application {
   public events: EventEmitter
   public app: () => string
-  public cache: RobotCache
+  public cache: Cache
   public router: express.Router
   public catchErrors?: boolean
   public log: LoggerWithTarget
 
-  constructor (options: RobotOptions) {
+  constructor (options: Options) {
     const opts = options || {}
     this.events = new EventEmitter()
     this.log = wrapLogger(logger, logger)
@@ -45,15 +45,15 @@ export class Robot {
    * expose HTTP endpoints
    *
    * @example
-   * module.exports = robot => {
+   * module.exports = app => {
    *   // Get an express router to expose new HTTP endpoints
-   *   const app = robot.route('/my-app');
+   *   const route = app.route('/my-app');
    *
    *   // Use any middleware
-   *   app.use(require('express').static(__dirname + '/public'));
+   *   route.use(require('express').static(__dirname + '/public'));
    *
    *   // Add a new route
-   *   app.get('/hello-world', (req, res) => {
+   *   route.get('/hello-world', (req, res) => {
    *     res.end('Hello World');
    *   });
    * };
@@ -85,16 +85,16 @@ export class Robot {
    * Often, your bot will only care about one type of action, so you can append
    * it to the event name with a `.`, like `issues.closed`.
    *
-   * @param {Robot~webhookCallback} callback - a function to call when the
+   * @param {Application~webhookCallback} callback - a function to call when the
    * webhook is received.
    *
    * @example
    *
-   * robot.on('push', context => {
+   * app.on('push', context => {
    *   // Code was just pushed.
    * });
    *
-   * robot.on('issues.opened', context => {
+   * app.on('issues.opened', context => {
    *   // An issue was just opened.
    * });
    */
@@ -138,15 +138,15 @@ export class Robot {
    *
    * You'll probably want to use `context.github` instead.
    *
-   * **Note**: `robot.auth` is asynchronous, so it needs to be prefixed with a
+   * **Note**: `app.auth` is asynchronous, so it needs to be prefixed with a
    * [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
    * to wait for the magic to happen.
    *
    * @example
    *
-   *  module.exports = function(robot) {
-   *    robot.on('issues.opened', async context => {
-   *      const github = await robot.auth();
+   *  module.exports = (app) => {
+   *    app.on('issues.opened', async context => {
+   *      const github = await app.auth();
    *    });
    *  };
    *
@@ -183,8 +183,6 @@ export class Robot {
   }
 }
 
-export const createRobot = (options: RobotOptions) => new Robot(options)
-
 export interface WebhookEvent {
   event: string
   id: number
@@ -195,32 +193,32 @@ export interface WebhookEvent {
 }
 
 // The TypeScript definition for cache-manager does not export the Cache interface so we recreate it here
-export interface RobotCache {
-  wrap<T>(key: string, wrapper: (callback: (error: any, result: T) => void) => any, options: RobotCacheConfig): Promise<any>;
+export interface Cache {
+  wrap<T>(key: string, wrapper: (callback: (error: any, result: T) => void) => any, options: CacheConfig): Promise<any>;
 }
-export interface RobotCacheConfig {
+export interface CacheConfig {
     ttl: number;
 }
 
-export interface RobotOptions {
+export interface Options {
   app: () => string
-  cache: RobotCache
+  cache: Cache
   router?: express.Router
   catchErrors: boolean
 }
 
 /**
  * Do the thing
- * @callback Robot~webhookCallback
+ * @callback Application~webhookCallback
  * @param {Context} context - the context of the event that was triggered,
  *   including `context.payload`, and helpers for extracting information from
  *   the payload, which can be passed to GitHub API calls.
  *
  *  ```js
- *  module.exports = robot => {
- *    robot.on('push', context => {
+ *  module.exports = app => {
+ *    app.on('push', context => {
  *      // Code was pushed to the repo, what should we do with it?
- *      robot.log(context);
+ *      app.log(context);
  *    });
  *  };
  *  ```

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -16,13 +16,13 @@
  *
  * @example
  *
- * robot.log("This is an info message");
- * robot.log.debug("…so is this");
- * robot.log.trace("Now we're talking");
- * robot.log.info("I thought you should know…");
- * robot.log.warn("Woah there");
- * robot.log.error("ETOOMANYLOGS");
- * robot.log.fatal("Goodbye, cruel world!");
+ * app.log("This is an info message");
+ * app.log.debug("…so is this");
+ * app.log.trace("Now we're talking");
+ * app.log.info("I thought you should know…");
+ * app.log.warn("Woah there");
+ * app.log.error("ETOOMANYLOGS");
+ * app.log.fatal("Goodbye, cruel world!");
  */
 
 import * as Logger from 'bunyan'

--- a/src/plugins/default.ts
+++ b/src/plugins/default.ts
@@ -1,10 +1,10 @@
 import * as path from 'path'
-import {Robot} from '../robot'
+import {Application} from '../application'
 
-export = (robot: Robot) => {
-  const app = robot.route()
+export = (app: Application) => {
+  const route = app.route()
 
-  app.get('/probot', (req, res) => {
+  route.get('/probot', (req, res) => {
     let pkg
     try {
       pkg = require(path.join(process.cwd(), 'package.json'))
@@ -14,5 +14,5 @@ export = (robot: Robot) => {
 
     res.render('probot.hbs', pkg)
   })
-  app.get('/', (req, res, next) => res.redirect('/probot'))
+  route.get('/', (req, res, next) => res.redirect('/probot'))
 }

--- a/src/plugins/sentry.ts
+++ b/src/plugins/sentry.ts
@@ -1,16 +1,16 @@
 import * as Raven from 'raven'
-import {Robot} from '../robot'
+import {Application} from '../application'
 const sentryStream = require('bunyan-sentry-stream')
 
-export = (robot: Robot) => {
+export = (app: Application) => {
   // If sentry is configured, report all logged errors
   if (process.env.SENTRY_DSN) {
-    robot.log.debug(process.env.SENTRY_DSN, 'Errors will be reported to Sentry')
+    app.log.debug(process.env.SENTRY_DSN, 'Errors will be reported to Sentry')
     Raven.disableConsoleAlerts()
     Raven.config(process.env.SENTRY_DSN, {
       autoBreadcrumbs: true
     }).install()
 
-    robot.log.target.addStream(sentryStream(Raven))
+    app.log.target.addStream(sentryStream(Raven))
   }
 }

--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -3,8 +3,8 @@ import {Logger} from './'
 // Return a function that defaults to "info" level, and has properties for
 // other levels:
 //
-//     robot.log("info")
-//     robot.log.trace("verbose details");
+//     app.log("info")
+//     app.log.trace("verbose details");
 //
 export const wrapLogger = (logger: Logger, baseLogger?: Logger): LoggerWithTarget => {
   const fn = logger.info.bind(logger)

--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,7 +1,7 @@
-module.exports = robot => {
-  robot.log('loaded app')
+module.exports = app => {
+  app.log('loaded app')
 
-  robot.on('issue_comment.created', context => {
+  app.on('issue_comment.created', context => {
     context.log('Comment created')
   })
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -18,11 +18,11 @@ describe('Probot', () => {
   })
 
   describe('webhook delivery', () => {
-    it('forwards webhooks to the robot', async () => {
-      const robot = probot.load(() => {})
-      robot.receive = jest.fn()
+    it('forwards webhooks to the app', async () => {
+      const app = probot.load(() => {})
+      app.receive = jest.fn()
       await probot.webhook.receive(event)
-      expect(robot.receive).toHaveBeenCalledWith({ event: event.name, payload: event.payload })
+      expect(app.receive).toHaveBeenCalledWith({ event: event.name, payload: event.payload })
     })
 
     it('responds with the correct error if webhook secret is wrong', async () => {
@@ -50,27 +50,27 @@ describe('Probot', () => {
 
   describe('server', () => {
     it('prefixes paths with route name', () => {
-      probot.load(robot => {
-        const app = robot.route('/my-plugin')
-        app.get('/foo', (req, res) => res.end('foo'))
+      probot.load(app => {
+        const route = app.route('/my-plugin')
+        route.get('/foo', (req, res) => res.end('foo'))
       })
 
       return request(probot.server).get('/my-plugin/foo').expect(200, 'foo')
     })
 
     it('allows routes with no path', () => {
-      probot.load(robot => {
-        const app = robot.route()
-        app.get('/foo', (req, res) => res.end('foo'))
+      probot.load(app => {
+        const route = app.route()
+        route.get('/foo', (req, res) => res.end('foo'))
       })
 
       return request(probot.server).get('/foo').expect(200, 'foo')
     })
 
     it('allows you to overwrite the root path', () => {
-      probot.load(robot => {
-        const app = robot.route()
-        app.get('/', (req, res) => res.end('foo'))
+      probot.load(app => {
+        const route = app.route()
+        route.get('/', (req, res) => res.end('foo'))
       })
 
       return request(probot.server).get('/').expect(200, 'foo')
@@ -78,15 +78,15 @@ describe('Probot', () => {
 
     it('isolates plugins from affecting eachother', async () => {
       ['foo', 'bar'].forEach(name => {
-        probot.load(robot => {
-          const app = robot.route('/' + name)
+        probot.load(app => {
+          const route = app.route('/' + name)
 
-          app.use(function (req, res, next) {
+          route.use(function (req, res, next) {
             res.append('X-Test', name)
             next()
           })
 
-          app.get('/hello', (req, res) => res.end(name))
+          route.get('/hello', (req, res) => res.end(name))
         })
       })
 
@@ -105,10 +105,10 @@ describe('Probot', () => {
       // eslint-disable-next-line handle-callback-err
       probot.server.use((err, req, res, next) => { })
 
-      probot.load(robot => {
-        const app = robot.route()
-        app.get('/webhook', (req, res) => res.end('get-webhook'))
-        app.post('/webhook', (req, res) => res.end('post-webhook'))
+      probot.load(app => {
+        const route = app.route()
+        route.get('/webhook', (req, res) => res.end('get-webhook'))
+        route.post('/webhook', (req, res) => res.end('post-webhook'))
       })
 
       // GET requests should succeed
@@ -150,8 +150,8 @@ describe('Probot', () => {
   describe('receive', () => {
     it('forwards events to each plugin', async () => {
       const spy = jest.fn()
-      const robot = probot.load(robot => robot.on('push', spy))
-      robot.auth = jest.fn().mockReturnValue(Promise.resolve({}))
+      const app = probot.load(app => app.on('push', spy))
+      app.auth = jest.fn().mockReturnValue(Promise.resolve({}))
 
       await probot.receive(event)
 
@@ -160,7 +160,7 @@ describe('Probot', () => {
   })
 
   describe('ghe support', function () {
-    let robot
+    let app
 
     beforeEach(() => {
       process.env.GHE_HOST = 'notreallygithub.com'
@@ -169,7 +169,7 @@ describe('Probot', () => {
         .defaultReplyHeaders({'Content-Type': 'application/json'})
         .get('/app/installations').reply(200, ['I work!'])
 
-      robot = helper.createRobot()
+      app = helper.createApp()
     })
 
     afterEach(() => {
@@ -179,14 +179,14 @@ describe('Probot', () => {
     it('requests from the correct API URL', async () => {
       const spy = jest.fn()
 
-      const plugin = async robot => {
-        const github = await robot.auth()
+      const plugin = async app => {
+        const github = await app.auth()
         const res = await github.apps.getInstallations({})
         return spy(res)
       }
 
-      await plugin(robot)
-      await robot.receive(event)
+      await plugin(app)
+      await app.receive(event)
       expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
     })
   })

--- a/test/plugins/default.test.js
+++ b/test/plugins/default.test.js
@@ -4,16 +4,12 @@ const plugin = require('../../src/plugins/default')
 const helper = require('./helper')
 
 describe('default plugin', function () {
-  let server, robot
+  let server, app
 
   beforeEach(async () => {
-    robot = helper.createRobot()
-
-    await plugin(robot)
-
+    app = helper.createApp(plugin)
     server = express()
-
-    server.use(robot.router)
+    server.use(app.router)
   })
 
   describe('GET /probot', () => {

--- a/test/plugins/helper.js
+++ b/test/plugins/helper.js
@@ -1,14 +1,16 @@
 // FIXME: move this to a test helper that can be used by other apps
 
 const cacheManager = require('cache-manager')
-const {createRobot} = require('../../src')
+const {Application} = require('../../src')
 
 const cache = cacheManager.caching({store: 'memory'})
 
-const app = jest.fn().mockReturnValue('test')
+const jwt = jest.fn().mockReturnValue('test')
 
 module.exports = {
-  createRobot () {
-    return createRobot({app, cache})
+  createApp (plugin = () => {}) {
+    const app = new Application({app: jwt, cache})
+    plugin(app)
+    return app
   }
 }

--- a/test/plugins/sentry.test.js
+++ b/test/plugins/sentry.test.js
@@ -5,10 +5,10 @@ const plugin = require('../../src/plugins/sentry')
 const helper = require('./helper')
 
 describe('sentry', () => {
-  let robot
+  let app
 
   beforeEach(async () => {
-    robot = helper.createRobot()
+    app = helper.createApp()
   })
 
   beforeEach(() => {
@@ -20,7 +20,7 @@ describe('sentry', () => {
     test('throws an error', () => {
       process.env.SENTRY_DSN = 1233
       expect(() => {
-        plugin(robot)
+        plugin(app)
       }).toThrow(/Invalid Sentry DSN: 1233/)
     })
   })
@@ -28,13 +28,13 @@ describe('sentry', () => {
   describe('with a SENTRY_DSN', () => {
     beforeEach(() => {
       process.env.SENTRY_DSN = 'https://user:pw@sentry.io/123'
-      plugin(robot)
+      plugin(app)
       Raven.captureException = jest.fn()
     })
 
     test('sends reported errors to sentry', () => {
       const err = new Error('test message')
-      robot.log.error(err)
+      app.log.error(err)
 
       expect(Raven.captureException).toHaveBeenCalledWith(err, expect.objectContaining({
         extra: expect.anything()

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -6,11 +6,13 @@ const plugin = require('../../src/plugins/stats')
 const helper = require('./helper')
 
 describe('stats', function () {
-  let robot, server
+  let app, server
 
   beforeEach(() => {
     // Clean up env variable
     delete process.env.DISABLE_STATS
+
+    server = express()
   })
 
   describe('GET /probot/stats', () => {
@@ -24,12 +26,8 @@ describe('stats', function () {
           {private: false, stargazers_count: 2}
         ]})
 
-      robot = helper.createRobot()
-
-      await plugin(robot)
-
-      server = express()
-      server.use(robot.router)
+      app = helper.createApp(plugin)
+      server.use(app.router)
     })
 
     it('returns installation count and popular accounts', () => {
@@ -42,12 +40,8 @@ describe('stats', function () {
     beforeEach(async () => {
       process.env.DISABLE_STATS = 'true'
 
-      robot = helper.createRobot()
-
-      await plugin(robot)
-
-      server = express()
-      server.use(robot.router)
+      app = helper.createApp(plugin)
+      server.use(app.router)
     })
 
     it('/probot/stats returns 404', () => {
@@ -67,12 +61,8 @@ describe('stats', function () {
           {private: false, stargazers_count: 2}
         ]})
 
-      robot = helper.createRobot()
-
-      await plugin(robot)
-
-      server = express()
-      server.use(robot.router)
+      app = helper.createApp(plugin)
+      server.use(app.router)
     })
 
     it('returns installation count and popular accounts while exclusing spammy users', () => {


### PR DESCRIPTION
I don't like the word "bot" for most purposes (nevermind the name "Pro**bot**", we'll deal with that later).

A "bot" is software that mimics a human, but maybe more efficiently, cheaply, or dependably (pick two). We tend to personify bots, turning them into an "algorithm with eyes", as @galaxykate calls them.

Conversely, an "app" is software that is _used by_ a human. We aren't tempted to make it act like a human, but instead embrace the affordances of the environment that the app runs in.

So why don't I like the word "bot"? The reason is pretty simple: rather than encouraging people to write software that mimics a human, I think we should be encouraging people to write apps that do something a human _can't_ do. Some apps will act like bots, but it should be the exception rather than the rule.

---

We've already been discouraging the word bot on the [apps on the probot.github.io website](http://probot.github.io/apps). This PR renames `robot` and `bot` to `application` and `app` in both the internals and the documentation to start to discourage people from using the word 'bot' at all to describe what they are building.

Before:

```js
module.exports = robot => {
  robot.on('issues.opened', context => {
    context.log('hello world')
  })
}
```

After:
```js
module.exports = app => {
  app.on('issues.opened', context => {
    context.log('hello world')
  })
}
```


> Note! This PR is against #540 to try to reduce merge conflicts, so I'm going to let it sit until the TypeScript changes are in master.