### PR TITLE
Use path.resolve instead of path.join to resolve payload paths.

### DIFF
--- a/bin/probot-receive.js
+++ b/bin/probot-receive.js
@@ -31,7 +31,7 @@ if (!githubToken && (!program.app || !cert)) {
   console.warn('No token specified and no certifiate found, which means you will not be able to do authenticated requests to GitHub')
 }
 
-const payload = require(path.join(process.cwd(), program.payloadPath))
+const payload = require(path.resolve(program.payloadPath))
 
 const probot = createProbot({
   id: program.app,


### PR DESCRIPTION
Background

I have tried to use probot in GitHub Actions following [the instruction](https://probot.github.io/docs/deployment/#github-actions) and found that `probot recieve` has an issue: GitHub Actions sets the environment variable `GITHUB_EVENT_PATH=/github/workflow/event.json`, which is an absolute path, but `probot receive` prepends `process.cwd()` to the path and it fails to load the payload json file.

Proposal

I propose to use `path.resolve`, which resolves the path only when the given argument is relative (and in that case `path.resolve` prepends cwd when no other argument is given).