### PR TITLE
Convert github tests to TypeScript

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -23,7 +23,7 @@ export function GitHubAPI (options: Options = {} as any) {
 }
 
 export interface Options extends Octokit.Options {
-  debug: boolean
+  debug?: boolean
   logger: Logger
   limiter?: any
 }

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,20 +1,21 @@
 import Bottleneck from 'bottleneck'
 import nock from 'nock'
-import { GitHubAPI } from '../src/github'
+import { GitHubAPI, Options } from '../src/github'
+import { logger } from '../src/logger'
 
 describe('GitHubAPI', () => {
   let github: GitHubAPI
 
   beforeEach(() => {
-    const logger = {
-      debug: jest.fn(),
-      trace: jest.fn()
-    }
-
     // Set a shorter limiter, otherwise tests are _slow_
     const limiter = new Bottleneck()
 
-    github = GitHubAPI({ logger, limiter } as any)
+    const options: Options = {
+      limiter,
+      logger
+    }
+
+    github = GitHubAPI(options)
   })
 
   test('works without options', async () => {

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -1,6 +1,6 @@
-const {GitHubAPI} = require('../src/github')
-const nock = require('nock')
-const Bottleneck = require('bottleneck')
+import Bottleneck from 'bottleneck'
+import nock from 'nock'
+import { GitHubAPI } from '../src/github'
 
 describe('GitHubAPI', () => {
   let github
@@ -19,7 +19,7 @@ describe('GitHubAPI', () => {
 
   test('works without options', async () => {
     github = new GitHubAPI()
-    const user = {login: 'ohai'}
+    const user = { login: 'ohai' }
 
     nock('https://api.github.com').get('/user').reply(200, user)
     expect((await github.users.get({})).data).toEqual(user)
@@ -30,9 +30,9 @@ describe('GitHubAPI', () => {
       // Prepare an array of issue objects
       const issues = new Array(5).fill().map((_, i, arr) => {
         return {
-          title: `Issue number ${i}`,
           id: i,
-          number: i
+          number: i,
+          title: `Issue number ${i}`
         }
       })
 
@@ -63,8 +63,8 @@ describe('GitHubAPI', () => {
     })
 
     it('stops iterating if the done() function is called in the callback', async () => {
-      const spy = jest.fn((res, done) => {
-        if (res.data.id === 2) done()
+      const spy = jest.fn((response, done) => {
+        if (response.data.id === 2) done()
       })
       const res = await github.paginate(github.issues.getForRepo({ owner: 'JasonEtco', repo: 'pizza', per_page: 1 }), spy)
       expect(res.length).toBe(3)

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -3,7 +3,7 @@ import nock from 'nock'
 import { GitHubAPI } from '../src/github'
 
 describe('GitHubAPI', () => {
-  let github
+  let github: GitHubAPI
 
   beforeEach(() => {
     const logger = {
@@ -14,11 +14,11 @@ describe('GitHubAPI', () => {
     // Set a shorter limiter, otherwise tests are _slow_
     const limiter = new Bottleneck()
 
-    github = new GitHubAPI({ logger, limiter })
+    github = GitHubAPI({ logger, limiter } as any)
   })
 
   test('works without options', async () => {
-    github = new GitHubAPI()
+    github = GitHubAPI()
     const user = { login: 'ohai' }
 
     nock('https://api.github.com').get('/user').reply(200, user)
@@ -28,7 +28,7 @@ describe('GitHubAPI', () => {
   describe('paginate', () => {
     beforeEach(() => {
       // Prepare an array of issue objects
-      const issues = new Array(5).fill().map((_, i, arr) => {
+      const issues = new Array(5).fill(0).map((_, i, arr) => {
         return {
           id: i,
           number: i,

--- a/tslint.json
+++ b/tslint.json
@@ -7,6 +7,6 @@
     "rules": {
       "interface-name": [true, "never-prefix"],
       "prefer-object-spread": false,
-      "no-implicit-dependencies": false
+      "no-implicit-dependencies": [true, "dev"]
     }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -6,6 +6,7 @@
     ],
     "rules": {
       "interface-name": [true, "never-prefix"],
-      "prefer-object-spread": false
+      "prefer-object-spread": false,
+      "no-implicit-dependencies": false
     }
 }


### PR DESCRIPTION
https://github.com/probot/probot/issues/582 Convert tests that `test/github.test.js`  to TypeScript. 

```
❯ npm run lint

> probot@7.0.1 lint /Users/Kentaro/workspace/github.com/probot/probot
> tslint --project test


ERROR: /Users/Kentaro/workspace/github.com/probot/probot/test/github.test.ts[2, 18]: Module 'nock' is not listed as dependency in package.json
```
Since `nock` was used only in tests, I added `no-implicit-dependencies` rule to tslint.json to avoid lint errors