### PR TITLE
Convert private-key tests to ts

### DIFF
--- a/src/private-key.ts
+++ b/src/private-key.ts
@@ -20,7 +20,7 @@ const hint = `please use:
  * @returns Private key
  * @private
  */
-function findPrivateKey (filepath: string): Buffer | string {
+export function findPrivateKey (filepath?: string): Buffer | string {
   if (filepath) {
     return fs.readFileSync(filepath)
   }
@@ -55,8 +55,4 @@ function findPrivateKey (filepath: string): Buffer | string {
     return findPrivateKey(pemFiles[0])
   }
   throw new Error(`Missing private key for GitHub App, ${hint}`)
-}
-
-module.exports = {
-  findPrivateKey
 }

--- a/test/private-key.test.ts
+++ b/test/private-key.test.ts
@@ -1,112 +1,112 @@
-const fs = require('fs')
+import fs from 'fs'
 const readFileSync = fs.readFileSync
 const readdirSync = fs.readdirSync
 
-const {findPrivateKey} = require('../src/private-key')
+import { findPrivateKey } from '../src/private-key'
 
-describe('private-key', function () {
-  let privateKey
-  let keyfilePath
+describe('private-key', () => {
+  let privateKey: string
+  let keyfilePath: string
 
-  beforeEach(function () {
+  beforeEach(() => {
     privateKey = '-----BEGIN RSA PRIVATE KEY-----\nTHIs+is+A+Fak3+K3y\n-----END RSA PRIVATE KEY-----'
     keyfilePath = '/some/path'
     fs.readFileSync = jest.fn().mockReturnValue(privateKey)
   })
 
-  afterEach(function () {
+  afterEach(() => {
     fs.readFileSync = readFileSync
   })
 
-  describe('findPrivateKey()', function () {
-    describe('when a filepath is provided', function () {
-      it('should read the file at given filepath', function () {
+  describe('findPrivateKey()', () => {
+    describe('when a filepath is provided', () => {
+      it('should read the file at given filepath', () => {
         findPrivateKey(keyfilePath)
         expect(fs.readFileSync).toHaveBeenCalledWith(keyfilePath)
       })
 
-      it('should return the key', function () {
+      it('should return the key', () => {
         expect(findPrivateKey(keyfilePath)).toEqual(privateKey)
       })
     })
 
-    describe('when a PRIVATE_KEY env var is provided', function () {
-      beforeEach(function () {
+    describe('when a PRIVATE_KEY env var is provided', () => {
+      beforeEach(() => {
         process.env.PRIVATE_KEY = privateKey
       })
 
-      afterEach(function () {
+      afterEach(() => {
         delete process.env.PRIVATE_KEY
       })
 
-      it('should return the key', function () {
+      it('should return the key', () => {
         process.env.PRIVATE_KEY = privateKey
         expect(findPrivateKey()).toEqual(privateKey)
       })
     })
 
-    describe('when a PRIVATE_KEY has line breaks', function () {
-      beforeEach(function () {
+    describe('when a PRIVATE_KEY has line breaks', () => {
+      beforeEach(() => {
         process.env.PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----\\nTHIs+is+A+Fak3+K3y\\n-----END RSA PRIVATE KEY-----'
       })
 
-      afterEach(function () {
+      afterEach(() => {
         delete process.env.PRIVATE_KEY
       })
 
-      it('should return the key', function () {
+      it('should return the key', () => {
         expect(findPrivateKey()).toEqual(privateKey)
       })
     })
 
-    describe('when a PRIVATE_KEY is base64 encoded', function () {
-      beforeEach(function () {
+    describe('when a PRIVATE_KEY is base64 encoded', () => {
+      beforeEach(() => {
         process.env.PRIVATE_KEY = Buffer.from(privateKey).toString('base64')
       })
 
-      afterEach(function () {
+      afterEach(() => {
         delete process.env.PRIVATE_KEY
       })
 
-      it('should decode and return the key', function () {
+      it('should decode and return the key', () => {
         expect(findPrivateKey()).toEqual(privateKey)
       })
     })
 
-    describe('when a PRIVATE_KEY_PATH env var is provided', function () {
-      beforeEach(function () {
+    describe('when a PRIVATE_KEY_PATH env var is provided', () => {
+      beforeEach(() => {
         process.env.PRIVATE_KEY_PATH = keyfilePath
       })
 
-      afterEach(function () {
+      afterEach(() => {
         delete process.env.PRIVATE_KEY_PATH
       })
 
-      it('should read the file at given filepath', function () {
+      it('should read the file at given filepath', () => {
         findPrivateKey()
         expect(fs.readFileSync).toHaveBeenCalledWith(keyfilePath)
       })
 
-      it('should return the key', function () {
+      it('should return the key', () => {
         expect(findPrivateKey()).toEqual(privateKey)
       })
     })
 
-    describe('when no private key is provided', function () {
-      beforeEach(function () {
+    describe('when no private key is provided', () => {
+      beforeEach(() => {
         fs.readdirSync = jest.fn().mockReturnValue([
           'foo.txt',
           'foo.pem'
         ])
       })
 
-      it('should look for one in the current directory', function () {
+      it('should look for one in the current directory', () => {
         findPrivateKey()
         expect(fs.readdirSync).toHaveBeenCalledWith(process.cwd())
       })
 
-      describe('and several key files are present', function () {
-        beforeEach(function () {
+      describe('and several key files are present', () => {
+        beforeEach(() => {
           fs.readdirSync = jest.fn().mockReturnValue([
             'foo.txt',
             'foo.pem',
@@ -114,24 +114,24 @@ describe('private-key', function () {
           ])
         })
 
-        it('should throw an error', function () {
+        it('should throw an error', () => {
           expect(findPrivateKey).toThrow(/Found several private keys: foo.pem, bar.pem/i)
         })
       })
 
-      describe('and a key file is present', function () {
-        it('should load the key file', function () {
+      describe('and a key file is present', () => {
+        it('should load the key file', () => {
           findPrivateKey()
           expect(fs.readFileSync).toHaveBeenCalledWith('foo.pem')
         })
       })
 
-      describe('and a key file is not present', function () {
-        beforeEach(function () {
+      describe('and a key file is not present', () => {
+        beforeEach(() => {
           fs.readdirSync = readdirSync
         })
 
-        it('should throw an error', function () {
+        it('should throw an error', () => {
           expect(findPrivateKey).toThrow(/missing private key for GitHub App/i)
         })
       })


### PR DESCRIPTION
Update private-key.ts to export the function without module.exports.

Change tests to typescript

Related to https://github.com/probot/probot/issues/582