### PR TITLE
fix: octokit webhooks import

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import { PayloadRepository, Webhooks } from '@octokit/webhooks'
+import Webhooks, { PayloadRepository } from '@octokit/webhooks'
 import yaml from 'js-yaml'
 import path from 'path'
 import { GitHubAPI } from './github'


### PR DESCRIPTION
The import of Webhooks from the `@octokit/webhooks` was incorrect, it is not a named export (see https://github.com/octokit/webhooks.js/blob/master/index.d.ts) but rather a default export