### PR TITLE
Fix #707 add alias for app.error to app.log.error

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -25,6 +25,7 @@ export class Application {
   public router: express.Router
   public catchErrors: boolean
   public log: LoggerWithTarget
+  public error: LoggerWithTarget['error']
 
   constructor (options?: Options) {
     const opts = options || {} as any


### PR DESCRIPTION
Adds TypeScript typings for `app.error`, which is undocumented but currently works. It is the `error` property of the logger