### PR TITLE
Fix link to "probot-metadata" extension

### DIFF
--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -16,7 +16,7 @@ Probot includes a wrapper for the GitHub API which can enable you to store and m
 - *Repository:* Built-in `context.config()` allows storing configuration in the repository.
 - *Labels:* The API can read labels, and add or remove them from issues and pull requests.
 
-If your Probot App needs to store more data than Issues and Pull Requests store normally, you can use the [`probot-metadata` extension](./extensions#metadata) to hide data in comments. It isn't meant to be super secure or scalable, but it's an easy way to manage some data without a full database.
+If your Probot App needs to store more data than Issues and Pull Requests store normally, you can use the [`probot-metadata` extension](/docs/extensions#metadata) to hide data in comments. It isn't meant to be super secure or scalable, but it's an easy way to manage some data without a full database.
 
 There are even more APIs that you can use to increase the functionality of your Probot App. You can read about all of the ones available in Probot on the [`@octokit/rest` documentation](http://octokit.github.io/rest.js/).
 


### PR DESCRIPTION
Fix broken link

-----
[View rendered docs/persistence.md](https://github.com/chadfawcett/probot/blob/patch-1/docs/persistence.md)