### PR TITLE
Fix webhook types

### DIFF
--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -47,7 +47,7 @@ declare module '@octokit/webhooks' {
   class Webhooks {
     public middleware: Application
 
-    constructor (Options)
+    constructor (options: Options)
 
     public on (event: string, callback: (event: WebhookEvent | Error) => void)
     public sign (data: WebhookPayloadWithRepository)

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -55,13 +55,20 @@ declare module '@octokit/webhooks' {
     }
   }
 
+  type AsyncEventCallbackFunction = (event: Webhooks.WebhookEvent) => Promise<void>;
+  type EventCallbackFunction = (event: Webhooks.WebhookEvent) => void;
+
   class Webhooks {
     public middleware: Application
 
     constructor (options: Options)
 
-    public on (event: string, callback: (event: Webhooks.WebhookEvent) => Promise<void>): void
+    public on (event: string, callback: AsyncEventCallbackFunction): void
+    public on (event: string[], callback: AsyncEventCallbackFunction): void
+    public on (event: string, callback: EventCallbackFunction): void
+    public on (event: string[], callback: EventCallbackFunction): void
     public on (event: 'error', callback: (err: Error) => void): void
+    public on (event: 'error', callback: (err: Error) => Promise<void>): void
     public sign (data: WebhookPayloadWithRepository): string
   }
 

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -60,7 +60,7 @@ declare module '@octokit/webhooks' {
 
     constructor (options: Options)
 
-    public on (event: string, callback: (event: Webhooks.WebhookEvent | Error) => void): void
+    public on (event: string, callback: (event: Webhooks.WebhookEvent) => Promise<void>): void
     public on (event: 'error', callback: (err: Error) => void): void
     public sign (data: WebhookPayloadWithRepository): string
   }

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -44,7 +44,7 @@ declare module '@octokit/webhooks' {
     }
   }
 
-  declare class Webhooks {
+  class Webhooks {
     public middleware: Application
 
     constructor (Options)
@@ -53,7 +53,7 @@ declare module '@octokit/webhooks' {
     public sign (data: WebhookPayloadWithRepository)
   }
 
-  declare namespace Webhooks {
+  namespace Webhooks {
     export interface WebhookEvent {
       id: string
       name: string

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -61,6 +61,7 @@ declare module '@octokit/webhooks' {
     constructor (options: Options)
 
     public on (event: string, callback: (event: Webhooks.WebhookEvent | Error) => void): void
+    public on (event: 'error', callback: (err: Error) => void): void
     public sign (data: WebhookPayloadWithRepository): string
   }
 

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -6,6 +6,44 @@ declare module '@octokit/webhooks' {
     secret: string
   }
 
+  export interface PayloadRepository {
+    [key: string]: any
+    full_name?: string
+    name: string
+    owner: {
+      [key: string]: any
+      login: string
+      name?: string
+    }
+    html_url?: string
+  }
+
+  export interface WebhookPayloadWithRepository {
+    [key: string]: any
+    repository?: PayloadRepository
+    issue?: {
+      [key: string]: any
+      number: number
+      html_url?: string
+      body?: string
+    }
+    pull_request?: {
+      [key: string]: any
+      number: number
+      html_url?: string
+      body?: string
+    }
+    sender?: {
+      [key: string]: any
+      type: string
+    }
+    action?: string
+    installation?: {
+      id: number
+      [key: string]: any
+    }
+  }
+
   declare class Webhooks {
     public middleware: Application
 
@@ -23,44 +61,6 @@ declare module '@octokit/webhooks' {
       protocol?: 'http' | 'https'
       host?: string
       url?: string
-    }
-
-    export interface PayloadRepository {
-      [key: string]: any
-      full_name?: string
-      name: string
-      owner: {
-        [key: string]: any
-        login: string
-        name?: string
-      }
-      html_url?: string
-    }
-
-    export interface WebhookPayloadWithRepository {
-      [key: string]: any
-      repository?: PayloadRepository
-      issue?: {
-        [key: string]: any
-        number: number
-        html_url?: string
-        body?: string
-      }
-      pull_request?: {
-        [key: string]: any
-        number: number
-        html_url?: string
-        body?: string
-      }
-      sender?: {
-        [key: string]: any
-        type: string
-      }
-      action?: string
-      installation?: {
-        id: number
-        [key: string]: any
-      }
     }
   }
 

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -49,8 +49,8 @@ declare module '@octokit/webhooks' {
 
     constructor (options: Options)
 
-    public on (event: string, callback: (event: WebhookEvent | Error) => void)
-    public sign (data: WebhookPayloadWithRepository)
+    public on (event: string, callback: (event: WebhookEvent | Error) => void): void
+    public sign (data: WebhookPayloadWithRepository): string
   }
 
   namespace Webhooks {

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -69,7 +69,13 @@ declare module '@octokit/webhooks' {
     public on (event: string[], callback: EventCallbackFunction): void
     public on (event: 'error', callback: (err: Error) => void): void
     public on (event: 'error', callback: (err: Error) => Promise<void>): void
+
     public sign (data: WebhookPayloadWithRepository): string
+    public verify (eventPayload: WebhookPayloadWithRepository, signature: string): boolean
+    public verifyAndReceive (options: {id: string, name: string, payload: WebhookPayloadWithRepository, signature: string}): Promise<void>
+    public receive (options: {id: string, name: string, payload: WebhookPayloadWithRepository}): Promise<void>
+    public removeListener (event: string, callback: AsyncEventCallbackFunction)
+    public removeListener (event: string, callback: EventCallbackFunction)
   }
 
   export = Webhooks

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -44,15 +44,6 @@ declare module '@octokit/webhooks' {
     }
   }
 
-  class Webhooks {
-    public middleware: Application
-
-    constructor (options: Options)
-
-    public on (event: string, callback: (event: WebhookEvent | Error) => void): void
-    public sign (data: WebhookPayloadWithRepository): string
-  }
-
   namespace Webhooks {
     export interface WebhookEvent {
       id: string
@@ -62,6 +53,15 @@ declare module '@octokit/webhooks' {
       host?: string
       url?: string
     }
+  }
+
+  class Webhooks {
+    public middleware: Application
+
+    constructor (options: Options)
+
+    public on (event: string, callback: (event: Webhooks.WebhookEvent | Error) => void): void
+    public sign (data: WebhookPayloadWithRepository): string
   }
 
   export = Webhooks


### PR DESCRIPTION
This PR fixes all of the problems in the `@octokit/webhooks` typings, except for one which I am unsure how to fix it other than to use ESModule's `export default` syntax. So, I left it out. **Note**: The tests seem to pass fine without it, but on my local machine, in VSCode, TSLint seems to not like it
Hopefully this is a step forward in fixing #675

I split it in different commits to show exactly what was done and provide more context instead of making one giant commit.