### PR TITLE
Fix sample code for serverless deployment

### DIFF
--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -40,7 +40,7 @@ AWS Lambda is an event-driven, serverless computing platform provided by Amazon 
 2. Create a `handler.js` file in the root of you probot application
    ```
    // handler.js
-   const serverless = require('@probot/serverless-lambda')
+   const { serverless } = require('@probot/serverless-lambda')
    const appFn = require('./')
    module.exports.probot = serverless(appFn)
    ```
@@ -57,7 +57,7 @@ Google Cloud Platform, is a suite of cloud computing services that run on the sa
 2. Create a `handler.js` file in the route of you probot application
    ```
    // handler.js
-   const serverless = require('@probot/serverless-gcf')
+   const { serverless } = require('@probot/serverless-gcf')
    const appFn = require('./')
    module.exports.probot = serverless(appFn)
    ```


### PR DESCRIPTION
Related issue: https://github.com/probot/probot.github.io/issues/275

Sample codes for serverless deployment document are out of date and I fixed these codes according to the following page.

* https://github.com/probot/serverless-lambda#usage
* https://github.com/probot/serverless-gcf#usage



-----
[View rendered docs/serverless-deployment.md](https://github.com/kentaro-m/probot/blob/fix-doc-serverless-deployment/docs/serverless-deployment.md)