### PR TITLE
Clarifies the Probot requires a webhook secret

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Variable | Description
 `PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. If not present, Probot will look for a file ending in `.pem` in your project's directory. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY` is not set. <p>_(Example: `path/to/key.pem`)_</p>
 `PRIVATE_KEY` | The contents of the private key for your GitHub App. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY_PATH` is not set.
 `WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. <p>_(Example: `https://smee.io/your-custom-url`)_</p>
-`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. Note: GitHub marks this value as optional, but we require it. **Required** <p>_(Example: `development`)_</p>
+`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. Note: GitHub marks this value as optional, but for optimal security it's required for Probot apps. **Required** <p>_(Example: `development`)_</p>
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Variable | Description
 `PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. If not present, Probot will look for a file ending in `.pem` in your project's directory. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY` is not set. <p>_(Example: `path/to/key.pem`)_</p>
 `PRIVATE_KEY` | The contents of the private key for your GitHub App. **Required** if the `.pem` file is not in your project directory and `PRIVATE_KEY_PATH` is not set.
 `WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. <p>_(Example: `https://smee.io/your-custom-url`)_</p>
-`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. **Required** <p>_(Example: `development`)_</p>
+`WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. Note: GitHub marks this value as optional, but we require it. **Required** <p>_(Example: `development`)_</p>
 
 For more on the set up of these items, check out [Configuring a GitHub App](https://probot.github.io/docs/development/#configuring-a-github-app).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,7 +53,7 @@ To run your app in development, you will need to configure a GitHub App to deliv
 1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` in `.env` to the URL that you are redirected to.
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
-    - **Webhook Secret:** `development` (Note: We **require** this secret be set, even though GitHub does not).
+    - **Webhook Secret:** `development` (Note: For optimal security, Probot apps **require** this secret be set, even though it's optional on GitHub.).
     - **Permissions & events** is located lower down the page and will depend on what data you want your app to have access to. Note: if, for example, you only enable issue events, you will not be able to listen on pull request webhooks with your app. However, for development we recommend enabling everything.
 1. Download the private key and move it to your project's directory. As long as it's in the root of your project, Probot will find it automatically regardless of the filename.
 1. Edit `.env` and set `APP_ID` to the ID of the app you just created. The App ID can be found in your app settings page here <img width="1048" alt="screen shot 2017-08-20 at 8 31 31 am" src="https://user-images.githubusercontent.com/5713670/42248717-f6bf4f10-7edb-11e8-8dd5-387181c771bc.png">

--- a/docs/development.md
+++ b/docs/development.md
@@ -53,7 +53,7 @@ To run your app in development, you will need to configure a GitHub App to deliv
 1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` in `.env` to the URL that you are redirected to.
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
     - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
-    - **Webhook Secret:** `development`
+    - **Webhook Secret:** `development` (Note: We **require** this secret be set, even though GitHub does not).
     - **Permissions & events** is located lower down the page and will depend on what data you want your app to have access to. Note: if, for example, you only enable issue events, you will not be able to listen on pull request webhooks with your app. However, for development we recommend enabling everything.
 1. Download the private key and move it to your project's directory. As long as it's in the root of your project, Probot will find it automatically regardless of the filename.
 1. Edit `.env` and set `APP_ID` to the ID of the app you just created. The App ID can be found in your app settings page here <img width="1048" alt="screen shot 2017-08-20 at 8 31 31 am" src="https://user-images.githubusercontent.com/5713670/42248717-f6bf4f10-7edb-11e8-8dd5-387181c771bc.png">


### PR DESCRIPTION
See: https://github.com/probot/probot/issues/607#issuecomment-403164780 for background.

GitHub Apps make the Webhook secret optional; however, we (through octokit/webhooks) require it for probot apps.

Currently if you don't set a webhook secret, the error message for that is being silenced, so in the meantime and as a clarification we can update our docs briefly to explain that we have this as a requirement, even if GitHub doesn't.