### PR TITLE
Fix webhook payload definition

### DIFF
--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -11,7 +11,7 @@ declare module '@octokit/webhooks' {
 
     constructor (Options)
 
-    public on (event: 'error', callback: (event: Error) => void)
+    public on (event: 'error', callback: (error: Error) => void)
     public on (event: '*' | string[], callback: (event: Webhooks.WebhookEvent | Error) => void)
     public on (event: string, callback: (event: Webhooks.WebhookEvent) => void)
     public sign (data: Webhooks.WebhookPayloadWithRepository)

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -11,7 +11,9 @@ declare module '@octokit/webhooks' {
 
     constructor (Options)
 
-    public on (event: string, callback: (event: Webhooks.WebhookEvent | Error) => void)
+    public on (event: 'error', callback: (event: Error) => void)
+    public on (event: '*' | string[], callback: (event: Webhooks.WebhookEvent | Error) => void)
+    public on (event: string, callback: (event: Webhooks.WebhookEvent) => void)
     public sign (data: Webhooks.WebhookPayloadWithRepository)
   }
 

--- a/src/@types/@octokit/webhooks/index.d.ts
+++ b/src/@types/@octokit/webhooks/index.d.ts
@@ -11,8 +11,8 @@ declare module '@octokit/webhooks' {
 
     constructor (Options)
 
-    public on (event: string, callback: (event: WebhookEvent | Error) => void)
-    public sign (data: WebhookPayloadWithRepository)
+    public on (event: string, callback: (event: Webhooks.WebhookEvent | Error) => void)
+    public sign (data: Webhooks.WebhookPayloadWithRepository)
   }
 
   declare namespace Webhooks {


### PR DESCRIPTION
Before `event` is treated as `any`:
![screen shot 2018-12-20 at 11 14 22](https://user-images.githubusercontent.com/50486/50280217-3b464f80-044c-11e9-9899-b057039c3a91.png)

After:
![screen shot 2018-12-20 at 11 14 38](https://user-images.githubusercontent.com/50486/50280221-3e414000-044c-11e9-94d6-dfd8748e9a70.png)

The compiler was not reporting an error, but it was treating `event` always as `any`.

I've also added some definitions to get only `Error` as argument in case of listening to the `error` event. I've assumed that if you subscribe to `*` you can get an event or an error as argument in the callback. But not sure if that's true.