### PR TITLE
fix: pass baseUrl option to @octokit/app

### DIFF
--- a/src/@types/@octokit/app/index.d.ts
+++ b/src/@types/@octokit/app/index.d.ts
@@ -1,7 +1,8 @@
 declare module '@octokit/app' {
   interface Options {
     id: number,
-    privateKey: string
+    privateKey: string,
+    baseUrl?: string
   }
 
   declare class App {

--- a/src/@types/@octokit/app/index.d.ts
+++ b/src/@types/@octokit/app/index.d.ts
@@ -1,8 +1,8 @@
 declare module '@octokit/app' {
   interface Options {
+    baseUrl?: string,
     id: number,
-    privateKey: string,
-    baseUrl?: string
+    privateKey: string
   }
 
   declare class App {

--- a/src/index.ts
+++ b/src/index.ts
@@ -52,9 +52,9 @@ export class Probot {
       }
 
       this.app = new OctokitApp({
+        baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
         id: options.id as number,
-        privateKey: options.cert as string,
-        baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`
+        privateKey: options.cert as string
       })
     }
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,10 @@ export class Probot {
     })
     this.githubToken = options.githubToken
     if (this.options.id) {
+      if (process.env.GHE_HOST && /^https?:\/\//.test(process.env.GHE_HOST)) {
+        throw new Error('Your \`GHE_HOST\` environment variable should not begin with https:// or http://')
+      }
+
       this.app = new OctokitApp({
         id: options.id as number,
         privateKey: options.cert as string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,7 +49,8 @@ export class Probot {
     if (this.options.id) {
       this.app = new OctokitApp({
         id: options.id as number,
-        privateKey: options.cert as string
+        privateKey: options.cert as string,
+        baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`
       })
     }
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -2,6 +2,8 @@
 
 exports[`Probot ghe support throws if the GHE host includes a protocol 1`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
 
+exports[`Probot ghe support throws if the GHE host includes a protocol 2`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
+
 exports[`Probot webhook delivery responds with the correct error if the PEM file is missing 1`] = `
 Array [
   Object {


### PR DESCRIPTION
To be able to use Probot `8.0.0-beta.*` with Github EE we need to provide our own `GHE_HOST` environment variable with the host. As Probot 8 `8.0.0-beta.*` now uses `@octokit/app` we have to pass `baseUrl` option there the same way we pass it to `@octokit/rest`.