### PR TITLE
Update octokit rest

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
   "author": "Brandon Keepers",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^15.11.0",
+    "@octokit/rest": "^15.13.0",
     "@octokit/webhooks": "^5.0.2",
     "@types/supports-color": "^5.3.0",
     "bottleneck": "^2.8.0",

--- a/src/application.ts
+++ b/src/application.ts
@@ -199,7 +199,7 @@ export class Application {
         log.trace(`creating token for installation`)
         github.authenticate({ type: 'app', token: this.app() })
 
-        return github.apps.createInstallationToken({ installation_id: String(id) })
+        return github.apps.createInstallationToken({ installation_id: id })
       }, { ttl: installationTokenTTL })
 
       github.authenticate({ type: 'token', token: res.data.token })


### PR DESCRIPTION
This update was [failing](https://travis-ci.org/probot/probot/jobs/437917736#L475) due to octokit expecting a number for an installation id instead of a string.

This issue https://github.com/octokit/rest.js/issues/1001 led to octokit rewriting many `id` parameters for the API (correctly) as integers, where they were previously strings.

Not sure what npm version to consider this change since it has the potential to break people using API endpoints where they're passing strings as `id` values.