### PR TITLE
Response object should call .send() and not .end()

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -16,7 +16,7 @@ module.exports = app => {
 
   // Add a new route
   router.get('/hello-world', (req, res) => {
-    res.end('Hello World')
+    res.send('Hello World')
   })
 }
 ```


### PR DESCRIPTION
`res.end()` is going to terminate the response process, and I believe this is not what the snippet is trying to acomplish.

Express API reference:
[res.send()](http://expressjs.com/pt-br/api.html#res.send) vs [res.end()](http://expressjs.com/pt-br/api.html#res.end)