### PR TITLE
Update links for our API

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -58,4 +58,4 @@ Apps _should_ allow all settings to be customized for each installation.
 
 ### Store configuration in the repository
 
-Any configuration _should_ be stored in the target repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/api/latest/Context.html#config).
+Any configuration _should_ be stored in the target repository. Unless the app is using files from an established convention, the configuration _should_ be stored in the `.github` directory. See the [API docs for `context.config`](https://probot.github.io/api/latest/classes/context.html#config).

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -12,7 +12,7 @@ module.exports = app => {
 }
 ```
 
-The `app` parameter is an instance of [`Application`](https://probot.github.io/api/latest/Application.html) and gives you access to all of the GitHub goodness.
+The `app` parameter is an instance of [`Application`](https://probot.github.io/api/latest/classes/application.html) and gives you access to all of the GitHub goodness.
 
 `app.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 


### PR DESCRIPTION
These are currently causing builds for the website to fail because these links changed from:

https://probot.github.io/api/latest/Context.html#config
and https://probot.github.io/api/latest/Application.html

to https://probot.github.io/api/latest/classes/context.html#config
and https://probot.github.io/api/latest/classes/application.html

which includes `classes` in the path. Not sure why this change is necessary, but assuming it's just a result of switching to ts doc generation, we can just update these links in our docs.