### PR TITLE
Throw if GHE_HOST includes a protocol

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -159,7 +159,7 @@ export class Application {
    */
   public async auth (id?: number, log = this.log): Promise<GitHubAPI> {
     if (process.env.GHE_HOST && /^https?:\/\//.test(process.env.GHE_HOST)) {
-      throw new Error('Your \`GHE_HOST\` environment variable should not include a protocol.')
+      throw new Error('Your \`GHE_HOST\` environment variable should not begin with https:// or http://')
     }
 
     const github = GitHubAPI({

--- a/src/application.ts
+++ b/src/application.ts
@@ -158,7 +158,7 @@ export class Application {
    * @private
    */
   public async auth (id?: number, log = this.log): Promise<GitHubAPI> {
-    if (process.env.GHE_HOST && /https?:\/\//.test(process.env.GHE_HOST)) {
+    if (process.env.GHE_HOST && /^https?:\/\//.test(process.env.GHE_HOST)) {
       throw new Error('Your \`GHE_HOST\` environment variable should not include a protocol.')
     }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -158,6 +158,10 @@ export class Application {
    * @private
    */
   public async auth (id?: number, log = this.log): Promise<GitHubAPI> {
+    if (process.env.GHE_HOST && /https?:\/\//.test(process.env.GHE_HOST)) {
+      throw new Error('Your \`GHE_HOST\` environment variable should not include a protocol.')
+    }
+
     const github = GitHubAPI({
       baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
       debug: process.env.LOG_LEVEL === 'trace',

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Probot ghe support throws if the GHE host includes a protocol 1`] = `[Error: Your \`GHE_HOST\` environment variable should not include a protocol.]`;
+
 exports[`Probot webhook delivery responds with the correct error if the PEM file is missing 1`] = `
 Array [
   "Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you're deploying to Now, visit https://probot.github.io/docs/deployment/#now.",

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Probot ghe support throws if the GHE host includes a protocol 1`] = `[Error: Your \`GHE_HOST\` environment variable should not include a protocol.]`;
+exports[`Probot ghe support throws if the GHE host includes a protocol 1`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
 
 exports[`Probot webhook delivery responds with the correct error if the PEM file is missing 1`] = `
 Array [

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -189,5 +189,15 @@ describe('Probot', () => {
       await app.receive(event)
       expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
     })
+
+    it('throws if the GHE host includes a protocol', async () => {
+      process.env.GHE_HOST = 'https://notreallygithub.com'
+
+      try {
+        await app.auth()
+      } catch (e) {
+        expect(e).toMatchSnapshot()
+      }
+    })
   })
 })


### PR DESCRIPTION
This PR adds a check to see if the `GHE_HOST` environment variable includes a protocol following this RegEx:

```js
/^https?:\/\//
```

The following error is thrown:

> Your `GHE_HOST` environment variable should not include a protocol.

---

I just have one question about my implementation if anyone wants to chip in: I added this check in `app.auth()`, which means it'd throw when thats called, not when the app starts. Should I move the check elsewhere? I did it this way because `process.env.GHE_HOST` isn't referenced anywhere else.

Closes #569 