### PR TITLE
remove manual base64 encoding/decoding of private key

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -113,16 +113,12 @@ Zeit [Now](http://zeit.co/now) is a great service for running Probot apps. After
 
 1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
 
-1. Add a `now-start` script to `package.json` as follows:
-
-        "now-start": "PRIVATE_KEY=$(echo $PRIVATE_KEY_BASE64 | base64 -d) npm start"
-
-1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the `PRIVATE_KEY_BASE64`:
+1. Run `now` to deploy, replacing the `APP_ID` and `WEBHOOK_SECRET` with the values for those variables, and setting the `PRIVATE_KEY`:
 
         $ now -e APP_ID=aaa \
             -e WEBHOOK_SECRET=bbb \
             -e NODE_ENV=production \
-            -e PRIVATE_KEY_BASE64="$(cat ~/Downloads/*.private-key.pem | base64)"
+            -e PRIVATE_KEY="$(cat ~/Downloads/*.private-key.pem | base64)"
 
       **NOTE**: Add `-e LOG_LEVEL=trace` to get verbose logging, or add `-e LOG_LEVEL=info` instead to show less details.
 


### PR DESCRIPTION
## What
Update deployment instructions for Now

## Why
Manually base64 encoding the the `PRIVATE_KEY` value and decoding it in a `now-start` hook is no longer necessary now that Probot [recognizes and decodes base64 encoded private keys](https://github.com/probot/probot/blob/f6946a0607fc835ef828bfb414aef8b234b02e56/src/private-key.ts#L30-L33). This should simply the deployment process as there is one less step for new users to get a Probot deployment up and running. 😊

-----
[View rendered docs/deployment.md](https://github.com/dmlittle/probot/blob/master/docs/deployment.md)