### PR TITLE
Add additional information to Sentry

### DIFF
--- a/src/apps/sentry.ts
+++ b/src/apps/sentry.ts
@@ -8,6 +8,12 @@ export = (app: Application) => {
     app.log.debug(process.env.SENTRY_DSN, 'Errors will be reported to Sentry')
     Raven.disableConsoleAlerts()
     Raven.config(process.env.SENTRY_DSN, {
+      captureUnhandledRejections: true,
+      tags: {
+        version: process.env.HEROKU_RELEASE_VERSION as string
+      },
+      release: process.env.HEROKU_SLUG_COMMIT,
+      environment: process.env.NODE_ENV || 'development',
       autoBreadcrumbs: true
     }).install()
 


### PR DESCRIPTION
Currently the Sentry configuration is quite minimal. This PR will add the following information:

* Version (version of deployed project)
* Revision (commit sha of deployed project). See https://docs.sentry.io/learn/releases/#tag-errors
* Environment (`production`, `development`, etc)
* Unhandled promise rejections

I'm hosting on Heroku and only know what environment variables Heroku passes to indicate the version and revision of the application. If there are other methods to retrieve the version or revision, please let me know.