### PR TITLE
pass "utf8" as 2nd argument when reading private key from file using `fs.readFileSync`

### DIFF
--- a/src/apps/stats.ts
+++ b/src/apps/stats.ts
@@ -40,9 +40,8 @@ export = async (app: Application): Promise<void> => {
     const github = await app.auth()
 
     const req = github.apps.listInstallations({ per_page: 100 })
-    return github.paginate(req, async (response: Promise<AnyResponse>) => {
-      const res = await response
-      return res.data
+    return github.paginate(req, (response: AnyResponse) => {
+      return response.data
     })
   }
 
@@ -59,9 +58,8 @@ export = async (app: Application): Promise<void> => {
       const github = await app.auth(installation.id)
 
       const req = github.apps.listRepos({ per_page: 100 })
-      const repositories: Repository[] = await github.paginate(req, async (response: Promise<AnyResponse>) => {
-        const res = await response
-        return res.data.repositories.filter((repository: Repository) => !repository.private)
+      const repositories: Repository[] = await github.paginate(req, (response: AnyResponse) => {
+        return response.data.repositories.filter((repository: Repository) => !repository.private)
       })
 
       account.stars = repositories.reduce((stars, repository) => {

--- a/src/private-key.ts
+++ b/src/private-key.ts
@@ -43,7 +43,7 @@ export function findPrivateKey (filepath?: string): Buffer | string | null {
   }
   if (process.env.PRIVATE_KEY_PATH) {
     if (fs.existsSync(process.env.PRIVATE_KEY_PATH)) {
-      return fs.readFileSync(process.env.PRIVATE_KEY_PATH)
+      return fs.readFileSync(process.env.PRIVATE_KEY_PATH, 'utf8')
     } else {
       throw new Error(`Private key does not exists at path: ${process.env.PRIVATE_KEY_PATH}. Please check to ensure that the PRIVATE_KEY_PATH is correct.`)
     }

--- a/test/private-key.test.ts
+++ b/test/private-key.test.ts
@@ -87,7 +87,7 @@ describe('private-key', () => {
 
       it('should read the file at given filepath', () => {
         findPrivateKey(undefined)
-        expect(fs.readFileSync).toHaveBeenCalledWith(keyfilePath)
+        expect(fs.readFileSync).toHaveBeenCalledWith(keyfilePath, 'utf8')
       })
 
       it('should return the key', () => {


### PR DESCRIPTION
This is included in https://github.com/probot/probot/pull/751 and that change is approved by @tcbyrd via https://github.com/probot/probot/pull/751/files#r230205707

I want to make sure we get it in in case #751 is blocked

rebased on #818 to make tests pass