### PR TITLE
Add done parameter to paginate callback in GitHubAPI interface

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -49,7 +49,7 @@ export interface OctokitError extends Error {
 }
 
 export interface GitHubAPI extends Octokit {
-  paginate: (res: Promise<Octokit.AnyResponse>, callback: (results: Octokit.AnyResponse) => void) => Promise<any[]>
+  paginate: (res: Promise<Octokit.AnyResponse>, callback: (response: Promise<Octokit.AnyResponse>, done?: () => void) => void) => Promise<any[]>
   // The following are added because Octokit does not expose the hook.error, hook.before, and hook.after methods
   hook: {
     error: (when: 'request', callback: (error: OctokitError, options: RequestOptions) => void) => void


### PR DESCRIPTION
Adds the `done` parameter to the `paginate` callback in the `GitHubAPI` interface. This partially fixes #670.