### PR TITLE
docs: Add probot-messages to extensions list

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -121,3 +121,26 @@ module.exports = app => {
 ```
 
 Check out [probot/unfurl](https://github.com/probot/unfurl) to see it in action.
+
+## Messages
+
+[probot-messages](https://github.com/dessant/probot-messages) is an extension for delivering messages that require user action to ensure the correct operation of the app, such as configuring the app after installation, or fixing configuration errors. A new issue is submitted for messages that don't already have an open issue, otherwise an optional update is posted on the existing issue in the form of a comment.
+
+```js
+const sendMessage = require('probot-messages');
+
+module.exports = app => {
+  app.on('installation_repositories.added', async context => {
+    for (const item of context.payload.repositories_added) {
+      const [owner, repo] = item.full_name.split('/');
+      await sendMessage(
+        app,
+        context,
+        '[{appName}] Getting started',
+        'Follow these steps to configure the app...',
+        {owner, repo}
+      );
+    }
+  });
+};
+```

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -127,20 +127,20 @@ Check out [probot/unfurl](https://github.com/probot/unfurl) to see it in action.
 [probot-messages](https://github.com/dessant/probot-messages) is an extension for delivering messages that require user action to ensure the correct operation of the app, such as configuring the app after installation, or fixing configuration errors. A new issue is submitted for messages that don't already have an open issue, otherwise an optional update is posted on the existing issue in the form of a comment.
 
 ```js
-const sendMessage = require('probot-messages');
+const sendMessage = require('probot-messages')
 
 module.exports = app => {
   app.on('installation_repositories.added', async context => {
     for (const item of context.payload.repositories_added) {
-      const [owner, repo] = item.full_name.split('/');
+      const [owner, repo] = item.full_name.split('/')
       await sendMessage(
         app,
         context,
         '[{appName}] Getting started',
         'Follow these steps to configure the app...',
         {owner, repo}
-      );
+      )
     }
-  });
-};
+  })
+}
 ```


### PR DESCRIPTION
I'm using this extension for notifying users about [config errors](https://github.com/dessant/reaction-comments/blob/104ffddd5c51f16d17ec35b25159d5ce67fb48cc/src/index.js#L93), and reminding them about the errors every once in a while, without worrying about opening multiple issues for the same error.

https://github.com/dessant/probot-messages