### PR TITLE
Prefill Glitch app name as GitHub app name for app manifests

### DIFF
--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -44,7 +44,7 @@ export class ManifestCreation {
       hook_attributes: {
         url: process.env.WEBHOOK_PROXY_URL || `${baseUrl}/`
       },
-      name: manifest.name || pkg.name,
+      name: manifest.name || pkg.name || process.env.PROJECT_DOMAIN,
       public: manifest.public || true,
       redirect_url: `${baseUrl}/probot/setup`,
       // TODO: add setup url

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -44,7 +44,7 @@ export class ManifestCreation {
       hook_attributes: {
         url: process.env.WEBHOOK_PROXY_URL || `${baseUrl}/`
       },
-      name: manifest.name || pkg.name || process.env.PROJECT_DOMAIN,
+      name: process.env.PROJECT_DOMAIN || manifest.name || pkg.name,
       public: manifest.public || true,
       redirect_url: `${baseUrl}/probot/setup`,
       // TODO: add setup url


### PR DESCRIPTION
I have no clue how to test if this works or not, but I think this should do it. I did try _something_ tho: I did `npm i && npm start` which threw an error for me.

Any way for me to test if this addition works? 😅

Thanks! 💖

<hr />
Closes #712.