### PR TITLE
Remove noImplicitAny and add types to params

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,14 @@
       }
     }
   },
-  "keywords": ["probot", "github-apps", "github", "automation", "robots", "workflow"],
+  "keywords": [
+    "probot",
+    "github-apps",
+    "github",
+    "automation",
+    "robots",
+    "workflow"
+  ],
   "bugs": "https://github.com/probot/probot/issues",
   "homepage": "https://probot.github.io",
   "author": "Brandon Keepers",
@@ -83,7 +90,8 @@
     "promise-events": "^0.1.3",
     "raven": "^2.4.2",
     "resolve": "^1.4.0",
-    "semver": "^5.5.0"
+    "semver": "^5.5.0",
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.4",
@@ -100,6 +108,7 @@
     "@types/resolve": "^0.0.4",
     "@types/semver": "^5.4.0",
     "@types/supertest": "^2.0.4",
+    "@types/uuid": "^3.4.3",
     "connect-sse": "^1.2.0",
     "eslint": "^4.18.2",
     "eslint-plugin-markdown": "^1.0.0-beta.7",

--- a/src/@types/promise-events/index.d.ts
+++ b/src/@types/promise-events/index.d.ts
@@ -1,0 +1,6 @@
+declare module "promise-events" {
+    class EventEmitter {
+        emit<T = void>(event: string | symbol, ...args: any[]): Promise<T>;
+        on<T = void>(event: string | symbol, handler: (...args: any[]) => Promise<T>): void;
+    }
+}

--- a/src/application.ts
+++ b/src/application.ts
@@ -63,7 +63,7 @@ export class Application {
    * @param {string} path - the prefix for the routes
    * @returns {@link http://expressjs.com/en/4x/api.html#router|express.Router}
    */
-  public route (path?: string) {
+  public route (path?: string): express.Router {
     if (path) {
       const router = express.Router()
       this.router.use(path, router)
@@ -157,7 +157,7 @@ export class Application {
    * @returns {Promise<github>} - An authenticated GitHub API client
    * @private
    */
-  public async auth (id?: number, log = this.log) {
+  public async auth (id?: number, log = this.log): Promise<GitHubAPI> {
     const github = GitHubAPI({
       baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
       debug: process.env.LOG_LEVEL === 'trace',

--- a/src/application.ts
+++ b/src/application.ts
@@ -6,7 +6,7 @@ import {logger} from './logger'
 import {LoggerWithTarget, wrapLogger} from './wrap-logger'
 
 // Some events can't get an authenticated client (#382):
-function isUnauthenticatedEvent (context) {
+function isUnauthenticatedEvent (context: Context) {
   return !context.payload.installation ||
     (context.event === 'installation' && context.payload.action === 'deleted')
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -15,9 +15,11 @@ export class Context {
   public github: GitHubAPI
   public log: LoggerWithTarget
   public payload!: WebhookPayloadWithRepository
+  public event: any
 
   constructor (event:any, github:GitHubAPI, log:LoggerWithTarget) {
     Object.assign(this, event)
+    this.event = event
     this.id = event.id
     this.github = github
     this.log = log

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -1,6 +1,6 @@
 import {GitHubAPI, Headers, Variables} from './'
 
-export function addGraphQL (client) {
+export function addGraphQL (client: GitHubAPI) {
   client.query = graphql.bind(null, client)
 }
 
@@ -29,7 +29,7 @@ class GraphQLError extends Error {
   public query: string
   public variables: Variables
 
-  constructor (errors, query: string, variables: Variables) {
+  constructor (errors: Error[], query: string, variables: Variables) {
     super(JSON.stringify(errors))
     this.name = 'GraphQLError'
     this.query = query

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -57,7 +57,7 @@ export interface GitHubAPI extends Octokit {
     after: (when: 'request', callback: (result: Result, options: RequestOptions) => void) => void
   }
 
-  request: (RequestOptions) => Promise<Octokit.AnyResponse>
+  request: (RequestOptions: RequestOptions) => Promise<Octokit.AnyResponse>
   query: (query: string, variables?: Variables, headers?: Headers) => Promise<Octokit.AnyResponse>
 }
 

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -1,11 +1,14 @@
-export function addPagination (octokit) {
+import {AnyResponse} from "@octokit/rest"
+import {GitHubAPI} from './'
+
+export function addPagination (octokit: GitHubAPI) {
   octokit.paginate = paginate.bind(null, octokit)
 }
 
-const defaultCallback = (response, done?) => response
+const defaultCallback = (response: Promise<AnyResponse>, done?: () => void) => response
 
-async function paginate (octokit, responsePromise, callback = defaultCallback) {
-  let collection = []
+async function paginate (octokit: GitHubAPI, responsePromise, callback = defaultCallback) {
+  let collection: any[] = []
   let getNextPage = true
 
   const done = () => {

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -7,7 +7,7 @@ export function addPagination (octokit: GitHubAPI) {
 
 const defaultCallback = (response: Promise<AnyResponse>, done?: () => void) => response
 
-async function paginate (octokit: GitHubAPI, responsePromise, callback = defaultCallback) {
+async function paginate (octokit: GitHubAPI, responsePromise: any, callback = defaultCallback) {
   let collection: any[] = []
   let getNextPage = true
 

--- a/src/github/rate-limiting.ts
+++ b/src/github/rate-limiting.ts
@@ -1,6 +1,7 @@
-const Bottleneck = require('bottleneck')
+import Bottleneck from 'bottleneck'
+import {GitHubAPI} from './'
 
-export function addRateLimiting (octokit, limiter) {
+export function addRateLimiting (octokit: GitHubAPI, limiter: Bottleneck) {
   if (!limiter) {
     limiter = new Bottleneck(1, 1000)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ export class Probot {
     this.webhook.on('error', this.errorHandler)
   }
 
-  public errorHandler (err) {
+  public errorHandler (err: Error) {
     switch (err.message) {
       case 'X-Hub-Signature does not match blob signature':
       case 'No X-Hub-Signature found on request':

--- a/src/middleware/log-request-errors.ts
+++ b/src/middleware/log-request-errors.ts
@@ -2,6 +2,8 @@ import {NextFunction} from 'express'
 import {Request,Response} from './logging'
 
 module.exports = (err: Error, req: Request, res: Response, next: NextFunction) => {
-  req.log.error(err)
+  if (req.log) {
+    req.log.error(err)
+  }
   next()
 }

--- a/src/middleware/log-request-errors.ts
+++ b/src/middleware/log-request-errors.ts
@@ -1,5 +1,7 @@
+import {NextFunction} from 'express'
+import {Request,Response} from './logging'
 
-module.exports = (err: Error, req, res, next) => {
+module.exports = (err: Error, req: Request, res: Response, next: NextFunction) => {
   req.log.error(err)
   next()
 }

--- a/src/middleware/log-request-errors.ts
+++ b/src/middleware/log-request-errors.ts
@@ -1,5 +1,4 @@
-import {NextFunction} from 'express'
-import {Request,Response} from './logging'
+import {NextFunction,Request,Response} from './logging'
 
 module.exports = (err: Error, req: Request, res: Response, next: NextFunction) => {
   if (req.log) {

--- a/src/middleware/log-request-errors.ts
+++ b/src/middleware/log-request-errors.ts
@@ -1,4 +1,5 @@
-module.exports = (err, req, res, next) => {
+
+module.exports = (err: Error, req, res, next) => {
   req.log.error(err)
   next()
 }

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -7,7 +7,7 @@ import * as express from 'express'
 import * as Logger from 'bunyan'
 
 export const logRequest = function ({logger}: any): express.RequestHandler {
-  return function (req: Request, res: Response, next: express.NextFunction) {
+  return function (req: Request, res: Response, next: NextFunction) {
     // Use X-Request-ID from request if it is set, otherwise generate a uuid
     req.id = req.headers['x-request-id'] ||
       req.headers['x-github-delivery'] ||
@@ -49,3 +49,5 @@ export interface Response extends express.Response {
   duration?: string
   log?: Logger
 }
+
+export interface NextFunction extends express.NextFunction { }

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -3,9 +3,11 @@
 // tslint:disable
 var uuid = require('uuid')
 import {wrapLogger} from '../wrap-logger'
+import * as express from 'express'
+import Logger = require('bunyan')
 
-export const logRequest = function ({logger}) {
-  return function (req, res, next) {
+export const logRequest = function ({logger}: any) {
+  return function (req: Request, res: Response, next: express.NextFunction) {
     // Use X-Request-ID from request if it is set, otherwise generate a uuid
     req.id = req.headers['x-request-id'] ||
       req.headers['x-github-delivery'] ||
@@ -34,4 +36,14 @@ export const logRequest = function ({logger}) {
 
     next()
   }
+}
+
+export interface Request extends express.Request {
+  id: number
+  log: Logger
+}
+
+export interface Response extends express.Response {
+  duration: string
+  log: Logger
 }

--- a/src/middleware/logging.ts
+++ b/src/middleware/logging.ts
@@ -1,12 +1,12 @@
 // Borrowed from https://github.com/vvo/bunyan-request
 // Copyright (c) Christian Tellnes <christian@tellnes.no>
 // tslint:disable
-var uuid = require('uuid')
 import {wrapLogger} from '../wrap-logger'
+import * as uuid from 'uuid'
 import * as express from 'express'
-import Logger = require('bunyan')
+import * as Logger from 'bunyan'
 
-export const logRequest = function ({logger}: any) {
+export const logRequest = function ({logger}: any): express.RequestHandler {
   return function (req: Request, res: Response, next: express.NextFunction) {
     // Use X-Request-ID from request if it is set, otherwise generate a uuid
     req.id = req.headers['x-request-id'] ||
@@ -30,8 +30,10 @@ export const logRequest = function ({logger}: any) {
 
       const message = `${req.method} ${req.url} ${res.statusCode} - ${res.duration} ms`
 
-      req.log.info(message)
-      req.log.trace({res})
+      if (req.log) {
+        req.log.info(message)
+        req.log.trace({res})
+      }
     })
 
     next()
@@ -39,11 +41,11 @@ export const logRequest = function ({logger}: any) {
 }
 
 export interface Request extends express.Request {
-  id: number
-  log: Logger
+  id?: string | number | string[]
+  log?: Logger
 }
 
 export interface Response extends express.Response {
-  duration: string
-  log: Logger
+  duration?: string
+  log?: Logger
 }

--- a/src/plugins/stats.ts
+++ b/src/plugins/stats.ts
@@ -1,3 +1,6 @@
+import {AnyResponse} from '@octokit/rest'
+import {Request,Response} from 'express'
+
 // Built-in plugin to expose stats about the deployment
 module.exports = async (app: any): Promise<void> => {
   if (process.env.DISABLE_STATS) {
@@ -19,7 +22,7 @@ module.exports = async (app: any): Promise<void> => {
   const ignoredAccounts = (process.env.IGNORED_ACCOUNTS || '').toLowerCase().split(',')
 
   // Setup /probot/stats endpoint to return cached stats
-  app.router.get('/probot/stats', async (req, res) => {
+  app.router.get('/probot/stats', async (req: Request, res: Response) => {
     // ensure stats are loaded
     await initializing
     res.json(stats)
@@ -35,7 +38,7 @@ module.exports = async (app: any): Promise<void> => {
   async function getInstallations (): Promise<Installation[]> {
     const github = await app.auth()
     const req = github.apps.getInstallations({per_page: 100})
-    return github.paginate(req, res => res.data)
+    return github.paginate(req, (res: AnyResponse) => res.data)
   }
 
   async function popularInstallations (installations: Installation[]): Promise<Account[]> {
@@ -43,8 +46,8 @@ module.exports = async (app: any): Promise<void> => {
       const github = await app.auth(installation.id)
 
       const req = github.apps.getInstallationRepositories({per_page: 100})
-      const repositories: Repository[] = await github.paginate(req, res => {
-        return res.data.repositories.filter(repository => !repository.private)
+      const repositories: Repository[] = await github.paginate(req, (res: AnyResponse) => {
+        return res.data.repositories.filter((repository: Repository) => !repository.private)
       })
       const account = installation.account
 

--- a/src/private-key.ts
+++ b/src/private-key.ts
@@ -17,7 +17,7 @@ const hint = `please use:
  * @returns {string} Private key
  * @private
  */
-function findPrivateKey (filepath) {
+function findPrivateKey (filepath: string): Buffer | string {
   if (filepath) {
     return fs.readFileSync(filepath)
   }

--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -52,6 +52,6 @@ export interface LoggerWithTarget extends Logger {
 export interface ChildArgs {
   options?: object
   name?: string
-  id?: number
+  id?: string | number | string[]
   installation?: string
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "outDir": "./lib",
     "skipLibCheck": true,
-    "noImplicitAny": true, // remove this once we've added all types
+    "noImplicitAny": true,
     "declaration": true // enable this once all files are .ts and we can remove allowJs
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "sourceMap": true,
     "outDir": "./lib",
     "skipLibCheck": true,
-    "noImplicitAny": false, // remove this once we've added all types
+    "noImplicitAny": true, // remove this once we've added all types
     "declaration": true // enable this once all files are .ts and we can remove allowJs
   },
   "include": [


### PR DESCRIPTION
This isn't ready yet, but wanted to show what is done so far.  I turned on `noImplicitAny` in `tsconfig.json` and went through all of the files that needed types in parameters.  There were a couple I put `any` because I couldn't tell what they were exactly (such as https://github.com/szeck87/probot/blob/enable-noimplicitany/src/github/pagination.ts#L11).  Three files still need work.  I could use some guidance on:

* src/github/pagination.ts:  responsePromise.  It doesn't like a type of `AnyResponse` or `Promise<AnyResponse` in the callbacks, so not sure what to use there.
* src/middleware/log-request-errors.ts:  `req`, `res`, and `next`
* src/middleware/logging.ts:  `req`, `res`, and `next`, as well as the `logger` bind.
