### PR TITLE
fix: Move smee-client require back to try/catch

### DIFF
--- a/src/webhook-proxy.ts
+++ b/src/webhook-proxy.ts
@@ -1,9 +1,9 @@
 import Logger from 'bunyan'
 import EventSource from 'eventsource'
-import SmeeClient from 'smee-client'
 
 export const createWebhookProxy = (opts: WebhookProxyOptions): EventSource | undefined => {
   try {
+    const SmeeClient = require('smee-client')
     const smee = new SmeeClient({
       logger: opts.logger,
       source: opts.url,


### PR DESCRIPTION
In production where `smee-client` is a devDependency (something we recommend and is in the `create-probot-app` templates), `smee-client` doesn't exist so this functionality throws an error and prevents the app from starting up. This PR moves the `require` call back into the `try/catch` block to ignore `smee-client` if it isn't present.

cc @gr2m and #851 