### PR TITLE
Fix path to GraphQL API when using GitHub Enterprise

### DIFF
--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -6,6 +6,7 @@ export function addGraphQL (client: GitHubAPI) {
 
 async function graphql (client: GitHubAPI, query: string, variables: Variables, headers: Headers = {}) {
   const res = await client.request({
+    baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api`,
     headers: {
       'accept': 'application/json',
       'content-type': 'application/json',

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -30,6 +30,7 @@ export interface Options extends Octokit.Options {
 }
 
 export interface RequestOptions {
+  baseUrl?: string
   method: string
   url: string
   headers: any

--- a/test/github/graphql.test.js
+++ b/test/github/graphql.test.js
@@ -76,4 +76,28 @@ describe('github/graphql', () => {
       await expect(github.query(query)).rejects.toThrow('Unexpected end of document')
     })
   })
+
+  describe('ghe support', () => {
+    const query = 'query { viewer { login } }'
+    let data
+
+    beforeEach(() => {
+      process.env.GHE_HOST = 'notreallygithub.com'
+    })
+
+    afterEach(() => {
+      delete process.env.GHE_HOST
+    })
+
+    test('makes a graphql query', async () => {
+      data = { viewer: { login: 'bkeepers' } }
+
+      nock('https://notreallygithub.com', {
+        reqheaders: { 'content-type': 'application/json' }
+      }).post('/api/graphql', {query})
+        .reply(200, { data })
+
+      expect(await github.query(query)).toEqual(data)
+    })
+  })
 })


### PR DESCRIPTION
The API path should be <ghe_host>/api/graphql, but it is defaulting to <ghe_host>/api/v3/graphql.