### PR TITLE
Adds missing awaits

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -73,7 +73,7 @@ const metadata = require('probot-metadata')
 module.exports = app => {
   app.on(['issues.edited', 'issue_comment.edited'], async context => {
     const kv = await metadata(context)
-    kv.set('edits', kv.get('edits') || 1)
+    await kv.set('edits', await kv.get('edits') || 1)
   })
 
   app.on('issues.closed', async context => {


### PR DESCRIPTION
Both `get` and `set` are async in the metadata library. The `await` in `get` is required in this case because otherwise it will always to set a promise on the metadata, which doesn't make sense, and the await in set is required to not swallow the rejection if it fails.