### PR TITLE
Resolve Jest transform option deprecation warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
       "node"
     ],
     "transform": {
-      ".+\\.tsx?$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      ".+\\.tsx?$": "ts-jest"
     },
     "testMatch": [
       "<rootDir>/test/**/*.(ts|js)"


### PR DESCRIPTION
When cloning this repo, running `npm install`, and then running `npm test`, I see the following deprecation warning from Jest:

```
[ts-jest][DEPRECATED] - replace any occurrences of "ts-jest/dist/preprocessor.js" or  "<rootDir>/node_modules/ts-jest/preprocessor.js" in the 'transform' section of your Jest config with just "ts-jest".
```

This code change resolves this logged deprecation warning.

