### PR TITLE
Update ocotokit/rest.js to v15.9.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "license": "ISC",
   "dependencies": {
     "@octokit/rest": "^15.9.4",
-    "@octokit/webhooks": "^4.0.0",
+    "@octokit/webhooks": "^3.1.1",
     "bottleneck": "^2.4.0",
     "bunyan": "^1.8.12",
     "bunyan-format": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^15.6.0",
-    "@octokit/webhooks": "^3.1.1",
+    "@octokit/rest": "^15.9.4",
+    "@octokit/webhooks": "^4.0.0",
     "bottleneck": "^2.4.0",
     "bunyan": "^1.8.12",
     "bunyan-format": "^0.2.1",


### PR DESCRIPTION
@gr2m I noticed greenkeeper hasn't been opening PRs for new Octokit versions, so we got a bit behind. This gets us back up to v15.9.4 and 4.0.0 for webhooks. Now that 7.0 is out I'll be able to pay attention to this more, but we should probably figure out why Greenkeeper hasn't been notifying us.