### PR TITLE
app.load()

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -25,7 +25,7 @@ describe('your-app', () => {
     // Here we create an `Application` instance
     app = new Application()
     // Here we initialize the app
-    plugin(app)
+    app.load(plugin)
     // This is an easy way to mock out the GitHub API
     github = {
       issues: {

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,6 +1,6 @@
 import * as express from 'express'
 import {EventEmitter} from 'promise-events'
-import {Plugin} from '.'
+import {ApplicationFunction} from '.'
 import {Context} from './context'
 import {GitHubAPI} from './github'
 import {logger} from './logger'
@@ -39,7 +39,7 @@ export class Application {
    * Loads a Probot plugin
    * @param {function} plugin - Probot plugin to load
    */
-  public load (app: Plugin | Plugin[]) : Application {
+  public load (app: ApplicationFunction | ApplicationFunction[]) : Application {
     if (Array.isArray(app)) {
       app.forEach(a => this.load(a))
     } else {

--- a/src/application.ts
+++ b/src/application.ts
@@ -1,5 +1,6 @@
 import * as express from 'express'
 import {EventEmitter} from 'promise-events'
+import {Plugin} from '.'
 import {Context} from './context'
 import {GitHubAPI} from './github'
 import {logger} from './logger'
@@ -38,8 +39,9 @@ export class Application {
    * Loads a Probot plugin
    * @param {function} plugin - Probot plugin to load
    */
-  public load (plugin: (Application) => void) {
-    return plugin(this)
+  public load (app: Plugin) : Application {
+    app(this)
+    return this
   }
 
   public async receive (event: WebhookEvent) {

--- a/src/application.ts
+++ b/src/application.ts
@@ -34,6 +34,14 @@ export class Application {
     this.router = opts.router || express.Router() // you can do this?
   }
 
+  /**
+   * Loads a Probot plugin
+   * @param {function} plugin - Probot plugin to load
+   */
+  public async load (plugin: Function) {
+    return plugin(this)
+  }
+
   public async receive (event: WebhookEvent) {
     return Promise.all([
       this.events.emit('*', event),

--- a/src/application.ts
+++ b/src/application.ts
@@ -39,8 +39,13 @@ export class Application {
    * Loads a Probot plugin
    * @param {function} plugin - Probot plugin to load
    */
-  public load (app: Plugin) : Application {
-    app(this)
+  public load (app: Plugin | Plugin[]) : Application {
+    if (Array.isArray(app)) {
+      app.forEach(a => this.load(a))
+    } else {
+      app(this)
+    }
+
     return this
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -38,7 +38,7 @@ export class Application {
    * Loads a Probot plugin
    * @param {function} plugin - Probot plugin to load
    */
-  public load (plugin: Function) {
+  public load (plugin: (Application) => void) {
     return plugin(this)
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -38,7 +38,7 @@ export class Application {
    * Loads a Probot plugin
    * @param {function} plugin - Probot plugin to load
    */
-  public async load (plugin: Function) {
+  public load (plugin: Function) {
     return plugin(this)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,9 +74,9 @@ export class Probot {
     return Promise.all(this.apps.map(app => app.receive(event)))
   }
 
-  public load (plugin: string | Plugin) {
-    if (typeof plugin === 'string') {
-      plugin = resolve(plugin) as Plugin
+  public load (appFunction: string | ApplicationFunction) {
+    if (typeof appFunction === 'string') {
+      appFunction = resolve(appFunction) as ApplicationFunction
     }
 
     const app = new Application({app: this.app, cache, catchErrors: true})
@@ -85,13 +85,13 @@ export class Probot {
     this.server.use(app.router)
 
     // Initialize the plugin
-    app.load(plugin)
+    app.load(appFunction)
     this.apps.push(app)
 
     return app
   }
 
-  public setup (apps: Array<string | Plugin>) {
+  public setup (apps: Array<string | ApplicationFunction>) {
     // Log all unhandled rejections
     process.on('unhandledRejection', this.errorHandler)
 
@@ -119,7 +119,7 @@ export class Probot {
 
 export const createProbot = (options: Options) => new Probot(options)
 
-export type Plugin = (app: Application) => void
+export type ApplicationFunction = (app: Application) => void
 
 export interface Options {
   webhookPath?: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,7 +85,7 @@ export class Probot {
     this.server.use(app.router)
 
     // Initialize the plugin
-    plugin(app)
+    app.load(plugin)
     this.apps.push(app)
 
     return app

--- a/test/application.test.js
+++ b/test/application.test.js
@@ -199,6 +199,29 @@ describe('Application', function () {
     })
   })
 
+  describe('load', () => {
+    it('loads one app', async () => {
+      const spy = jest.fn()
+      const myApp = a => a.on('test', spy)
+
+      app.load(myApp)
+      await app.receive(event)
+      expect(spy).toHaveBeenCalled()
+    })
+
+    it('loads multiple apps', async () => {
+      const spy = jest.fn()
+      const spy2 = jest.fn()
+      const myApp = a => a.on('test', spy)
+      const myApp2 = a => a.on('test', spy2)
+
+      app.load([myApp, myApp2])
+      await app.receive(event)
+      expect(spy).toHaveBeenCalled()
+      expect(spy2).toHaveBeenCalled()
+    })
+  })
+
   describe('error handling', () => {
     let error
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,7 +185,7 @@ describe('Probot', () => {
         return spy(res)
       }
 
-      await app.load(plugin)
+      await plugin(app)
       await app.receive(event)
       expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
     })

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -185,7 +185,7 @@ describe('Probot', () => {
         return spy(res)
       }
 
-      await plugin(app)
+      await app.load(plugin)
       await app.receive(event)
       expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
     })

--- a/test/plugins/helper.js
+++ b/test/plugins/helper.js
@@ -10,7 +10,7 @@ const jwt = jest.fn().mockReturnValue('test')
 module.exports = {
   createApp (plugin = () => {}) {
     const app = new Application({app: jwt, cache})
-    plugin(app)
+    app.load(plugin)
     return app
   }
 }


### PR DESCRIPTION
This PR adds a new method to the `Application` class:

```js
app.load(require('./path/to/plugin')
```

Its a very small method, but just adds a little but of sugar around loading up an app. The paradigm of calling your app as a function isn't super approachable (JS-wise it makes sense, but people aren't used to exporting a function), but calling `.load()` on something is more commonly used.

<details>
<summary>I've solved this, but expand if you're curious!</summary>

@tcbyrd - my Typescript knowledge reached its limit within typing about four characters. I'm seeing this error:

```
ERROR: /Users/jasonetco/dev/probot/src/application.ts[41, 24]: Don't use 'Function' as a type. Avoid using the `Function` type. Prefer a specific function type, like `() => void`.
```

Which I understand but don't quite know what the right type would be. `app => void`? Would love your help there.
</details>

---

`cc` #542 where this first came up.