### PR TITLE
fix: error.code => error.status

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -174,7 +174,7 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
       const config = yaml.safeLoad(Buffer.from(res.data.content, 'base64').toString()) || {}
       return Object.assign({}, defaultConfig, config)
     } catch (err) {
-      if (err.code === 404) {
+      if (err.status === 404) {
         if (defaultConfig) {
           return defaultConfig
         }

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -57,8 +57,7 @@ export interface Result {
 }
 
 export interface OctokitError extends Error {
-  code: number
-  status: string
+  status: number
 }
 
 interface Paginate extends Octokit.Paginate {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -122,10 +122,9 @@ describe('Context', () => {
 
     it('returns null when the file is missing', async () => {
       const error: OctokitError = {
-        code: 404,
         message: 'An error occurred',
         name: 'OctokitError',
-        status: 'Not Found'
+        status: 404
       }
 
       jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(error))
@@ -135,10 +134,9 @@ describe('Context', () => {
 
     it('returns the default config when the file is missing and default config is passed', async () => {
       const error: OctokitError = {
-        code: 404,
         message: 'An error occurred',
         name: 'OctokitError',
-        status: 'Not Found'
+        status: 404
       }
 
       jest.spyOn(github.repos, 'getContents').mockReturnValue(Promise.reject(error))


### PR DESCRIPTION
This PR updates the `error.code` to be `error.status`, as recommended by a deprecation message in `@octokit/rest`. @gr2m I posed a question in #869 but I'll move it over here for posterity and ease-of-review:

> since we're using our own types for the OctokitError class - what's more correct here?

And you already answered:

> `error.status` is correct, it’s a number. It used to be the status text, that is a breaking change that comes with v8, so we should update it in probot

Closes #869 