### PR TITLE
Remove all remnants of localtunnel

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -10,7 +10,6 @@ const {findPrivateKey} = require('../lib/private-key')
 program
   .usage('[options] <apps...>')
   .option('-p, --port <n>', 'Port to start the server on', process.env.PORT || 3000)
-  .option('-t, --tunnel <subdomain>', 'Deprecated: localtunnel support has been removed', process.env.SUBDOMAIN)
   .option('-W, --webhook-proxy <url>', 'URL of the webhook proxy service.`', process.env.WEBHOOK_PROXY_URL)
   .option('-w, --webhook-path <path>', 'URL path which receives webhooks. Ex: `/webhook`', process.env.WEBHOOK_PATH)
   .option('-a, --app <id>', 'ID of the GitHub App', process.env.APP_ID)
@@ -37,11 +36,6 @@ const probot = createProbot({
   webhookPath: program.webhookPath,
   webhookProxy: program.webhookProxy
 })
-
-if (!program.webhookProxy && program.tunnel) {
-  // TOOD: Remove for the 6.0.0 release
-  console.warn('[DEPRECATED] localtunnel support has been removed. See https://github.com/probot/probot/issues/391')
-}
 
 pkgConf('probot').then(pkg => {
   probot.setup(program.args.concat(pkg.apps || pkg.plugins || []))


### PR DESCRIPTION
I was looking at the code for `probot-run` and saw some old remnants of our `localtunnel` support. I think we've let the deprecation message run its course (especially since the comment here says to remove it in Probot 6, while we are now at 7).

Nod to #387 for original discussion on removing `localtunnel`.

