### PR TITLE
Disable codecov comments

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,6 +8,4 @@ coverage:
       default:
         threshold: 3
 
-comment:
-  layout: diff
-  require_changes: yes
+comment: false


### PR DESCRIPTION
I don't find the comments very valuable. If coverage falls below the threshold then the status will be failing and you can click through to see the results.