### PR TITLE
Make cacheErrors option optional

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -22,7 +22,7 @@ export class Application {
   public app: () => string
   public cache: Cache
   public router: express.Router
-  public catchErrors?: boolean
+  public catchErrors: boolean
   public log: LoggerWithTarget
 
   constructor (options?: Options) {
@@ -31,7 +31,7 @@ export class Application {
     this.log = wrapLogger(logger, logger)
     this.app = opts.app
     this.cache = opts.cache
-    this.catchErrors = opts.catchErrors
+    this.catchErrors = opts.catchErrors || false
     this.router = opts.router || express.Router() // you can do this?
   }
 
@@ -222,5 +222,5 @@ export interface Options {
   app: () => string
   cache: Cache
   router?: express.Router
-  catchErrors: boolean
+  catchErrors?: boolean
 }


### PR DESCRIPTION
Set a default value of false and update the property to note that it
will now always be a boolean

---

As per https://github.com/probot/probot/issues/512#issuecomment-396595637

There are still issue with default values for app and cache, but they'll go away once #563 is merged