### PR TITLE
Add documentation about template flag

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -12,8 +12,10 @@ To develop a Probot app, you will first need a recent version of [Node.js](https
 
 To get started, run one of these commands:
 
-- If you're using npm: `$ npx create-probot-app [--typescript] my-first-app`
-- or, if you're using Yarn: `$ yarn create probot-app [--typescript] my-first-app`
+- If you're using npm: `$ npx create-probot-app my-first-app [--template=basic-ts]`
+- or, if you're using Yarn: `$ yarn create probot-app my-first-app [--template=basic-ts]`
+
+> The `template` argument is optional and accepts the following values: `basic-js` (default), `checks-js`, `git-data-js`, `deploy-js` and `basic-ts` (use this one for TypeScript support).
 
 This will ask you a series of questions about your app, which should look something like this:
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -28,7 +28,12 @@ Let's create a Probot app!
 ? Homepage:
 ? GitHub user or org name: khorne3
 ? Repository name: my-first-app
-? Which template would you like to use? basic-js
+? Which template would you like to use? (Use arrow keys)
+❯ basic-js 
+  checks-js 
+  git-data-js 
+  deploy-js 
+  basic-ts 
 created files...
 Finished scaffolding files!
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,7 +12,7 @@ To develop a Probot app, you will first need a recent version of [Node.js](https
 
 To get started, run one of these commands:
 
-- If you're using npm: `$ npx create-probot-app my-first-app [--template=basic-ts]`
+- If you're using npm: `$ npx create-probot-app my-first-app`
 - or, if you're using Yarn: `$ yarn create probot-app my-first-app`
 
 > The `template` argument is optional and accepts the following values: `basic-js` (default), `checks-js`, `git-data-js`, `deploy-js` and `basic-ts` (use this one for TypeScript support).

--- a/docs/development.md
+++ b/docs/development.md
@@ -15,7 +15,7 @@ To get started, run one of these commands:
 - If you're using npm: `$ npx create-probot-app my-first-app`
 - or, if you're using Yarn: `$ yarn create probot-app my-first-app`
 
-> The `template` argument is optional and accepts the following values: `basic-js` (default), `checks-js`, `git-data-js`, `deploy-js` and `basic-ts` (use this one for TypeScript support).
+> `create-probot-app` accepts an optional `template` argument which accepts the following values: `basic-js`, `checks-js`, `git-data-js`, `deploy-js` and `basic-ts` (use this one for TypeScript support).
 
 This will ask you a series of questions about your app, which should look something like this:
 
@@ -28,6 +28,7 @@ Let's create a Probot app!
 ? Homepage:
 ? GitHub user or org name: khorne3
 ? Repository name: my-first-app
+? Which template would you like to use? basic-js
 created files...
 Finished scaffolding files!
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -13,7 +13,7 @@ To develop a Probot app, you will first need a recent version of [Node.js](https
 To get started, run one of these commands:
 
 - If you're using npm: `$ npx create-probot-app my-first-app [--template=basic-ts]`
-- or, if you're using Yarn: `$ yarn create probot-app my-first-app [--template=basic-ts]`
+- or, if you're using Yarn: `$ yarn create probot-app my-first-app`
 
 > The `template` argument is optional and accepts the following values: `basic-js` (default), `checks-js`, `git-data-js`, `deploy-js` and `basic-ts` (use this one for TypeScript support).
 


### PR DESCRIPTION
`create-probot-app` was recently updated and removes support for the `typescript` flag. In this PR I documented how the `template` flag should be used. I'm unsure about the copy but for now this is what I came up with :). We should probably also explain users what the various templates include.

CC: @hiimbex 

-----
[View rendered docs/development.md](https://github.com/TimonVS/probot/blob/patch-1/docs/development.md)