### PR TITLE
doc: update GitHub actions workflow reference

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -171,7 +171,7 @@ GitHub Actions allows you to trigger workflows based on GitHub events, which mak
     }
     ```
 
-`uses` inside an `action` must take the form `owner/repo@ref`, where `ref` can either be a branch: `jasonetco/todo@master`, or a tag: `jasonetco/todo@v1.0.0`.
+`uses` inside an `action` must take the form `owner/repo@ref`, where `ref` can be a branch: `jasonetco/todo@master`, a tag: `jasonetco/todo@v1.0.0`, or a commit sha: `jasonetco/todo@f61798f9722c6af9dd12781ea3512306ea451bce`.
 
 There are a few caveats when running Probot Apps on GitHub Actions:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -166,10 +166,12 @@ GitHub Actions allows you to trigger workflows based on GitHub events, which mak
     }
 
     action "TODO" {
-      uses = "jasonetco/todo"
+      uses = "jasonetco/todo@master"
       secrets = ["GITHUB_TOKEN"]
     }
     ```
+
+`uses` inside an `action` must take the form `owner/repo@ref`, where `ref` can either be a branch: `jasonetco/todo@master`, or a tag: `jasonetco/todo@v1.0.0`.
 
 There are a few caveats when running Probot Apps on GitHub Actions:
 


### PR DESCRIPTION
In the example `main.workflow`, `uses` inside an `action` must now take the form `owner/repo@ref`. This updates the GitHub Actions deployment documentation to reflect this.

/cc @JasonEtco 

-----
[View rendered docs/deployment.md](https://github.com/codebytere/probot/blob/update-actions-doc/docs/deployment.md)