### PR TITLE
check if error message exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,11 +55,13 @@ export class Probot {
   }
 
   public errorHandler (err: Error) {
-    const errMessage = err.message.toLowerCase()
-    if (errMessage.includes('x-hub-signature')) {
-      logger.error({ err }, 'Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.')
-    } else if (errMessage.includes('pem') || errMessage.includes('json web token')) {
-      logger.error({ err }, 'Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you\'re deploying to Now, visit https://probot.github.io/docs/deployment/#now.')
+    if (err.message) {
+      const errMessage = err.message.toLowerCase()
+      if (errMessage.includes('x-hub-signature')) {
+        logger.error({ err }, 'Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.')
+      } else if (errMessage.includes('pem') || errMessage.includes('json web token')) {
+        logger.error({ err }, 'Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you\'re deploying to Now, visit https://probot.github.io/docs/deployment/#now.')
+      }
     } else {
       logger.error(err)
     }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -46,3 +46,9 @@ Array [
   "Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.",
 ]
 `;
+
+exports[`Probot webhook delivery responds with the error even if the was no error message 1`] = `
+Array [
+  [Error: null],
+]
+`;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -78,6 +78,19 @@ describe('Probot', () => {
         expect(probot.logger.error.mock.calls[0]).toMatchSnapshot()
       }
     })
+
+    it('responds with the error even if the was no error message', async () => {
+      probot.logger.error = jest.fn()
+      let err = Error()
+      err.message = null
+      probot.webhook.on('*', () => { throw err })
+
+      try {
+        await probot.webhook.receive(event)
+      } catch (e) {
+        expect(probot.logger.error.mock.calls[0]).toMatchSnapshot()
+      }
+    })
   })
 
   describe('server', () => {


### PR DESCRIPTION
Fixes https://github.com/probot/probot/issues/673 by checking if `err.message` exists and adding a test to expose this issue.