### PR TITLE
Create serverless-deployment.md

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -175,4 +175,4 @@ Probot comes bundled with a client for the [Sentry](https://github.com/getsentry
   3. Set the `SENTRY_DSN` environment variable with the DSN you retrieved.
 
 ## Serverless
-Serverless abstracts away the most menial parts of building an application, leaving developers to write code and not actively manage scaling for their applications. The [Serverless Deployment](/serverless-deployment) will show you how to deploy you application using functions instead of servers.
+Serverless abstracts away the most menial parts of building an application, leaving developers to write code and not actively manage scaling for their applications. The [Serverless Deployment](/serverless-deployment) section will show you how to deploy you application using functions instead of servers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,6 +18,7 @@ Every app can either be deployed stand-alone, or combined with other apps in one
 1. [Share the app](#share-the-app)
 1. [Combining apps](#combining-apps)
 1. [Error tracking](#error-tracking)
+1. [Servereless Deployments](#serverless)
 
 ## Create the GitHub App
 
@@ -172,3 +173,6 @@ Probot comes bundled with a client for the [Sentry](https://github.com/getsentry
   1. [Install Sentry from Marketplace](https://github.com/marketplace/sentry) (with [10k events/month free](https://github.com/marketplace/sentry/plan/MDIyOk1hcmtldHBsYWNlTGlzdGluZ1BsYW40Nw==#pricing-and-setup)) or [host your own instance](https://github.com/getsentry/sentry) (Students can get [extra Sentry credit](https://education.github.com/pack))
   2. Follow the setup instructions to find your DSN.
   3. Set the `SENTRY_DSN` environment variable with the DSN you retrieved.
+
+## Serverless
+Serverless abstracts away the most menial parts of building an application, leaving developers to write code and not actively manage scaling for their applications. The [Serverless Deployment](/serverless-deployment) will show you how to deploy you application using functions instead of servers.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -18,7 +18,7 @@ Every app can either be deployed stand-alone, or combined with other apps in one
 1. [Share the app](#share-the-app)
 1. [Combining apps](#combining-apps)
 1. [Error tracking](#error-tracking)
-1. [Servereless Deployments](#serverless)
+1. [Serverless Deployments](#serverless)
 
 ## Create the GitHub App
 

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -31,6 +31,8 @@ To deploy an app to any cloud provider, you will need 3 environment variables:
 
 > These environment variables will need to be pass through to your FaaS solution. Each solution is different, please consult their documentation on how to use variables in the deployed environment. 
 
+Choosing a FaaS provider is mostly dependent on developer preference. Each Probot plugin interacts in a similar fashion, but the plugins implementation is dealing with different requests and responses specific to the provider. If you do not have a preference for a provider, choose the solution you have the most familiarity with.
+
 ### AWS Lambda
 
 AWS Lambda is an event-driven, serverless computing platform provided by Amazon as a part of the Amazon Web Services. AWS Lamba additionally manages the computing resources required for the code and adjusts those resources in conjunction with incoming events.

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -29,15 +29,15 @@ To deploy an app to any cloud provider, you will need 3 environment variables:
 - `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
 - `PRIVATE_KEY_PATH`: the path to a private key file
 
-> These environment variables will need to be pass through to your FaaS solution. Each solution is different, please consult their documentation on how to use variables in the deployed environment. 
+> These environment variables will need to be passed through to your FaaS solution. Each solution is different; please consult their documentation on how to use variables in the deployed environment. 
 
-Choosing a FaaS provider is mostly dependent on developer preference. Each Probot plugin interacts in a similar fashion, but the plugins implementation is dealing with different requests and responses specific to the provider. If you do not have a preference for a provider, choose the solution you have the most familiarity with.
+Choosing a FaaS provider is mostly dependent on developer preference. Each Probot plugin interacts similarly, but the plugins implementation is dealing with different requests and responses specific to the provider. If you do not have a preference for a provider, choose the solution you have the most familiarity.
 
 ### AWS Lambda
 
 AWS Lambda is an event-driven, serverless computing platform provided by Amazon as a part of the Amazon Web Services. AWS Lamba additionally manages the computing resources required for the code and adjusts those resources in conjunction with incoming events.
 1. [Install the @probot/serverless-lambda](https://github.com/probot/serverless-lambda#usage) plugin.
-2. Create a `handler.js` file in the route of you probot application
+2. Create a `handler.js` file in the root of you probot application
    ```
    // handler.js
    const serverless = require('@probot/serverless-lambda')
@@ -47,11 +47,11 @@ AWS Lambda is an event-driven, serverless computing platform provided by Amazon 
 2. Follow the lambda [configuration steps](https://github.com/probot/serverless-lambda#configuration) using the [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless).
 3. Once the app is is configured and you can proceed with deploying using the either [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless)
 
-> note: The Serverless framework provides a simpler approach to setting up your AWS environment. It requires the creation of a serverless.yml in the root of your application.
+> note: The Serverless framework provides a more straightforward approach to setting up your AWS environment. It requires the creation of a serverless.yml in the root of your application.
 
 ### Google Cloud Function
 
-Google Cloud Platform, is a suite of cloud computing services that runs on the same infrastructure that Google uses internally for its end-user products. Cloud Functions are the Platform's FaaS offering.
+Google Cloud Platform, is a suite of cloud computing services that run on the same infrastructure that Google uses internally for its end-user products. Cloud Functions are the Platform's FaaS offering.
 
 1. [Install the @probot/serverless-gcf](https://github.com/probot/serverless-gcf#usage) plugin.
 2. Create a `handler.js` file in the route of you probot application

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -4,7 +4,9 @@ next: docs/persistence.md
 
 # Serverless Deployment
 
-Serverless computing is a model which aims to abstract server management without concerns for implementing, tweaking, or scaling a server (at least, to the perspective of a user). The follow sections will provide examples on how to deploy your application to service that will run on-demand as a Function as a Service(FaaS).
+Serverless computing is a model which aims to abstract server management without concerns for implementing, tweaking, or scaling a server (at least, to the perspective of a user). The following sections will provide examples on how to deploy your application to service that will run on-demand as a Function as a Service(FaaS).
+
+To learn more about other FaaS offerings and the concept of serverless, check out the [comparisons and case studies](https://serverless.com/learn/overview) created by the Serverless Framework.
 
 > Deploying to FaaS provider will require you to first [create a GitHub App](#create-the-github-app)
 
@@ -17,16 +19,7 @@ Serverless computing is a model which aims to abstract server management without
 
 ## Create the GitHub App
 
-Every deployment will need an [App](https://developer.github.com/apps/).
-
-1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
-    - **Homepage URL**: the URL to the GitHub repository for your app
-    - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed app.
-    - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed app.
-
-1. Download the private key from the app and rename it to private-key.pem.
-
-1. Make sure that you click the green **Install** button on the top left of the app page. This gives you an option of installing the app on all or a subset of your repositories.
+Every deployment will need an [App](https://developer.github.com/apps/). If you have not created a GitHub App, you learn how using the [Deployment section of our docs](/deployment/#create-the-github-app)
 
 ## Deploy the app
 
@@ -37,7 +30,7 @@ To deploy an app to any cloud provider, you will need 2 environment variables:
 
 ### AWS Lambda
 
-AWS Lambda is an event-driven, serverless computing platform provided by Amazon as a part of the Amazon Web Services. It is a computing service that runs code in response to events and automatically manages the computing resources required by that code.
+AWS Lambda is an event-driven, serverless computing platform provided by Amazon as a part of the Amazon Web Services. AWS Lamba additionally manages the computing resources required for the code and adjusts those resources in conjunction with incoming events.
 1. [Install the @probot/serverless-lambda](https://github.com/probot/serverless-lambda#usage) plugin.
 2. Create a `handler.js` file in the route of you probot application
    ```

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -47,7 +47,7 @@ AWS Lambda is an event-driven, serverless computing platform provided by Amazon 
 2. Follow the lambda [configuration steps](https://github.com/probot/serverless-lambda#configuration) using the [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless).
 3. Once the app is is configured and you can proceed with deploying using the either [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless)
 
-> note: The Servereless framework provides a simpler approach to setting up your AWS environment. It requires the creation of a serverless.yml in the root of your application.
+> note: The Serverless framework provides a simpler approach to setting up your AWS environment. It requires the creation of a serverless.yml in the root of your application.
 
 ### Google Cloud Function
 

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -8,7 +8,7 @@ Serverless computing is a model which aims to abstract server management without
 
 To learn more about other FaaS offerings and the concept of serverless, check out the [comparisons and case studies](https://serverless.com/learn/overview) created by the Serverless Framework.
 
-> Deploying to FaaS provider will require you to first [create a GitHub App](#create-the-github-app)
+> note: Deploying to FaaS provider will require you to first [create a GitHub App](#create-the-github-app)
 
 **Contents:**
 
@@ -23,10 +23,13 @@ Every deployment will need an [App](https://developer.github.com/apps/). If you 
 
 ## Deploy the app
 
-To deploy an app to any cloud provider, you will need 2 environment variables:
+To deploy an app to any cloud provider, you will need 3 environment variables:
 
 - `APP_ID`: the ID of the app, which you can get from the [app settings page](https://github.com/settings/apps).
 - `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
+- `PRIVATE_KEY_PATH`: the path to a private key file
+
+> These environment variables will need to be pass through to your FaaS solution. Each solution is different, please consult their documentation on how to use variables in the deployed environment. 
 
 ### AWS Lambda
 

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -1,0 +1,67 @@
+---
+next: docs/persistence.md
+---
+
+# Serverless Deployment
+
+Serverless computing is a model which aims to abstract server management without concerns for implementing, tweaking, or scaling a server (at least, to the perspective of a user). The follow sections will provide examples on how to deploy your application to service that will run on-demand as a Function as a Service(FaaS).
+
+> Deploying to FaaS provider will require you to first [create a GitHub App](#create-the-github-app)
+
+**Contents:**
+
+1. [Create the GitHub App](#create-the-github-app)
+1. [Deploy the app to a FaaS provider](#deploy-the-app)
+    1. [AWS Lambda](#aws-lambda)
+    1. [Google Cloud Function](#google-cloud-function)
+
+## Create the GitHub App
+
+Every deployment will need an [App](https://developer.github.com/apps/).
+
+1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
+    - **Homepage URL**: the URL to the GitHub repository for your app
+    - **Webhook URL**: Use `https://example.com/` for now, we'll come back in a minute to update this with the URL of your deployed app.
+    - **Webhook Secret**: Generate a unique secret with `openssl rand -base64 32` and save it because you'll need it in a minute to configure your deployed app.
+
+1. Download the private key from the app and rename it to private-key.pem.
+
+1. Make sure that you click the green **Install** button on the top left of the app page. This gives you an option of installing the app on all or a subset of your repositories.
+
+## Deploy the app
+
+To deploy an app to any cloud provider, you will need 2 environment variables:
+
+- `APP_ID`: the ID of the app, which you can get from the [app settings page](https://github.com/settings/apps).
+- `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
+
+### AWS Lambda
+
+AWS Lambda is an event-driven, serverless computing platform provided by Amazon as a part of the Amazon Web Services. It is a computing service that runs code in response to events and automatically manages the computing resources required by that code.
+1. [Install the @probot/serverless-lambda](https://github.com/probot/serverless-lambda#usage) plugin.
+2. Create a `handler.js` file in the route of you probot application
+   ```
+   // handler.js
+   const serverless = require('@probot/serverless-lambda')
+   const appFn = require('./')
+   module.exports.probot = serverless(appFn)
+   ```
+2. Follow the lambda [configuration steps](https://github.com/probot/serverless-lambda#configuration) using the [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless).
+3. Once the app is is configured and you can proceed with deploying using the either [AWS CLI](https://aws.amazon.com/cli/) or [Serverless framework](https://github.com/serverless/serverless)
+
+> note: The Servereless framework provides a simpler approach to setting up your AWS environment. It requires the creation of a serverless.yml in the root of your application.
+
+### Google Cloud Function
+
+Google Cloud Platform, is a suite of cloud computing services that runs on the same infrastructure that Google uses internally for its end-user products. Cloud Functions are the Platform's FaaS offering.
+
+1. [Install the @probot/serverless-gcf](https://github.com/probot/serverless-gcf#usage) plugin.
+2. Create a `handler.js` file in the route of you probot application
+   ```
+   // handler.js
+   const serverless = require('@probot/serverless-gcf')
+   const appFn = require('./')
+   module.exports.probot = serverless(appFn)
+   ```
+2. Follow the GCF [configuration steps](https://github.com/probot/gcf#configuration) using the [gcloud CLI](https://cloud.google.com/pubsub/docs/quickstart-cli) or [Serverless framework](https://github.com/serverless/serverless).
+3. Once the app is is configured and you can proceed with deploying using the either [gcloud CLI](https://cloud.google.com/pubsub/docs/quickstart-cli) or [Serverless framework](https://github.com/serverless/serverless)


### PR DESCRIPTION
I have worked alongside @tcbyrd and @JasonEtco testing out their Serverless plugins in preparation for a Serverless conference I am attending this week. Having a Serverless section would be nice to share while at the conference, but not required.

This PR adds a new Serverless section to the docs (open to suggestions on placement), @hiimbex mentioned creating a new section to assist not over-crowding the (already existing) deployment.md.

After this week, I plan to begin working with another provider (Azure).