### PR TITLE
Tweak formatting of config docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,28 +6,28 @@ next: docs/deployment.md
 
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
-Variable | Sample Value | Required | Description
+Variable | Example | Description
 ---|---|---|---
-`WEBHOOK_PROXY_URL` | 'https://smee.io/yourcustomurl'| Required | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started.
-`WEBHOOK_SECRET` | development | Required | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub.
-`APP_ID` | 1234 | Required | The App ID assigned to your GitHub App
-`PRIVATE_KEY` | SECRETS | Optional | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App.
-`PRIVATE_KEY_PATH` | /path/to/private/key | Optional | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory.
+`WEBHOOK_PROXY_URL` | 'https://smee.io/yourcustomurl'| Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. **Required**
+`WEBHOOK_SECRET` | development | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required**
+`APP_ID` | 1234 | The App ID assigned to your GitHub App **Required**
+`PRIVATE_KEY` | SECRETS | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App. **Required** if `PRIVATE_KEY_PATH` is not set.
+`PRIVATE_KEY_PATH` | /path/to/private/key | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory. **Required** if `PRIVATE_KEY` is not set.
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
 Some less common environment variables are:
 
-Variable | Sample Value | Required | Description
+Variable | Example | Description
 ---|---|---|---
-`LOG_LEVEL` | debug | Optional | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
-`IGNORED_ACCOUNTS` | 'spammyUser,abusiveUser' | Optional | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
-`DISABLE_STATS` | true | Optional | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
-`GHE_HOST` | 'fake.github-enterprise.com' | Optional | Allows for a Probot App to be run on a GitHub Enterprise instance.
-`PORT` | 5000 | Optional | The port on which Probot will start a local server on. By default, this is 3000.
-`WEBHOOK_PATH` | '/webhook' | Optional | The URL path which will recieve webhooks. By default, this is `'/'`.
-`SENTRY_DSN` | 'https://user:pw@sentry.io/1234' | Optional | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
-`LOG_FORMAT` | json |  Optional | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
+`LOG_LEVEL` | debug | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
+`IGNORED_ACCOUNTS` | 'spammyUser,abusiveUser' | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+`DISABLE_STATS` | true | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
+`GHE_HOST` | 'fake.github-enterprise.com' | Allows for a Probot App to be run on a GitHub Enterprise instance.
+`PORT` | 5000 | The port on which Probot will start a local server on. By default, this is 3000.
+`WEBHOOK_PATH` | '/webhook' | The URL path which will recieve webhooks. By default, this is `'/'`.
+`SENTRY_DSN` | 'https://user:pw@sentry.io/1234' | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
+`LOG_FORMAT` | json |  By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,11 +8,11 @@ When developing a Probot App, you will need to have several different fields in 
 
 Variable | Description
 ---|---
-`WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. **Required**
+`APP_ID` | The App ID assigned to your GitHub App. **Required**
+`PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. If not present, Probot will look for a file ending in `.pem` in your project's directory. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY` is not set.
+`PRIVATE_KEY` | The contents of the private key for your GitHub App. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY_PATH` is not set.
+`WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started.
 `WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required**
-`APP_ID` | 1234 | The App ID assigned to your GitHub App **Required**
-`PRIVATE_KEY` | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App. **Required** if `PRIVATE_KEY_PATH` is not set.
-`PRIVATE_KEY_PATH` | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory. **Required** if `PRIVATE_KEY` is not set.
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
@@ -20,14 +20,13 @@ Some less common environment variables are:
 
 Variable | Description
 ---|---
-`LOG_LEVEL` | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
-`IGNORED_ACCOUNTS` | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
-`DISABLE_STATS` | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app. For example: `true`
-`GHE_HOST` | 'fake.github-enterprise.com' | Allows for a Probot App to be run on a GitHub Enterprise instance.
-`PORT` | The port on which Probot will start a local server on. By default, this is `3000`.
-`WEBHOOK_PATH` | The URL path which will recieve webhooks. By default, this is `/`.
-`SENTRY_DSN` | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
-`LOG_FORMAT` | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
-
+`DISABLE_STATS` | Set to `true` to disable the the `/probot/stats` endpoint, which gathers data about each app. Recommend for apps with a lot of installations.
+`GHE_HOST` | The hostname of your GitHub Enterprise instance, such as  `github.mycompany.com`.
+`IGNORED_ACCOUNTS` | A comma-separated list of GitHub account names to ignore. This is currently used by the `/probot/stats`. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+`LOG_FORMAT` | By default, logs are formatted for readability in development. You can set this to `short`, `long`, `simple`, `json`, `bunyan`. Default: `short`
+`LOG_LEVEL` | The verbosity of logs to show when running your app, which can be `trace`, `debug`, `info`, `warn`, `error`, or `fatal`. Default: `info`
+`PORT` | The port to start the local server on. Default: `3000`.
+`SENTRY_DSN` | Set to a [Sentry](https://sentry.io/) DSN to report all errors thrown by your app.
+`WEBHOOK_PATH` | The URL path which will recieve webhooks. Default: `/`.
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -8,11 +8,11 @@ When developing a Probot App, you will need to have several different fields in 
 
 Variable | Description
 ---|---
-`APP_ID` | The App ID assigned to your GitHub App. **Required**
-`PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. If not present, Probot will look for a file ending in `.pem` in your project's directory. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY` is not set.
+`APP_ID` | The App ID assigned to your GitHub App. **Required** <p>_(Example: `1234`)_</p>
+`PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. If not present, Probot will look for a file ending in `.pem` in your project's directory. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY` is not set. <p>_(Example: `path/to/key.pem`)_</p>
 `PRIVATE_KEY` | The contents of the private key for your GitHub App. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY_PATH` is not set.
-`WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started.
-`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required**
+`WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. <p>_(Example: `https://smee.io/your-custom-url`)_</p>
+`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required** <p>_(Example: `development`)_</p>
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
@@ -20,13 +20,13 @@ Some less common environment variables are:
 
 Variable | Description
 ---|---
-`DISABLE_STATS` | Set to `true` to disable the the `/probot/stats` endpoint, which gathers data about each app. Recommend for apps with a lot of installations.
-`GHE_HOST` | The hostname of your GitHub Enterprise instance, such as  `github.mycompany.com`.
-`IGNORED_ACCOUNTS` | A comma-separated list of GitHub account names to ignore. This is currently used by the `/probot/stats`. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+`DISABLE_STATS` | Set to `true` to disable the the `/probot/stats` endpoint, which gathers data about each app. Recommend for apps with a lot of installations. <p>_(Example: `true`)_</p>
+`GHE_HOST` | The hostname of your GitHub Enterprise instance. <p>_(Example: `github.mycompany.com`)_</p>
+`IGNORED_ACCOUNTS` | A comma-separated list of GitHub account names to ignore. This is currently used by the `/probot/stats`. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404. <p>_(Example: `spammyPerson,abusiveAccount`)_</p>
 `LOG_FORMAT` | By default, logs are formatted for readability in development. You can set this to `short`, `long`, `simple`, `json`, `bunyan`. Default: `short`
 `LOG_LEVEL` | The verbosity of logs to show when running your app, which can be `trace`, `debug`, `info`, `warn`, `error`, or `fatal`. Default: `info`
 `PORT` | The port to start the local server on. Default: `3000`.
-`SENTRY_DSN` | Set to a [Sentry](https://sentry.io/) DSN to report all errors thrown by your app.
+`SENTRY_DSN` | Set to a [Sentry](https://sentry.io/) DSN to report all errors thrown by your app.  <p>_(Example: `https://1234abcd@sentry.io/12345`)_</p>
 `WEBHOOK_PATH` | The URL path which will recieve webhooks. Default: `/`.
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,28 +6,28 @@ next: docs/deployment.md
 
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
-Variable | Example | Description
----|---|---|---
-`WEBHOOK_PROXY_URL` | 'https://smee.io/yourcustomurl'| Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. **Required**
-`WEBHOOK_SECRET` | development | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required**
+Variable | Description
+---|---
+`WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. **Required**
+`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required**
 `APP_ID` | 1234 | The App ID assigned to your GitHub App **Required**
-`PRIVATE_KEY` | SECRETS | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App. **Required** if `PRIVATE_KEY_PATH` is not set.
-`PRIVATE_KEY_PATH` | /path/to/private/key | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory. **Required** if `PRIVATE_KEY` is not set.
+`PRIVATE_KEY` | Private key; however, this variable is optional, if it is not present Probot will look in your project's directory for the private key, specifically a file ending in `.pem`. Having a private key somewhere _is_ necessary to run your Probot App. **Required** if `PRIVATE_KEY_PATH` is not set.
+`PRIVATE_KEY_PATH` | Path to your private key, a `.pem` file. This is only necessary if your private key is not in your project directory. **Required** if `PRIVATE_KEY` is not set.
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 
 Some less common environment variables are:
 
-Variable | Example | Description
----|---|---|---
-`LOG_LEVEL` | debug | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
-`IGNORED_ACCOUNTS` | 'spammyUser,abusiveUser' | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
-`DISABLE_STATS` | true | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app.
+Variable | Description
+---|---
+`LOG_LEVEL` | The default log level is `info`, but you can also change it to `trace`, `debug`, or `warn`. This affects the verbosity of the logging Probot provides when running your app.
+`IGNORED_ACCOUNTS` | Specific to the probot/stats endpoint which fuels the data about each Probot App for our website. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404.
+`DISABLE_STATS` | Allows for Probot Apps to opt out of inclusion in the /stats endpoint which gathers data about each app. For example: `true`
 `GHE_HOST` | 'fake.github-enterprise.com' | Allows for a Probot App to be run on a GitHub Enterprise instance.
-`PORT` | 5000 | The port on which Probot will start a local server on. By default, this is 3000.
-`WEBHOOK_PATH` | '/webhook' | The URL path which will recieve webhooks. By default, this is `'/'`.
-`SENTRY_DSN` | 'https://user:pw@sentry.io/1234' | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
-`LOG_FORMAT` | json |  By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
+`PORT` | The port on which Probot will start a local server on. By default, this is `3000`.
+`WEBHOOK_PATH` | The URL path which will recieve webhooks. By default, this is `/`.
+`SENTRY_DSN` | Logs all errors to [Sentry](https://sentry.io/) for error tracking.
+`LOG_FORMAT` | By default, logs are formatted for readability in development. If you intend to drain logs to a logging service, use this option.
 
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).


### PR DESCRIPTION
The layout on https://probot.github.io/docs/configuration/ makes the descriptions hard to read. This attempts to clean it up a bit by:

1. move the required/optional indicator into the description to avoid taking a whole column.
2. Remove the example column and just include any applicable sample values in the description
3. Tweak language on several of the descriptions.

Before:

![image](https://user-images.githubusercontent.com/173/42143647-d57840fc-7d7b-11e8-8879-1a606548d5b3.png)

After:

![image](https://user-images.githubusercontent.com/173/42143662-f1b7f47e-7d7b-11e8-9171-71f3d02dc004.png)
