### PR TITLE
Extract type declarations for @octokit/webhooks

### DIFF
--- a/bin/probot-simulate.js
+++ b/bin/probot-simulate.js
@@ -32,4 +32,4 @@ const probot = createProbot({
 probot.setup(program.args.slice(2))
 
 probot.logger.debug('Simulating event', eventName)
-probot.receive({event: eventName, payload})
+probot.receive({name: eventName, payload})

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -26,14 +26,14 @@ declare module '@octokit/webhooks' {
 
     export interface PayloadRepository {
       [key: string]: any
-      full_name: string
+      full_name?: string
       name: string
       owner: {
         [key: string]: any
         login: string
-        name: string
+        name?: string
       }
-      html_url: string
+      html_url?: string
     }
 
     export interface WebhookPayloadWithRepository {
@@ -42,14 +42,14 @@ declare module '@octokit/webhooks' {
       issue?: {
         [key: string]: any
         number: number
-        html_url: string
-        body: string
+        html_url?: string
+        body?: string
       }
       pull_request?: {
         [key: string]: any
         number: number
-        html_url: string
-        body: string
+        html_url?: string
+        body?: string
       }
       sender?: {
         [key: string]: any

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -1,0 +1,67 @@
+declare module '@octokit/webhooks' {
+  import { Application } from 'express'
+
+  interface Options {
+    path: string,
+    secret: string
+  }
+
+  declare class Webhooks {
+    public middleware: Application
+
+    constructor (Options)
+
+    public on (event: string, callback: (event: WebhookEvent | Error) => void)
+  }
+
+  declare namespace Webhooks {
+    export interface WebhookEvent {
+      id: string
+      name: string
+      payload: WebhookPayloadWithRepository
+      protocol?: 'http' | 'https'
+      host?: string
+      url?: string
+    }
+
+    export interface PayloadRepository {
+      [key: string]: any
+      full_name: string
+      name: string
+      owner: {
+        [key: string]: any
+        login: string
+        name: string
+      }
+      html_url: string
+    }
+
+    export interface WebhookPayloadWithRepository {
+      [key: string]: any
+      repository?: PayloadRepository
+      issue?: {
+        [key: string]: any
+        number: number
+        html_url: string
+        body: string
+      }
+      pull_request?: {
+        [key: string]: any
+        number: number
+        html_url: string
+        body: string
+      }
+      sender?: {
+        [key: string]: any
+        type: string
+      }
+      action?: string
+      installation?: {
+        id: number
+        [key: string]: any
+      }
+    }
+  }
+
+  export = Webhooks
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,8 +1,9 @@
+import { WebhookEvent } from '@octokit/webhooks'
 import Logger from 'bunyan'
 import cacheManager from 'cache-manager'
 import express from 'express'
 import { Application } from './application'
-import { Context, WebhookEvent } from './context'
+import { Context } from './context'
 import { createApp } from './github-app'
 import { logger } from './logger'
 import { resolve } from './resolver'
@@ -46,11 +47,8 @@ export class Probot {
     this.server = createServer({ webhook: this.webhook.middleware, logger })
 
     // Log all received webhooks
-    this.webhook.on('*', (event: any) => {
-      const webhookEvent = { ...event, event: event.name }
-      delete webhookEvent.name
-
-      return this.receive(webhookEvent)
+    this.webhook.on('*', (event: WebhookEvent) => {
+      return this.receive(event)
     })
 
     // Log all webhook errors

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { WebhookEvent } from '@octokit/webhooks'
+import Webhooks, { WebhookEvent } from '@octokit/webhooks'
 import Logger from 'bunyan'
 import cacheManager from 'cache-manager'
 import express from 'express'
@@ -12,7 +12,6 @@ import { createWebhookProxy } from './webhook-proxy'
 
 // tslint:disable:no-var-requires
 // These needs types
-const Webhooks = require('@octokit/webhooks')
 const logRequestErrors = require('./middleware/log-request-errors')
 
 const cache = cacheManager.caching({
@@ -29,7 +28,7 @@ const defaultApps: ApplicationFunction[] = [
 
 export class Probot {
   public server: express.Application
-  public webhook: any
+  public webhook: Webhooks
   public logger: Logger
 
   private options: Options

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -1,14 +1,14 @@
+import { PayloadRepository, WebhookEvent } from '@octokit/webhooks'
 import bunyan from 'bunyan'
 import express from 'express'
-import { PayloadRepository } from './context'
 
 export const serializers: bunyan.StdSerializers = {
 
-  event: (event: any) => {
+  event: (event: WebhookEvent | any) => {
     if (typeof event !== 'object' || !event.payload) {
       return event
     } else {
-      let name = event.event
+      let name = event.name
       if (event.payload && event.payload.action) {
         name = `${name}.${event.payload.action}`
       }

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -1,10 +1,11 @@
+ import { WebhookEvent } from '@octokit/webhooks'
 import { Application } from '../src/application'
 import { Context } from '../src/context'
 import { logger } from '../src/logger'
 
 describe('Application', () => {
   let app: Application
-  let event: any
+  let event: WebhookEvent
   let output: any
 
   beforeAll(() => {
@@ -25,8 +26,8 @@ describe('Application', () => {
     app.auth = jest.fn().mockReturnValue({})
 
     event = {
-      event: 'test',
       id: '123-456',
+      name: 'test',
       payload: {
         action: 'foo',
         installation: { id: 1 }
@@ -71,13 +72,14 @@ describe('Application', () => {
     })
 
     it('calls callback x amount of times when an array of x actions is passed', async () => {
-      const event2 = {
-        event: 'arrayTest',
+      const event2: WebhookEvent = {
+        id: '123',
+        name: 'arrayTest',
         payload: {
           action: 'bar',
           installation: { id: 2 }
         }
-      } as any
+      }
 
       const spy = jest.fn()
       app.on(['test.foo', 'arrayTest.bar'], spy)
@@ -105,8 +107,8 @@ describe('Application', () => {
 
     it('returns an authenticated client for installation.created', async () => {
       event = {
-        event: 'installation',
         id: '123-456',
+        name: 'installation',
         payload: {
           action: 'created',
           installation: { id: 1 }
@@ -124,8 +126,8 @@ describe('Application', () => {
 
     it('returns an unauthenticated client for installation.deleted', async () => {
       event = {
-        event: 'installation',
         id: '123-456',
+        name: 'installation',
         payload: {
           action: 'deleted',
           installation: { id: 1 }
@@ -143,8 +145,8 @@ describe('Application', () => {
 
     it('returns an authenticated client for events without an installation', async () => {
       event = {
-        event: 'foobar',
         id: '123-456',
+        name: 'foobar',
         payload: { /* no installation */ }
       }
 

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -262,4 +262,20 @@ describe('Application', () => {
       expect(output[0].event.id).toEqual(event.id)
     })
   })
+
+  describe('deprecations', () => {
+    test('recieve() accepts param with {event}', async () => {
+      const spy = jest.fn()
+      app.events.on('deprecated', spy)
+      await app.receive({ event: 'deprecated', payload: { action: 'test' } } as any)
+      expect(spy).toHaveBeenCalled()
+    })
+
+    test('recieve() accepts param with {name,event}', async () => {
+      const spy = jest.fn()
+      app.events.on('real-event-name', spy)
+      await app.receive({ name: 'real-event-name', event: 'deprecated', payload: { action: 'test' } } as any)
+      expect(spy).toHaveBeenCalled()
+    })
+  })
 })

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -221,4 +221,20 @@ describe('Context', () => {
       })
     })
   })
+
+  describe('isBot', () => {
+    test('returns true if sender is a bot', () => {
+      event.payload.sender = { type: 'Bot' }
+      context = new Context(event, {} as any, {} as any)
+
+      expect(context.isBot).toBe(true)
+    })
+
+    test('returns false if sender is not a bot', () => {
+      event.payload.sender = { type: 'User' }
+      context = new Context(event, {} as any, {} as any)
+
+      expect(context.isBot).toBe(false)
+    })
+  })
 })

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,16 +1,18 @@
 import fs = require('fs')
 import path = require('path')
 
+import { WebhookEvent } from '@octokit/webhooks'
 import { Context } from '../src/context'
 import { GitHubAPI, OctokitError } from '../src/github'
 
 describe('Context', () => {
-  let event: any
+  let event: WebhookEvent
   let context: Context
 
   beforeEach(() => {
     event = {
-      event: 'push',
+      id: '123',
+      name: 'push',
       payload: {
         issue: { number: 4 },
         repository: {
@@ -25,6 +27,11 @@ describe('Context', () => {
 
   it('inherits the payload', () => {
     expect(context.payload).toBe(event.payload)
+  })
+
+  it('aliases the event name', () => {
+    expect(context.name).toEqual('push')
+    expect(context.event).toEqual('push')
   })
 
   describe('repo', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,7 +22,7 @@ describe('Probot', () => {
       const app = probot.load(() => {})
       app.receive = jest.fn()
       await probot.webhook.receive(event)
-      expect(app.receive).toHaveBeenCalledWith({ event: event.name, payload: event.payload })
+      expect(app.receive).toHaveBeenCalledWith(event)
     })
 
     it('responds with the correct error if webhook secret does not match', async () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -12,7 +12,6 @@ describe('Probot', () => {
 
     event = {
       name: 'push',
-      event: 'push',
       payload: require('./fixtures/webhook/push')
     }
   })

--- a/test/serializers.test.js
+++ b/test/serializers.test.js
@@ -23,7 +23,7 @@ describe('serializers', () => {
   describe('event', () => {
     it('works with a legit event', () => {
       const event = {id: 1,
-        event: 'test',
+        name: 'test',
         payload: {
           action: 'test',
           repository: {full_name: 'probot/test'},
@@ -40,7 +40,7 @@ describe('serializers', () => {
 
     it('works a malformed event', () => {
       const event = {id: 1,
-        event: 'test',
+        name: 'test',
         payload: {}}
       expect(serializers.event(event)).toEqual({
         id: 1,


### PR DESCRIPTION
These changes were pulled out of #565 to try to slim that PR down.

Notable changes:

- Moves all type declarations for webhooks into `src/@types/@octokit/webhooks`. This is just a start and there's a lot of room for improvement for these types. Once we've had a chance to iterate on them a little, we can submit them upstream to `@octokit/webhooks`

- Deprecates `receive({event, ...})` in favor of using `receive({name, ...})`, which is what `@octokit/webhooks` uses. Apps using this method in tests should continue to pass, but they will see deprecation warnings. `context.event` is an alias for `context.name` and is not deprecated.

- Marks most `WebhookEvent` properties as optional. Until we get complete types for webhooks and some way to easily generate them, it's too much of a hassle to create valid objects in tests.