### PR TITLE
Fix URL for Serverless GCF repository

### DIFF
--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -61,5 +61,5 @@ Google Cloud Platform, is a suite of cloud computing services that run on the sa
    const appFn = require('./')
    module.exports.probot = serverless(appFn)
    ```
-2. Follow the GCF [configuration steps](https://github.com/probot/gcf#configuration) using the [gcloud CLI](https://cloud.google.com/pubsub/docs/quickstart-cli) or [Serverless framework](https://github.com/serverless/serverless).
+2. Follow the GCF [configuration steps](https://github.com/probot/serverless-gcf#configuration) using the [gcloud CLI](https://cloud.google.com/pubsub/docs/quickstart-cli) or [Serverless framework](https://github.com/serverless/serverless).
 3. Once the app is is configured and you can proceed with deploying using the either [gcloud CLI](https://cloud.google.com/pubsub/docs/quickstart-cli) or [Serverless framework](https://github.com/serverless/serverless)


### PR DESCRIPTION
The URL to the Serverless Configuration for GCF on [this](https://probot.github.io/docs/serverless-deployment/) page is broken. This PR fixes it.

-----
[View rendered docs/serverless-deployment.md](https://github.com/pgoodjohn/probot/blob/doc-fix-gcf-url/docs/serverless-deployment.md)