### PR TITLE
Include version in manifest

### DIFF
--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -49,7 +49,8 @@ export class ManifestCreation {
       redirect_url: `${baseUrl}/probot/setup`,
       // TODO: add setup url
       // setup_url:`${baseUrl}/probot/success`,
-      url: manifest.url || pkg.homepage || pkg.repository
+      url: manifest.url || pkg.homepage || pkg.repository,
+      version: 'v1'
     }, manifest))
 
     return generatedManifest

--- a/test/manifest-creation.test.js
+++ b/test/manifest-creation.test.js
@@ -80,7 +80,7 @@ describe('ManifestCreation', () => {
   describe('getManifest', () => {
     test('creates an app from a code', () => {
       // checks that getManifest returns a JSON.stringified manifest
-      expect(setup.getManifest(package, 'localhost://3000')).toEqual('{"description":"🤖 A framework for building GitHub Apps to automate and improve your workflow","hook_attributes":{"url":"localhost://3000/"},"name":"probot","public":true,"redirect_url":"localhost://3000/probot/setup","url":"https://probot.github.io"}')
+      expect(setup.getManifest(package, 'localhost://3000')).toEqual('{"description":"🤖 A framework for building GitHub Apps to automate and improve your workflow","hook_attributes":{"url":"localhost://3000/"},"name":"probot","public":true,"redirect_url":"localhost://3000/probot/setup","url":"https://probot.github.io","version":"v1"}')
     })
   })
 })


### PR DESCRIPTION
Including the version in the manifest, since GitHub supports that now.

This will enable us to make breaking changes to the manifest in the future which would be under a different version.

Tested that this works locally with `create-probot-app` but Glitch seems to now run out of memory when installing a dependency from a GitHub branch