### PR TITLE
Follow GitHub Casing Standards

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,4 +1,4 @@
-# Best Practices
+# Best practices
 
 First and foremost, your app must obey the [The Three Laws of Robotics](https://en.wikipedia.org/wiki/Three_Laws_of_Robotics):
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -12,7 +12,7 @@ Variable | Description
 **Private Key Options** | One of the following is **Required** if there is no `.pem` file in your project's root directory
 `PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. <p>_(Example: `path/to/key.pem`)_</p>
 `PRIVATE_KEY` | The contents of the private key for your GitHub App. If you're unable to use multiline environment variables, use base64 encoding to convert the key to a single line string. See the [Deployment](deployment.md) docs for provider specific usage. |
-**Webhook Options** |
+**Webhook options** |
 `WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. <p>_(Example: `https://smee.io/your-custom-url`)_</p>
 `WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. Note: GitHub marks this value as optional, but for optimal security it's required for Probot apps. **Required** <p>_(Example: `development`)_</p>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -9,7 +9,7 @@ When developing a Probot App, you will need to have several different fields in 
 Variable | Description
 ---|---
 `APP_ID` | The App ID assigned to your GitHub App. **Required** <p>_(Example: `1234`)_</p>
-**Private Key Options** | One of the following is **Required** if there is no `.pem` file in your project's root directory
+**Private key options** | One of the following is **Required** if there is no `.pem` file in your project's root directory
 `PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. <p>_(Example: `path/to/key.pem`)_</p>
 `PRIVATE_KEY` | The contents of the private key for your GitHub App. If you're unable to use multiline environment variables, use base64 encoding to convert the key to a single line string. See the [Deployment](deployment.md) docs for provider specific usage. |
 **Webhook options** |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 next: docs/deployment.md
 ---
 
-# Environment Configuration
+# Environment configuration
 
 When developing a Probot App, you will need to have several different fields in a `.env` file which specify environment variables. Here are some common use cases:
 
@@ -11,8 +11,8 @@ Variable | Description
 `APP_ID` | The App ID assigned to your GitHub App. **Required** <p>_(Example: `1234`)_</p>
 **Private Key Options** | One of the following is **Required** if there is no `.pem` file in your project's root directory
 `PRIVATE_KEY_PATH` | The path to the `.pem` file for your GitHub App. <p>_(Example: `path/to/key.pem`)_</p>
-`PRIVATE_KEY` | The contents of the private key for your GitHub App. If you're unable to use multiline environment variables, use base64 encoding to convert the key to a single line string. See the [Deployment](deployment.md) docs for provider specific usage. | 
-**Webhook Options** | 
+`PRIVATE_KEY` | The contents of the private key for your GitHub App. If you're unable to use multiline environment variables, use base64 encoding to convert the key to a single line string. See the [Deployment](deployment.md) docs for provider specific usage. |
+**Webhook Options** |
 `WEBHOOK_PROXY_URL` | Allows your local development environment to receive GitHub webhook events. Go to https://smee.io/new to get started. <p>_(Example: `https://smee.io/your-custom-url`)_</p>
 `WEBHOOK_SECRET` | The webhook secret used when creating a GitHub App. 'development' is used as a default, but the value in `.env` needs to match the value configured in your App settings on GitHub. Note: GitHub marks this value as optional, but for optimal security it's required for Probot apps. **Required** <p>_(Example: `development`)_</p>
 

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -2,7 +2,7 @@
 next: docs/development.md
 ---
 
-# Hello World
+# Hello world
 
 A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 

--- a/docs/http.md
+++ b/docs/http.md
@@ -2,7 +2,7 @@
 next: docs/simulating-webhooks.md
 ---
 
-# HTTP Routes
+# HTTP routes
 
 Calling `app.route('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
 

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -2,7 +2,7 @@
 next: docs/persistence.md
 ---
 
-# Serverless Deployment
+# Serverless deployment
 
 Serverless computing is a model which aims to abstract server management without concerns for implementing, tweaking, or scaling a server (at least, to the perspective of a user). The following sections will provide examples on how to deploy your application to service that will run on-demand as a Function as a Service(FaaS).
 
@@ -29,7 +29,7 @@ To deploy an app to any cloud provider, you will need 3 environment variables:
 - `WEBHOOK_SECRET`: the **Webhook Secret** that you generated when you created the app.
 - `PRIVATE_KEY_PATH`: the path to a private key file
 
-> These environment variables will need to be passed through to your FaaS solution. Each solution is different; please consult their documentation on how to use variables in the deployed environment. 
+> These environment variables will need to be passed through to your FaaS solution. Each solution is different; please consult their documentation on how to use variables in the deployed environment.
 
 Choosing a FaaS provider is mostly dependent on developer preference. Each Probot plugin interacts similarly, but the plugins implementation is dealing with different requests and responses specific to the provider. If you do not have a preference for a provider, choose the solution you have the most familiarity.
 

--- a/docs/simulating-webhooks.md
+++ b/docs/simulating-webhooks.md
@@ -2,7 +2,7 @@
 next: docs/testing.md
 ---
 
-# Simulate Receiving Webhooks
+# Simulate receiving webhooks
 
 As you are developing your app, you will likely want to test it by repeatedly triggering the same webhook. You can simulate a webhook being delivered by saving the payload to a file, and then calling `probot receive` from the command line.
 

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2,7 +2,7 @@
 next: docs/github-api.md
 ---
 
-# Receiving Webhooks
+# Receiving webhooks
 
 [GitHub webhooks](https://developer.github.com/webhooks/) are fired for almost every significant action that users take on GitHub, whether it's pushes to code, opening or closing issues, opening or merging pull requests, or commenting on a discussion.
 


### PR DESCRIPTION
The inconsistency in our docs' names casing was bothering me, so this makes it more consistent.

-----
[View rendered docs/best-practices.md](https://github.com/probot/probot/blob/casing-matters/docs/best-practices.md)
[View rendered docs/configuration.md](https://github.com/probot/probot/blob/casing-matters/docs/configuration.md)
[View rendered docs/hello-world.md](https://github.com/probot/probot/blob/casing-matters/docs/hello-world.md)
[View rendered docs/http.md](https://github.com/probot/probot/blob/casing-matters/docs/http.md)
[View rendered docs/serverless-deployment.md](https://github.com/probot/probot/blob/casing-matters/docs/serverless-deployment.md)
[View rendered docs/simulating-webhooks.md](https://github.com/probot/probot/blob/casing-matters/docs/simulating-webhooks.md)
[View rendered docs/webhooks.md](https://github.com/probot/probot/blob/casing-matters/docs/webhooks.md)