### PR TITLE
add env config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,6 @@
-# Environmental Configuration
+# Environment Configuration
 
-When developing a Probot App, you will need to have several different fields in a `.env` file which specify environmental variables. Here are some common use cases:
+When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
 ```
 WEBHOOK_PROXY_URL='https://smee.io/yourcustomurl'
@@ -20,7 +20,7 @@ PRIVATE_KEY_PATH=/path/to/private/key #OPTIONAL
 ```
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
-Some less common environmental variables are:
+Some less common environment variables are:
 
 ```
 LOG_LEVEL=debug #OPTIONAL

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -47,3 +47,5 @@ SENTRY_DSN='https://user:pw@sentry.io/1234' #OPTIONAL
 LOG_FORMAT=json # OPTIONAL
 # By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 ```
+
+For more information on the formatting conventions and rules of `.env` files, check out [the npm documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -24,8 +24,8 @@ LOG_LEVEL | debug | Optional | The default log level is `info`, but you can also
 IGNORED_ACCOUNTS | 'spammyUser,abusiveUser' | Optional | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
 DISABLE_STATS | true | Optional | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
 GHE_HOST | 'fake.github-enterprise.com' | Optional | Allows for a Probot App to be run on a GitHub Enterprise instance.
-PORT | 3000 | Optional | The port on which Probot will start a local server on.
-WEBHOOK_PATH | '/webhook' | Optional | The URL path which will recieve webhooks
+PORT | 5000 | Optional | The port on which Probot will start a local server on. By default, this is 3000.
+WEBHOOK_PATH | '/webhook' | Optional | The URL path which will recieve webhooks. By default, this is `'/'`.
 SENTRY_DSN | 'https://user:pw@sentry.io/1234' | Optional | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
 LOG_FORMAT | json |  Optional | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,50 +2,28 @@
 
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
-```
-WEBHOOK_PROXY_URL='https://smee.io/yourcustomurl'
-# This is used to allow smee to communicate as your Webhook URL
+Variable | Sample Value | Required | Description
+---|---
+WEBHOOK_PROXY_URL | 'https://smee.io/yourcustomurl'| Required | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started.
+WEBHOOK_SECRET | development | Optional | The webhook secret used when creating a GitHub App
+APP_ID | 1234 | Required | The App ID assigned to your GitHub App
+PRIVATE_KEY | SECRETS | Optional | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App.
+PRIVATE_KEY_PATH | /path/to/private/key | Optional | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory.
 
-WEBHOOK_SECRET=development #OPTIONAL
-# This is the webhook secret used when creating a GitHub App
-
-APP_ID=1234
-# This is the App ID assigned to your GitHub App
-
-PRIVATE_KEY=SECRETS #OPTIONAL
-# This is your private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key.
-
-PRIVATE_KEY_PATH=/path/to/private/key #OPTIONAL
-# This is the path to your private key.
-```
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
 Some less common environment variables are:
 
-```
-LOG_LEVEL=debug #OPTIONAL
-# The default log level is `info`, but you can also change it to trace, debug, or warn. This affects the verbosity of the logging Probot provides when running your app.
+Variable | Sample Value | Required | Description
+---|---
+LOG_LEVEL | debug | Optional | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
+IGNORED_ACCOUNTS | 'spammyUser,abusiveUser' | Optional | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+DISABLE_STATS | true | Optional | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
+GHE_HOST | 'fake.github-enterprise.com' | Optional | Allows for a Probot App to be run on a GitHub Enterprise instance.
+PORT | 3000 | Optional | The port on which Probot will start a local server on.
+WEBHOOK_PATH | '/webhook' | Optional | The URL path which will recieve webhooks
+SENTRY_DSN | 'https://user:pw@sentry.io/1234' | Optional | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
+LOG_FORMAT | json |  Optional | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 
-IGNORED_ACCOUNTS='spammyUser,abusiveUser' #OPTIONAL
-# This option is specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
-
-DISABLE_STATS=true #OPTIONAL
-# This option allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
-
-GHE_HOST='fake.github-enterprise.com' #OPTIONAL
-# This allows for a Probot App to be run on a GitHub Enterprise instance.
-
-PORT=3000 #OPTIONAL
-# The port on which Probot will start a local server on.
-
-WEBHOOK_PATH='/webhook' #OPTIONAL
-# This is the URL path which will recieve webhooks
-
-SENTRY_DSN='https://user:pw@sentry.io/1234' #OPTIONAL
-# Logs all errors to Sentry for error tracking.
-
-LOG_FORMAT=json # OPTIONAL
-# By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
-```
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,49 @@
+# Environmental Configuration
+
+When developing a Probot App, you will need to have several different fields in a `.env` file which specify environmental variables. Here are some common use cases:
+
+```
+WEBHOOK_PROXY_URL=https://smee.io/yourcustomurl
+# This is used to allow smee to communicate as your Webhook URL
+
+WEBHOOK_SECRET=development #OPTIONAL
+# This is the webhook secret used when creating a GitHub App
+
+APP_ID=1234
+# This is the App ID assigned to your GitHub App
+
+PRIVATE_KEY=SECRETS #OPTIONAL
+# This is your private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key.
+
+PRIVATE_KEY_PATH=/path/to/private/key #OPTIONAL
+# This is the path to your private key.
+```
+For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
+
+Some less common environmental variables are:
+
+```
+LOG_LEVEL=debug #OPTIONAL
+# The default log level is `info`, but you can also change it to trace, debug, or warn. This affects the verbosity of the logging Probot provides when running your app.
+
+IGNORED_ACCOUNTS='spammyUser,abusiveUser' #OPTIONAL
+# This option is specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+
+DISABLE_STATS=true #OPTIONAL
+# This option allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
+
+GHE_HOST=fake.github-enterprise.com #OPTIONAL
+# This allows for a Probot App to be run on a GitHub Enterprise instance.
+
+PORT=3000 #OPTIONAL
+# The port on which Probot will start a local server on.
+
+WEBHOOK_PATH=/webhook #OPTIONAL
+# This is the URL of the path which will recieve webhooks
+
+SENTRY_DSN='https://user:pw@sentry.io/1234' #OPTIONAL
+# Logs all errors to Sentry for error tracking.
+
+LOG_FORMAT=json # OPTIONAL
+# By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
+```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,7 +7,7 @@ next: docs/deployment.md
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
 Variable | Sample Value | Required | Description
----|---
+---|---|---|---
 WEBHOOK_PROXY_URL | 'https://smee.io/yourcustomurl'| Required | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started.
 WEBHOOK_SECRET | development | Optional | The webhook secret used when creating a GitHub App
 APP_ID | 1234 | Required | The App ID assigned to your GitHub App
@@ -19,7 +19,7 @@ For more on the set up of these items, check out [Configuring a GitHub App](http
 Some less common environment variables are:
 
 Variable | Sample Value | Required | Description
----|---
+---|---|---|---
 LOG_LEVEL | debug | Optional | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
 IGNORED_ACCOUNTS | 'spammyUser,abusiveUser' | Optional | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
 DISABLE_STATS | true | Optional | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -3,7 +3,7 @@
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environmental variables. Here are some common use cases:
 
 ```
-WEBHOOK_PROXY_URL=https://smee.io/yourcustomurl
+WEBHOOK_PROXY_URL='https://smee.io/yourcustomurl'
 # This is used to allow smee to communicate as your Webhook URL
 
 WEBHOOK_SECRET=development #OPTIONAL
@@ -32,14 +32,14 @@ IGNORED_ACCOUNTS='spammyUser,abusiveUser' #OPTIONAL
 DISABLE_STATS=true #OPTIONAL
 # This option allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
 
-GHE_HOST=fake.github-enterprise.com #OPTIONAL
+GHE_HOST='fake.github-enterprise.com' #OPTIONAL
 # This allows for a Probot App to be run on a GitHub Enterprise instance.
 
 PORT=3000 #OPTIONAL
 # The port on which Probot will start a local server on.
 
-WEBHOOK_PATH=/webhook #OPTIONAL
-# This is the URL of the path which will recieve webhooks
+WEBHOOK_PATH='/webhook' #OPTIONAL
+# This is the URL path which will recieve webhooks
 
 SENTRY_DSN='https://user:pw@sentry.io/1234' #OPTIONAL
 # Logs all errors to Sentry for error tracking.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,4 +48,4 @@ LOG_FORMAT=json # OPTIONAL
 # By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 ```
 
-For more information on the formatting conventions and rules of `.env` files, check out [the npm documentation](https://www.npmjs.com/package/dotenv#rules).
+For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,3 +1,7 @@
+---
+next: docs/deployment.md
+---
+
 # Environment Configuration
 
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -1,5 +1,5 @@
 ---
-next: docs/deployment.md
+next: docs/configuration.md
 ---
 
 # Extensions


### PR DESCRIPTION
The more I thought about https://github.com/probot/probot/issues/534, the more I saw it as a great opportunity to add docs about all of our different configuration options.

I purposefully left out any variables specific to the [persistence database stuff](https://github.com/probot/probot/blob/master/docs/persistence.md) or the [deployment stuff](https://github.com/probot/probot/blob/master/docs/deployment.md) as well as the `SUBDOMAIN` (localtunnel relic) variable since we are deprecating it.

I'm not sure the best place for this on the website in the ordering of other docs, but preferably somewhere hidden, since many of these options are powerful as well as unnecessary. (I still need to place it somewhere in the doc ordering with a `next` block at the top).

Would love feedback/thoughts @probot/maintainers 🙏🏼