### PR TITLE
Added env var INSTALLATION_TOKEN_TTL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,5 +28,6 @@ Variable | Description
 `PORT` | The port to start the local server on. Default: `3000`.
 `SENTRY_DSN` | Set to a [Sentry](https://sentry.io/) DSN to report all errors thrown by your app.  <p>_(Example: `https://1234abcd@sentry.io/12345`)_</p>
 `WEBHOOK_PATH` | The URL path which will recieve webhooks. Default: `/`.
+`INSTALLATION_TOKEN_TTL` | The length of time installation auth tokens are cached by Probot. Default: `3540` _(59 minutes)_.
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,6 @@ Variable | Description
 `PORT` | The port to start the local server on. Default: `3000`.
 `SENTRY_DSN` | Set to a [Sentry](https://sentry.io/) DSN to report all errors thrown by your app.  <p>_(Example: `https://1234abcd@sentry.io/12345`)_</p>
 `WEBHOOK_PATH` | The URL path which will recieve webhooks. Default: `/`.
-`INSTALLATION_TOKEN_TTL` | The length of time installation auth tokens are cached by Probot. Default: `3540` _(59 minutes)_.
+`INSTALLATION_TOKEN_TTL` | The length of time installation access tokens are cached by Probot. This may be useful if your app is running long processes before accessing `context.github`. Default: `3540` (59 minutes) <p>_(Example: `3300` or 55 minutes)_</p>
 
 For more information on the formatting conventions and rules of `.env` files, check out [the npm `dotenv` module's documentation](https://www.npmjs.com/package/dotenv#rules).

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "ts-jest": {
         "skipBabel": true
       }
-    }
+    },
+    "testURL": "http://localhost/"
   },
   "keywords": [
     "probot",

--- a/src/application.ts
+++ b/src/application.ts
@@ -7,6 +7,9 @@ import { GitHubAPI } from './github'
 import { logger } from './logger'
 import { LoggerWithTarget, wrapLogger } from './wrap-logger'
 
+// Cache for 1 minute less than GitHub expiry
+const installationTokenTTL = parseInt(process.env.INSTALLATION_TOKEN_TTL || '3540', 10)
+
 // Some events can't get an authenticated client (#382):
 function isUnauthenticatedEvent (event: WebhookEvent) {
   return !event.payload.installation ||
@@ -197,7 +200,7 @@ export class Application {
         github.authenticate({ type: 'app', token: this.app() })
 
         return github.apps.createInstallationToken({ installation_id: String(id) })
-      }, { ttl: 60 * 59 }) // Cache for 1 minute less than GitHub expiry
+      }, { ttl: installationTokenTTL })
 
       github.authenticate({ type: 'token', token: res.data.token })
     } else {

--- a/src/application.ts
+++ b/src/application.ts
@@ -7,9 +7,6 @@ import { GitHubAPI } from './github'
 import { logger } from './logger'
 import { LoggerWithTarget, wrapLogger } from './wrap-logger'
 
-// Cache for 1 minute less than GitHub expiry
-const installationTokenTTL = parseInt(process.env.INSTALLATION_TOKEN_TTL || '3540', 10)
-
 // Some events can't get an authenticated client (#382):
 function isUnauthenticatedEvent (event: WebhookEvent) {
   return !event.payload.installation ||
@@ -193,6 +190,9 @@ export class Application {
       debug: process.env.LOG_LEVEL === 'trace',
       logger: log.child({ name: 'github', installation: String(id) })
     })
+
+    // Cache for 1 minute less than GitHub expiry
+    const installationTokenTTL = parseInt(process.env.INSTALLATION_TOKEN_TTL || '3540', 10)
 
     if (id) {
       const res = await this.cache.wrap(`app:${id}:token`, () => {

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -1,4 +1,7 @@
  import { WebhookEvent } from '@octokit/webhooks'
+import cacheManager from 'cache-manager'
+import nock from 'nock'
+
 import { Application } from '../src/application'
 import { Context } from '../src/context'
 import { logger } from '../src/logger'
@@ -276,6 +279,96 @@ describe('Application', () => {
       app.events.on('real-event-name', spy)
       await app.receive({ name: 'real-event-name', event: 'deprecated', payload: { action: 'test' } } as any)
       expect(spy).toHaveBeenCalled()
+    })
+  })
+
+  describe('auth cache', () => {
+    let scopeInstall: nock.Scope
+    let scopeData: nock.Scope
+
+    beforeEach(() => {
+      delete process.env.INSTALLATION_TOKEN_TTL
+
+      const cache = cacheManager.caching({
+        store: 'memory',
+        ttl: 60 * 60 // 1 hour
+      })
+      app = new Application({ cache } as any)
+      app.app = () => 'app-bearer-authorization-token'
+
+      nock.cleanAll()
+      scopeInstall = nock('https://api.github.com')
+        .post('/installations/1/access_tokens')
+        .reply(200, { token: 'installation-bearer-authorization-token' })
+      scopeData = nock('https://api.github.com')
+        .matchHeader('authorization', 'token installation-bearer-authorization-token')
+        .get('/orgs/myorg')
+        .reply(200, {})
+    })
+
+    afterEach(() => {
+      expect(scopeInstall.isDone()).toEqual(true)
+      expect(scopeData.isDone()).toEqual(true)
+    })
+
+    it('requests an installation token once for one event', async () => {
+      // Receive first event
+      app.on('test.foo', async context => {
+        await context.github.orgs.get({ org: 'myorg' })
+      })
+
+      await app.receive(event)
+    })
+
+    it('requests an installation token once for two events', async () => {
+      // Receive first event
+      app.on('test.foo', async context => {
+        await context.github.orgs.get({ org: 'myorg' })
+      })
+      await app.receive(event)
+
+      // Receive second event
+      const scopeInstallTwo = nock('https://api.github.com')
+        .post('/installations/1/access_tokens')
+          .reply(200, { token: 'token-should-not-be-requested' })
+      const scopeDataTwo = nock('https://api.github.com')
+        .matchHeader('authorization', 'token installation-bearer-authorization-token')
+        .get('/orgs/myorg')
+          .reply(200, {})
+      await app.receive(event)
+
+      // we should have not requested a second token, and just used the first one
+      expect(scopeInstallTwo.isDone()).toEqual(false)
+      expect(scopeDataTwo.isDone()).toEqual(true)
+    })
+
+    it('requests an installation token once for each event if not cached', async () => {
+      // Only cache token for 1 second
+      process.env.INSTALLATION_TOKEN_TTL = '1'
+
+      // Receive first event
+      app.on('test.foo', async context => {
+        await context.github.orgs.get({ org: 'myorg' })
+      })
+      await app.receive(event)
+
+      // Sleep for 2 seconds to let token cache expire
+      const sleep = async () => new Promise(resolve => setTimeout(resolve, 1200))
+      await sleep()
+
+      // Receive second event
+      const scopeInstallTwo = nock('https://api.github.com')
+        .post('/installations/1/access_tokens')
+          .reply(200, { token: 'second-installation-token' })
+      const scopeDataTwo = nock('https://api.github.com')
+        .matchHeader('authorization', 'token second-installation-token')
+        .get('/orgs/myorg')
+          .reply(200, {})
+      await app.receive(event)
+
+      // our second token should have been requested and used
+      expect(scopeInstallTwo.isDone()).toEqual(true)
+      expect(scopeDataTwo.isDone()).toEqual(true)
     })
   })
 })

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -286,8 +286,13 @@ describe('Application', () => {
     let scopeInstall: nock.Scope
     let scopeData: nock.Scope
 
-    beforeEach(() => {
+    const cleanGlobals = () => {
       delete process.env.INSTALLATION_TOKEN_TTL
+      nock.cleanAll()
+    }
+
+    beforeEach(() => {
+      cleanGlobals()
 
       const cache = cacheManager.caching({
         store: 'memory',
@@ -296,7 +301,6 @@ describe('Application', () => {
       app = new Application({ cache } as any)
       app.app = () => 'app-bearer-authorization-token'
 
-      nock.cleanAll()
       scopeInstall = nock('https://api.github.com')
         .post('/installations/1/access_tokens')
         .reply(200, { token: 'installation-bearer-authorization-token' })
@@ -309,6 +313,8 @@ describe('Application', () => {
     afterEach(() => {
       expect(scopeInstall.isDone()).toEqual(true)
       expect(scopeData.isDone()).toEqual(true)
+
+      cleanGlobals()
     })
 
     it('requests an installation token once for one event', async () => {

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -352,7 +352,7 @@ describe('Application', () => {
       })
       await app.receive(event)
 
-      // Sleep for 2 seconds to let token cache expire
+      // Sleep longer than ttl value to let token cache expire
       const sleep = async () => new Promise(resolve => setTimeout(resolve, 1200))
       await sleep()
 


### PR DESCRIPTION
Add env var `INSTALLATION_TOKEN_TTL` to customise how long auth tokens are cached for internally.
- added to documentation
- calculated once on probot load
- only reduces cache time for auth tokens

Closes #637 