### PR TITLE
Revert "Configuration: DISABLE_STATS=true"

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,8 +28,6 @@ Variable | Sample Value | Required | Description
 `WEBHOOK_PATH` | '/webhook' | Optional | The URL path which will recieve webhooks. By default, this is `'/'`.
 `SENTRY_DSN` | 'https://user:pw@sentry.io/1234' | Optional | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
 `LOG_FORMAT` | json |  Optional | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
-`DISABLE_STATS` | true | Optional | Disable requests to retrieve installation statistics. Recommended for local development.
-
 
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).


### PR DESCRIPTION
Reverts probot/probot#578

Sorry I missed the original ping for this PR, but the configuration.md file already has an option for `DISABLE_STATS`: https://github.com/probot/probot/blob/master/docs/configuration.md and [here](https://github.com/probot/probot/pull/591/files#diff-76e731333fb756df3bff5ddb3b731c46L25)

So this reverts that PR to keep the original. Happy to update the language on the original if that makes sense.