### PR TITLE
Optimize IGNORED_ACCOUNTS check

### DIFF
--- a/src/plugins/stats.ts
+++ b/src/plugins/stats.ts
@@ -43,22 +43,23 @@ module.exports = async (app: any): Promise<void> => {
 
   async function popularInstallations (installations: Installation[]): Promise<Account[]> {
     let popular = await Promise.all(installations.map(async (installation) => {
+      const {account} = installation
+
+      if (ignoredAccounts.includes(account.login.toLowerCase())) {
+        account.stars = 0
+        app.log.debug({installation}, 'Installation is ignored')
+      }
+
       const github = await app.auth(installation.id)
 
       const req = github.apps.getInstallationRepositories({per_page: 100})
       const repositories: Repository[] = await github.paginate(req, (res: AnyResponse) => {
         return res.data.repositories.filter((repository: Repository) => !repository.private)
       })
-      const account = installation.account
 
-      if (ignoredAccounts.includes(installation.account.login.toLowerCase())) {
-        account.stars = 0
-        app.log.debug({installation}, 'Installation is ignored')
-      } else {
-        account.stars = repositories.reduce((stars, repository) => {
-          return stars + repository.stargazers_count
-        }, 0)
-      }
+      account.stars = repositories.reduce((stars, repository) => {
+        return stars + repository.stargazers_count
+      }, 0)
 
       return account
     }))

--- a/src/plugins/stats.ts
+++ b/src/plugins/stats.ts
@@ -48,6 +48,7 @@ module.exports = async (app: any): Promise<void> => {
       if (ignoredAccounts.includes(account.login.toLowerCase())) {
         account.stars = 0
         app.log.debug({installation}, 'Installation is ignored')
+        return account
       }
 
       const github = await app.auth(installation.id)


### PR DESCRIPTION
Previously, the stats endpoint would still fetch all repositories before checking if the account was ignored. This moves the check for ignored account before fetching all repositories to save a lot of time on spammy installations with a lot of repositories.