### PR TITLE
Run tslint against tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "rimraf lib && tsc -p tsconfig.json",
     "start": "node ./bin/probot run",
     "lint": "tslint --project test",
-    "test": "tsc --noEmit -p . && jest --coverage && npm run lint && npm run doc-lint",
+    "test": "tsc --noEmit -p test && jest --coverage && npm run lint && npm run doc-lint",
     "doc-lint": "standard-markdown docs/",
     "doc": "typedoc --options .typedoc.json",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
     "start": "node ./bin/probot run",
-    "lint": "tslint --project .",
+    "lint": "tslint --project test",
     "test": "tsc --noEmit -p . && jest --coverage && npm run lint && npm run doc-lint",
     "doc-lint": "standard-markdown docs/",
     "doc": "typedoc --options .typedoc.json",

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,11 +1,11 @@
 import fs = require('fs')
 import path = require('path')
 
-import { Context, WebhookEvent } from '../src/context'
+import { Context } from '../src/context'
 import { GitHubAPI, OctokitError } from '../src/github'
 
 describe('Context', () => {
-  let event: WebhookEvent
+  let event: any
   let context: Context
 
   beforeEach(() => {
@@ -95,12 +95,7 @@ describe('Context', () => {
     }
 
     beforeEach(() => {
-      github = {
-        repos: {
-          getContent: jest.fn()
-        }
-      }
-
+      github = GitHubAPI()
       context = new Context(event, github, {} as any)
     })
 

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,23 +1,27 @@
 import fs = require('fs')
 import path = require('path')
 
-import { Context } from '../src/context'
-import { OctokitError } from '../src/github'
+import { Context, WebhookEvent } from '../src/context'
+import { GitHubAPI, OctokitError } from '../src/github'
 
 describe('Context', () => {
-  let event
-  let context
+  let event: WebhookEvent
+  let context: Context
 
   beforeEach(() => {
     event = {
       event: 'push',
+      host: 'example.com',
+      id: '123',
       payload: {
         issue: { number: 4 },
         repository: {
           name: 'probot',
           owner: { login: 'bkeepers' }
         }
-      }
+      },
+      protocol: 'https',
+      url: '/'
     }
 
     context = new Context(event, {} as any, {} as any)
@@ -82,9 +86,9 @@ describe('Context', () => {
   })
 
   describe('config', () => {
-    let github
+    let github: GitHubAPI
 
-    function readConfig (fileName) {
+    function readConfig (fileName: string) {
       const configPath = path.join(__dirname, 'fixtures', 'config', fileName)
       const content = fs.readFileSync(configPath, { encoding: 'utf8' })
       return { data: { content: Buffer.from(content).toString('base64') } }

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,8 +1,8 @@
 import fs = require('fs')
 import path = require('path')
 
-import {Context} from '../src/context'
-import {OctokitError} from '../src/github'
+import { Context } from '../src/context'
+import { OctokitError } from '../src/github'
 
 describe('Context', () => {
   let event
@@ -12,11 +12,11 @@ describe('Context', () => {
     event = {
       event: 'push',
       payload: {
-        issue: {number: 4},
+        issue: { number: 4 },
         repository: {
           name: 'probot',
-          owner: {login: 'bkeepers'},
-        },
+          owner: { login: 'bkeepers' }
+        }
       }
     }
 
@@ -29,17 +29,17 @@ describe('Context', () => {
 
   describe('repo', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.repo()).toEqual({owner: 'bkeepers', repo: 'probot'})
+      expect(context.repo()).toEqual({ owner: 'bkeepers', repo: 'probot' })
     })
 
     it('merges attributes', () => {
-      expect(context.repo({foo: 1, bar: 2})).toEqual({
-        bar: 2, foo: 1, owner: 'bkeepers', repo: 'probot',
+      expect(context.repo({ foo: 1, bar: 2 })).toEqual({
+        bar: 2, foo: 1, owner: 'bkeepers', repo: 'probot'
       })
     })
 
     it('overrides repo attributes', () => {
-      expect(context.repo({owner: 'muahaha'})).toEqual({
+      expect(context.repo({ owner: 'muahaha' })).toEqual({
         owner: 'muahaha', repo: 'probot'
       })
     })
@@ -50,7 +50,7 @@ describe('Context', () => {
       event.payload = require('./fixtures/webhook/push')
 
       context = new Context(event, {} as any, {} as any)
-      expect(context.repo()).toEqual({owner: 'bkeepers-inc', repo: 'test'})
+      expect(context.repo()).toEqual({ owner: 'bkeepers-inc', repo: 'test' })
     })
 
     it('return error for context.repo() when repository doesn\'t exist', () => {
@@ -65,17 +65,17 @@ describe('Context', () => {
 
   describe('issue', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.issue()).toEqual({owner: 'bkeepers', repo: 'probot', number: 4})
+      expect(context.issue()).toEqual({ owner: 'bkeepers', repo: 'probot', number: 4 })
     })
 
     it('merges attributes', () => {
-      expect(context.issue({foo: 1, bar: 2})).toEqual({
-        bar: 2, foo: 1, number: 4, owner: 'bkeepers', repo: 'probot',
+      expect(context.issue({ foo: 1, bar: 2 })).toEqual({
+        bar: 2, foo: 1, number: 4, owner: 'bkeepers', repo: 'probot'
       })
     })
 
     it('overrides repo attributes', () => {
-      expect(context.issue({owner: 'muahaha', number: 5})).toEqual({
+      expect(context.issue({ owner: 'muahaha', number: 5 })).toEqual({
         number: 5, owner: 'muahaha', repo: 'probot'
       })
     })
@@ -86,8 +86,8 @@ describe('Context', () => {
 
     function readConfig (fileName) {
       const configPath = path.join(__dirname, 'fixtures', 'config', fileName)
-      const content = fs.readFileSync(configPath, {encoding: 'utf8'})
-      return {data: {content: Buffer.from(content).toString('base64')}}
+      const content = fs.readFileSync(configPath, { encoding: 'utf8' })
+      return { data: { content: Buffer.from(content).toString('base64') } }
     }
 
     beforeEach(() => {
@@ -107,12 +107,12 @@ describe('Context', () => {
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
         path: '.github/test-file.yml',
-        repo: 'probot',
+        repo: 'probot'
       })
       expect(config).toEqual({
         bar: 7,
         baz: 11,
-        foo: 5,
+        foo: 5
       })
     })
 
@@ -121,8 +121,8 @@ describe('Context', () => {
         code: 404,
         message: 'An error occurred',
         name: 'OctokitError',
-        status: 'Not Found',
-      };
+        status: 'Not Found'
+      }
 
       github.repos.getContent = jest.fn().mockReturnValue(Promise.reject(error))
 
@@ -134,14 +134,14 @@ describe('Context', () => {
         code: 404,
         message: 'An error occurred',
         name: 'OctokitError',
-        status: 'Not Found',
-      };
+        status: 'Not Found'
+      }
 
       github.repos.getContent = jest.fn().mockReturnValue(Promise.reject(error))
       const defaultConfig = {
         bar: 7,
         baz: 11,
-        foo: 5,
+        foo: 5
       }
       const contents = await context.config('test-file.yml', defaultConfig)
       expect(contents).toEqual(defaultConfig)
@@ -189,33 +189,33 @@ describe('Context', () => {
 
     it('overwrites default config settings', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('basic.yml')))
-      const config = await context.config('test-file.yml', {foo: 10})
+      const config = await context.config('test-file.yml', { foo: 10 })
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
         path: '.github/test-file.yml',
-        repo: 'probot',
+        repo: 'probot'
       })
       expect(config).toEqual({
         bar: 7,
         baz: 11,
-        foo: 5,
+        foo: 5
       })
     })
 
     it('uses default settings to fill in missing options', async () => {
       github.repos.getContent = jest.fn().mockReturnValue(Promise.resolve(readConfig('missing.yml')))
-      const config = await context.config('test-file.yml', {bar: 7})
+      const config = await context.config('test-file.yml', { bar: 7 })
 
       expect(github.repos.getContent).toHaveBeenCalledWith({
         owner: 'bkeepers',
         path: '.github/test-file.yml',
-        repo: 'probot',
+        repo: 'probot'
       })
       expect(config).toEqual({
         bar: 7,
         baz: 11,
-        foo: 5,
+        foo: 5
       })
     })
   })

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -11,17 +11,13 @@ describe('Context', () => {
   beforeEach(() => {
     event = {
       event: 'push',
-      host: 'example.com',
-      id: '123',
       payload: {
         issue: { number: 4 },
         repository: {
           name: 'probot',
           owner: { login: 'bkeepers' }
         }
-      },
-      protocol: 'https',
-      url: '/'
+      }
     }
 
     context = new Context(event, {} as any, {} as any)

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../tsconfig",
+  "include": [
+    "**/*.ts"
+  ]
+}

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../tsconfig",
   "include": [
+    "../src/**/*",
     "**/*.ts"
   ]
 }


### PR DESCRIPTION
`tslint` isn't currently running against our test files. This is because the `--project` option looks at `tsconfig.json` to see which files the linter should run against, and that config only specifies `src`. If you add `test` to the list, then all the tests will be transpiled into `lib`, which is not exactly what we want.

I searched around a bit and couldn't really find any definitive answers for getting tslint to run against tests, but I did see a few mentions of creating another `tsconfig.json` for the tests that extends the existing config and adds `test` to the includes, so that's what I did here.

Edit: `tsc` wasn't being run against the tests either, which has now caught a bunch of other issues.