### PR TITLE
Fixed GitHubAPI.paginate callback signature

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -49,7 +49,7 @@ export interface OctokitError extends Error {
 }
 
 export interface GitHubAPI extends Octokit {
-  paginate: (res: Promise<Octokit.AnyResponse>, callback: (response: Promise<Octokit.AnyResponse>, done?: () => void) => void) => Promise<any[]>
+  paginate: (res: Promise<Octokit.AnyResponse>, callback: (response: Octokit.AnyResponse, done?: () => void) => any) => Promise<any[]>
   // The following are added because Octokit does not expose the hook.error, hook.before, and hook.after methods
   hook: {
     error: (when: 'request', callback: (error: OctokitError, options: RequestOptions) => void) => void

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -5,7 +5,7 @@ export function addPagination (octokit: GitHubAPI) {
   octokit.paginate = paginate.bind(null, octokit)
 }
 
-const defaultCallback = (response: Promise<AnyResponse>, done?: () => void) => response
+const defaultCallback = (response: AnyResponse, done?: () => void) => response
 
 async function paginate (octokit: GitHubAPI, responsePromise: any, callback = defaultCallback) {
   let collection: any[] = []

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -17,12 +17,12 @@ async function paginate (octokit: GitHubAPI, responsePromise: any, callback = de
 
   let response = await responsePromise
 
-  collection = collection.concat(await callback(response, done))
+  collection = collection.concat(callback(response, done))
 
   // eslint-disable-next-line no-unmodified-loop-condition
   while (getNextPage && octokit.hasNextPage(response)) {
     response = await octokit.getNextPage(response)
-    collection = collection.concat(await callback(response, done))
+    collection = collection.concat(callback(response, done))
   }
   return collection
 }


### PR DESCRIPTION
The callback in paginate method is always called with the response, not a promise:
https://github.com/probot/probot/blob/master/src/github/pagination.ts#L18
https://github.com/probot/probot/blob/master/src/github/pagination.ts#L24

Also the returned value should have type `any` instead of `void` cause the method expects that we return something.

Base also on your documentation:
https://probot.github.io/docs/pagination/