### PR TITLE
test: Use modern Jest configuration format

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,14 +36,7 @@
       "json",
       "node"
     ],
-    "transform": {
-      ".+\\.tsx?$": "ts-jest"
-    },
-    "globals": {
-      "ts-jest": {
-        "skipBabel": true
-      }
-    }
+    "preset": "ts-jest"
   },
   "keywords": [
     "probot",

--- a/package.json
+++ b/package.json
@@ -39,15 +39,11 @@
     "transform": {
       ".+\\.tsx?$": "ts-jest"
     },
-    "testMatch": [
-      "<rootDir>/test/**/*.test.(ts|js)"
-    ],
     "globals": {
       "ts-jest": {
         "skipBabel": true
       }
-    },
-    "testURL": "http://localhost/"
+    }
   },
   "keywords": [
     "probot",


### PR DESCRIPTION
Currently, running `npm test` makes quite a few warnings pop up.

```
ts-jest[backports] (WARN) "[jest-config].globals.ts-jest.skipBabel" is deprecated, use "[jest-config].globals.ts-jest.babelConfig" instead.
ts-jest[backports] (WARN) Your Jest configuration is outdated. Use the CLI to help migrating it: ts-jest config:migrate <config-file>.
...
```

This PR makes them go away by replacing the deprecated `globals` setting with modern `preset`.

- See https://kulshekhar.github.io/ts-jest/user/config/#the-3-presets for more details.
- See https://jestjs.io/docs/en/configuration.html for default options for the rest.