### PR TITLE
Refer to instances of ApplicationFunction as appFn

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -80,8 +80,7 @@ $ npm run dev
 > my-app@1.0.0 start /Users/z/Desktop/foo
 > probot run ./index.js
 
-Yay, the plugin was loaded!
-18:11:55.838Z DEBUG Probot: Loaded plugin: ./index.js
+18:11:55.838Z INFO probot: Yay, the app was loaded!
 ```
 
 The `dev` script will start your app using [nodemon](https://github.com/remy/nodemon#nodemon), which will watch for any files changes in your local development environment and automatically restart the server.

--- a/src/application.ts
+++ b/src/application.ts
@@ -14,7 +14,7 @@ function isUnauthenticatedEvent (event: WebhookEvent) {
 }
 
 /**
- * The `app` parameter available to apps
+ * The `app` parameter available to `ApplicationFunction`s
  *
  * @property {logger} log - A logger
  */
@@ -37,14 +37,14 @@ export class Application {
   }
 
   /**
-   * Loads a Probot plugin
-   * @param plugin - Probot plugin to load
+   * Loads an ApplicationFunction into the current Application
+   * @param appFn - Probot application function to load
    */
-  public load (app: ApplicationFunction | ApplicationFunction[]): Application {
-    if (Array.isArray(app)) {
-      app.forEach(a => this.load(a))
+  public load (appFn: ApplicationFunction | ApplicationFunction[]): Application {
+    if (Array.isArray(appFn)) {
+      appFn.forEach(a => this.load(a))
     } else {
-      app(this)
+      appFn(this)
     }
 
     return this

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ const cache = cacheManager.caching({
   ttl: 60 * 60 // 1 hour
 })
 
-const defaultApps: ApplicationFunction[] = [
+const defaultAppFns: ApplicationFunction[] = [
   require('./plugins/default'),
   require('./plugins/sentry'),
   require('./plugins/stats')
@@ -75,9 +75,9 @@ export class Probot {
     return Promise.all(this.apps.map(app => app.receive(event)))
   }
 
-  public load (appFunction: string | ApplicationFunction) {
-    if (typeof appFunction === 'string') {
-      appFunction = resolve(appFunction) as ApplicationFunction
+  public load (appFn: string | ApplicationFunction) {
+    if (typeof appFn === 'string') {
+      appFn = resolve(appFn) as ApplicationFunction
     }
 
     const app = new Application({ app: this.app, cache, catchErrors: true })
@@ -85,19 +85,19 @@ export class Probot {
     // Connect the router from the app to the server
     this.server.use(app.router)
 
-    // Initialize the plugin
-    app.load(appFunction)
+    // Initialize the ApplicationFunction
+    app.load(appFn)
     this.apps.push(app)
 
     return app
   }
 
-  public setup (apps: Array<string | ApplicationFunction>) {
+  public setup (appFns: Array<string | ApplicationFunction>) {
     // Log all unhandled rejections
     process.on('unhandledRejection', this.errorHandler)
 
-    // Load the given apps along with the default apps
-    apps.concat(defaultApps).forEach(app => this.load(app))
+    // Load the given appFns along with the default ones
+    appFns.concat(defaultAppFns).forEach(appFn => this.load(appFn))
 
     // Register error handler as the last middleware
     this.server.use(logRequestErrors)

--- a/src/plugins/stats.ts
+++ b/src/plugins/stats.ts
@@ -1,7 +1,7 @@
 import { AnyResponse } from '@octokit/rest'
 import { Request,Response } from 'express'
 
-// Built-in plugin to expose stats about the deployment
+// Built-in app to expose stats about the deployment
 module.exports = async (app: any): Promise<void> => {
   if (process.env.DISABLE_STATS) {
     return
@@ -12,7 +12,7 @@ module.exports = async (app: any): Promise<void> => {
   // Cache of stats that get reported
   const stats = { installations: 0, popular: [{}] }
 
-  // Refresh the stats when the plugin is loaded
+  // Refresh the stats when the ApplicationFunction is loaded
   const initializing = refresh()
 
   // Refresh the stats on an interval

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,14 +1,14 @@
 const defaultOptions: ResolveOptions = {}
 
-export const resolve = (app: string, opts?: ResolveOptions) => {
+export const resolve = (appFnId: string, opts?: ResolveOptions) => {
   opts = opts || defaultOptions
   // These are mostly to ease testing
   const basedir = opts.basedir || process.cwd()
   const resolver = opts.resolver || require('resolve').sync
-  return require(resolver(app, { basedir }))
+  return require(resolver(appFnId, { basedir }))
 }
 
 export interface ResolveOptions {
   basedir?: string
-  resolver?: (app: string, opts: {basedir: string}) => string
+  resolver?: (appFnId: string, opts: {basedir: string}) => string
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -83,11 +83,11 @@ describe('Probot', () => {
   describe('server', () => {
     it('prefixes paths with route name', () => {
       probot.load(app => {
-        const route = app.route('/my-plugin')
+        const route = app.route('/my-app')
         route.get('/foo', (req, res) => res.end('foo'))
       })
 
-      return request(probot.server).get('/my-plugin/foo').expect(200, 'foo')
+      return request(probot.server).get('/my-app/foo').expect(200, 'foo')
     })
 
     it('allows routes with no path', () => {
@@ -108,7 +108,7 @@ describe('Probot', () => {
       return request(probot.server).get('/').expect(200, 'foo')
     })
 
-    it('isolates plugins from affecting eachother', async () => {
+    it('isolates apps from affecting eachother', async () => {
       ['foo', 'bar'].forEach(name => {
         probot.load(app => {
           const route = app.route('/' + name)
@@ -180,7 +180,7 @@ describe('Probot', () => {
   })
 
   describe('receive', () => {
-    it('forwards events to each plugin', async () => {
+    it('forwards events to each app', async () => {
       const spy = jest.fn()
       const app = probot.load(app => app.on('push', spy))
       app.auth = jest.fn().mockReturnValue(Promise.resolve({}))
@@ -211,13 +211,13 @@ describe('Probot', () => {
     it('requests from the correct API URL', async () => {
       const spy = jest.fn()
 
-      const plugin = async app => {
+      const appFn = async app => {
         const github = await app.auth()
         const res = await github.apps.getInstallations({})
         return spy(res)
       }
 
-      await plugin(app)
+      await appFn(app)
       await app.receive(event)
       expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
     })

--- a/test/plugins/default.test.js
+++ b/test/plugins/default.test.js
@@ -1,13 +1,13 @@
 const request = require('supertest')
 const express = require('express')
-const plugin = require('../../src/plugins/default')
+const appFn = require('../../src/plugins/default')
 const helper = require('./helper')
 
-describe('default plugin', function () {
+describe('default app', function () {
   let server, app
 
   beforeEach(async () => {
-    app = helper.createApp(plugin)
+    app = helper.createApp(appFn)
     server = express()
     server.use(app.router)
   })

--- a/test/plugins/helper.js
+++ b/test/plugins/helper.js
@@ -8,9 +8,9 @@ const cache = cacheManager.caching({store: 'memory'})
 const jwt = jest.fn().mockReturnValue('test')
 
 module.exports = {
-  createApp (plugin = () => {}) {
+  createApp (appFn = () => {}) {
     const app = new Application({app: jwt, cache})
-    app.load(plugin)
+    app.load(appFn)
     return app
   }
 }

--- a/test/plugins/sentry.test.js
+++ b/test/plugins/sentry.test.js
@@ -1,10 +1,8 @@
 const Raven = require('raven')
-
-const plugin = require('../../src/plugins/sentry')
-
 const helper = require('./helper')
+const appFn = require('../../src/plugins/sentry')
 
-describe('sentry', () => {
+describe('sentry app', () => {
   let app
 
   beforeEach(async () => {
@@ -20,7 +18,7 @@ describe('sentry', () => {
     test('throws an error', () => {
       process.env.SENTRY_DSN = 1233
       expect(() => {
-        plugin(app)
+        appFn(app)
       }).toThrow(/Invalid Sentry DSN: 1233/)
     })
   })
@@ -28,7 +26,7 @@ describe('sentry', () => {
   describe('with a SENTRY_DSN', () => {
     beforeEach(() => {
       process.env.SENTRY_DSN = 'https://user:pw@sentry.io/123'
-      plugin(app)
+      appFn(app)
       Raven.captureException = jest.fn()
     })
 

--- a/test/plugins/stats.test.js
+++ b/test/plugins/stats.test.js
@@ -1,11 +1,10 @@
 const request = require('supertest')
 const express = require('express')
 const nock = require('nock')
-const plugin = require('../../src/plugins/stats')
-
 const helper = require('./helper')
+const appFn = require('../../src/plugins/stats')
 
-describe('stats', function () {
+describe('stats app', function () {
   let app, server
 
   beforeEach(() => {
@@ -26,7 +25,7 @@ describe('stats', function () {
           {private: false, stargazers_count: 2}
         ]})
 
-      app = helper.createApp(plugin)
+      app = helper.createApp(appFn)
       server.use(app.router)
     })
 
@@ -40,7 +39,7 @@ describe('stats', function () {
     beforeEach(async () => {
       process.env.DISABLE_STATS = 'true'
 
-      app = helper.createApp(plugin)
+      app = helper.createApp(appFn)
       server.use(app.router)
     })
 
@@ -61,7 +60,7 @@ describe('stats', function () {
           {private: false, stargazers_count: 2}
         ]})
 
-      app = helper.createApp(plugin)
+      app = helper.createApp(appFn)
       server.use(app.router)
     })
 

--- a/test/resolver.test.js
+++ b/test/resolver.test.js
@@ -1,18 +1,18 @@
 const {resolve} = require('../src/resolver')
 
-const stubPluginPath = require.resolve('./fixtures/plugin/stub-plugin')
+const stubAppFnPath = require.resolve('./fixtures/plugin/stub-plugin')
 const basedir = process.cwd()
 
 describe('resolver', () => {
   let stubResolver
 
   beforeEach(() => {
-    stubResolver = jest.fn().mockReturnValue(stubPluginPath)
+    stubResolver = jest.fn().mockReturnValue(stubAppFnPath)
   })
 
   it('loads the module at the resolved path', () => {
     const module = resolve('foo', {resolver: stubResolver})
-    expect(module).toBe(require(stubPluginPath))
+    expect(module).toBe(require(stubAppFnPath))
     expect(stubResolver).toHaveBeenCalledWith('foo', {basedir})
   })
 })


### PR DESCRIPTION
Stop using the names 'plugin' and 'app' to refer to instances of
ApplicationFunction.

This renames all variable names, but leaves the plugins folder in place,
to be renamed later

---

Partial fix for #632 