### PR TITLE
Remove extra event property on Context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -27,7 +27,6 @@ export class Context {
 
   constructor (event: any, github: GitHubAPI, log: LoggerWithTarget) {
     Object.assign(this, event)
-    this.event = event
     this.id = event.id
     this.github = github
     this.log = log


### PR DESCRIPTION
We seem to have unintentionally introduced a breaking change (which I'd call a bug) where `context.event` became the full event object `{ event: 'a-string', payload: {} }` instead of just the actual webhook event.

@tcbyrd and I nailed it down to this commit https://github.com/probot/probot/commit/e51dd016dc0ef8e96622dd54fcbbf4b56e61c75a in which `this.event = event` overrides the previous line's `Object.assign(this, event)` for just that `event` property.

The main reason this is a bug, aside from it being an unintentional breaking change, is that now we have `context.event.payload` and `context.payload`, which are exactly the same.