### PR TITLE
feat: allow default exported apps

### DIFF
--- a/bin/probot-run.js
+++ b/bin/probot-run.js
@@ -5,7 +5,7 @@ require('dotenv').config()
 const pkgConf = require('pkg-conf')
 const program = require('commander')
 
-const {findPrivateKey} = require('../lib/private-key')
+const { findPrivateKey } = require('../lib/private-key')
 
 program
   .usage('[options] <apps...>')
@@ -19,7 +19,7 @@ program
 
 program.privateKey = findPrivateKey()
 
-const {createProbot} = require('../')
+const { createProbot } = require('../')
 
 const probot = createProbot({
   id: program.app,

--- a/src/apps/default.ts
+++ b/src/apps/default.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import { Application } from '../application'
 
-export = (app: Application) => {
+export default (app: Application) => {
   const route = app.route()
 
   route.get('/probot', (req, res) => {

--- a/src/apps/sentry.ts
+++ b/src/apps/sentry.ts
@@ -2,7 +2,7 @@ import sentryStream from 'bunyan-sentry-stream'
 import Raven from 'raven'
 import { Application } from '../application'
 
-export = (app: Application) => {
+export default (app: Application) => {
   // If sentry is configured, report all logged errors
   if (process.env.SENTRY_DSN) {
     app.log.debug(process.env.SENTRY_DSN, 'Errors will be reported to Sentry')

--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -8,7 +8,7 @@ import { ManifestCreation } from '../manifest-creation'
 const domain = process.env.PROJECT_DOMAIN || `http://localhost:${process.env.PORT || 3000}`
 const welcomeMessage = `\nWelcome to Probot! Go to ${domain} to get started.\n`
 
-export = async (app: Application, setup: ManifestCreation = new ManifestCreation()) => {
+export default async (app: Application, setup: ManifestCreation = new ManifestCreation()) => {
   // If not on Glitch or Production, create a smee URL
   if (process.env.NODE_ENV !== 'production' && !(process.env.PROJECT_DOMAIN || process.env.WEBHOOK_PROXY_URL)) {
     await setup.createWebhookChannel()

--- a/src/apps/stats.ts
+++ b/src/apps/stats.ts
@@ -2,7 +2,7 @@ import { AnyResponse } from '@octokit/rest'
 import { Request, Response } from 'express'
 
 // Built-in app to expose stats about the deployment
-export = async (app: any): Promise<void> => {
+export default async (app: any): Promise<void> => {
   if (process.env.DISABLE_STATS) {
     return
   }

--- a/src/middleware/log-request-errors.ts
+++ b/src/middleware/log-request-errors.ts
@@ -1,6 +1,8 @@
+import { ErrorRequestHandler } from 'express'
+
 import { NextFunction, Request, Response } from './logging'
 
-module.exports = (err: Error, req: Request, res: Response, next: NextFunction) => {
+export const requestErrorLogger: ErrorRequestHandler = (err: Error, req: Request, res: Response, next: NextFunction) => {
   if (req.log) {
     req.log.error(err)
   }

--- a/src/private-key.ts
+++ b/src/private-key.ts
@@ -1,7 +1,5 @@
 import fs from 'fs'
-
-// tslint:disable-next-line:no-var-requires
-const isBase64 = require('is-base64')
+import isBase64 from 'is-base64'
 
 const hint = `please use:
   * \`--private-key=/path/to/private-key\` flag, or

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -2,7 +2,7 @@ import { sync } from 'resolve'
 
 const defaultOptions: ResolveOptions = {}
 
-export const resolve = (appFnId: string, opts?: ResolveOptions) => {
+export const resolve = <T>(appFnId: string, opts?: ResolveOptions): T => {
   opts = opts || defaultOptions
   // These are mostly to ease testing
   const basedir = opts.basedir || process.cwd()

--- a/test/apps/default.test.ts
+++ b/test/apps/default.test.ts
@@ -1,7 +1,7 @@
 import express from 'express'
 import request from 'supertest'
 import { Application } from '../../src'
-import appFn = require('../../src/apps/default')
+import appFn from '../../src/apps/default'
 import { createApp } from './helper'
 
 describe('default app', () => {

--- a/test/apps/sentry.test.ts
+++ b/test/apps/sentry.test.ts
@@ -1,6 +1,6 @@
 import Raven from 'raven'
 import { Application } from '../../src'
-import appFn = require('../../src/apps/sentry')
+import appFn from '../../src/apps/sentry'
 import { createApp } from './helper'
 
 describe('sentry app', () => {

--- a/test/apps/stats.test.ts
+++ b/test/apps/stats.test.ts
@@ -2,7 +2,7 @@ import express from 'express'
 import nock from 'nock'
 import request from 'supertest'
 import { Application } from '../../src'
-import appFn = require('../../src/apps/stats')
+import appFn from '../../src/apps/stats'
 import { createApp } from './helper'
 
 describe('stats app', () => {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,5 +1,5 @@
-import fs = require('fs')
-import path = require('path')
+import fs from 'fs'
+import path from 'path'
 
 import { WebhookEvent } from '@octokit/webhooks'
 import { Context } from '../src/context'

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "../tsconfig",
   "include": [
     "../src/**/*",
+    "../typings/*.d.ts",
     "**/*.ts"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "declaration": true // enable this once all files are .ts and we can remove allowJs
   },
   "include": [
-    "src/**/*"
+    "src/**/*",
+    "typings/*.d.ts"
   ],
   "compileOnSave": false
 }

--- a/typings/ambient.d.ts
+++ b/typings/ambient.d.ts
@@ -1,0 +1,6 @@
+declare module 'is-base64' {
+  type Base64Fn = (value: string) => boolean
+
+  const isBase64: Base64Fn
+  export = isBase64
+}


### PR DESCRIPTION
* Cleans up some TS so that all imports in probot are ES imports not require calls
* Modified the resolver to check for __esModule and load the default export when present

Currently, probot requires that apps are exported like this

```js
module.exports = (app) => {}
```

When using tooling like `babel` or `typescript` people should be doing this though:

```ts
export default (app) => {

}
```

Unfortunately probot didn't support this, now it does 🎉 With this support we can stop doing weird hacks this [this](https://github.com/electron/trop/pull/63/files#diff-f41e9d04a45c83f3b6f6e630f10117feR227)

cc @codebytere 