### PR TITLE
restructure helpful error messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,18 +58,13 @@ export class Probot {
   }
 
   public errorHandler (err: Error) {
-    switch (err.message) {
-      case 'X-Hub-Signature does not match blob signature':
-      case 'No X-Hub-Signature found on request':
-      case 'webhooks:receiver ignored: POST / due to missing headers: x-hub-signature':
-        logger.error('Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.')
-        break
-      case 'error:0906D06C:PEM routines:PEM_read_bio:no start line':
-      case '{"message":"A JSON web token could not be decoded","documentation_url":"https://developer.github.com/v3"}':
-        logger.error('Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you\'re deploying to Now, visit https://probot.github.io/docs/deployment/#now.')
-        break
-      default:
-        logger.error(err)
+    const errMessage = err.message.toLowerCase()
+    if (errMessage.includes('x-hub-signature')) {
+      logger.error('Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.')
+    } else if (errMessage.includes('pem') || errMessage.includes('json web token')) {
+      logger.error('Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you\'re deploying to Now, visit https://probot.github.io/docs/deployment/#now.')
+    } else {
+      logger.error(err)
     }
   }
 


### PR DESCRIPTION
I do think there's a larger problem with our error handling re: https://github.com/probot/probot/issues/607#issuecomment-402813774, but I think this might catch future weird error messages related to webhook secrets and pem files.

Open to ideas for a better way to accomplish this.

cc/ @probot/maintainers 