### PR TITLE
update octokit/rest and tests to use /app/installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^15.9.4",
+    "@octokit/rest": "^15.11.0",
     "@octokit/webhooks": "5.0.0",
     "bottleneck": "^2.8.0",
     "bunyan": "^1.8.12",

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -302,7 +302,7 @@ describe('Application', () => {
       app.app = () => 'app-bearer-authorization-token'
 
       scopeInstall = nock('https://api.github.com')
-        .post('/installations/1/access_tokens')
+        .post('/app/installations/1/access_tokens')
         .reply(200, { token: 'installation-bearer-authorization-token' })
       scopeData = nock('https://api.github.com')
         .matchHeader('authorization', 'token installation-bearer-authorization-token')
@@ -335,7 +335,7 @@ describe('Application', () => {
 
       // Receive second event
       const scopeInstallTwo = nock('https://api.github.com')
-        .post('/installations/1/access_tokens')
+        .post('/app/installations/1/access_tokens')
           .reply(200, { token: 'token-should-not-be-requested' })
       const scopeDataTwo = nock('https://api.github.com')
         .matchHeader('authorization', 'token installation-bearer-authorization-token')
@@ -364,7 +364,7 @@ describe('Application', () => {
 
       // Receive second event
       const scopeInstallTwo = nock('https://api.github.com')
-        .post('/installations/1/access_tokens')
+        .post('/app/installations/1/access_tokens')
           .reply(200, { token: 'second-installation-token' })
       const scopeDataTwo = nock('https://api.github.com')
         .matchHeader('authorization', 'token second-installation-token')

--- a/test/apps/stats.test.js
+++ b/test/apps/stats.test.js
@@ -18,7 +18,7 @@ describe('stats app', function () {
     beforeEach(async () => {
       nock('https://api.github.com')
         .defaultReplyHeaders({'Content-Type': 'application/json'})
-        .post('/installations/1/access_tokens').reply(200, {token: 'test'})
+        .post('/app/installations/1/access_tokens').reply(200, {token: 'test'})
         .get('/app/installations?per_page=100').reply(200, [{id: 1, account: {login: 'testing'}}])
         .get('/installation/repositories?per_page=100').reply(200, {repositories: [
           {private: true, stargazers_count: 1},
@@ -53,7 +53,7 @@ describe('stats app', function () {
       process.env.IGNORED_ACCOUNTS = 'hiimbex,spammyUser'
       nock('https://api.github.com')
         .defaultReplyHeaders({'Content-Type': 'application/json'})
-        .post('/installations/1/access_tokens').reply(200, {token: 'test'})
+        .post('/app/installations/1/access_tokens').reply(200, {token: 'test'})
         .get('/app/installations?per_page=100').reply(200, [{id: 1, account: {login: 'spammyUser'}}])
         .get('/installation/repositories?per_page=100').reply(200, {repositories: [
           {private: true, stargazers_count: 1},


### PR DESCRIPTION
Closes https://github.com/probot/probot/issues/679

Updates octokit/rest which includes [this](https://github.com/octokit/rest.js/commit/830088c9ba41f2b5884157c240e47116cbefc522) endpoint update which is being [deprecated](https://developer.github.com/changes/2018-08-16-renaming-and-deprecation-of-github-app-installation-access-token-route/).