### PR TITLE
Fixed jest tests not running due to insecure localhost warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
       "ts-jest": {
         "skipBabel": true
       }
-    }
+    },
+    "testURL": "http://localhost/"
   },
   "keywords": [
     "probot",


### PR DESCRIPTION
This fixes all tests not running in any environment.

Closes #639 