### PR TITLE
Fix: Bump up dependency version to solve #888 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -545,13 +545,6 @@
         "is-plain-object": "^2.0.4",
         "universal-user-agent": "^2.0.1",
         "url-template": "^2.0.8"
-      },
-      "dependencies": {
-        "deepmerge": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.2.0.tgz",
-          "integrity": "sha512-6+LuZGU7QCNUnAJyX8cIrlzoEgggTM6B7mm+znKOX4t5ltluT9KLjN6g61ECMS0LTsLW7yDpNoxhix5FZcrIow=="
-        }
       }
     },
     "@octokit/graphql": {
@@ -595,19 +588,41 @@
       }
     },
     "@octokit/rest": {
-      "version": "16.13.3",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.13.3.tgz",
-      "integrity": "sha512-vrCQYuLkGcFCWe0VyWdRfhmAcyZWLL/Igwz+qnFyRKXn9ml1li0Au8e4hGXbY6Q3kQ+3YWUOGDl3OkO1znh7dA==",
+      "version": "16.17.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-16.17.1.tgz",
+      "integrity": "sha512-cRosFoYEXraBsXe+FDHFW4b98RM0WuvSv9HUsbV69E+j8aRGAU/4FudEdpgBSIiXv8HvUOLlo6fAdJmmJHSVKw==",
       "requires": {
-        "@octokit/request": "2.3.0",
-        "before-after-hook": "^1.2.0",
+        "@octokit/request": "2.4.1",
+        "before-after-hook": "^1.4.0",
         "btoa-lite": "^1.0.0",
+        "deprecation": "^1.0.1",
         "lodash.get": "^4.4.2",
         "lodash.set": "^4.3.2",
         "lodash.uniq": "^4.5.0",
         "octokit-pagination-methods": "^1.1.0",
+        "once": "^1.4.0",
         "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
+      },
+      "dependencies": {
+        "@octokit/request": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.4.1.tgz",
+          "integrity": "sha512-nN8W24ZXEpJQJoVgMsGZeK9FOzxkc39Xn9ykseUpPpPMNEDFSvqfkCeqqKrjUiXRm72ubGLWG1SOz0aJPcgGww==",
+          "requires": {
+            "@octokit/endpoint": "^3.1.1",
+            "deprecation": "^1.0.1",
+            "is-plain-object": "^2.0.4",
+            "node-fetch": "^2.3.0",
+            "once": "^1.4.0",
+            "universal-user-agent": "^2.0.1"
+          }
+        },
+        "before-after-hook": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.4.0.tgz",
+          "integrity": "sha512-l5r9ir56nda3qu14nAXIlyq1MmUSs0meCIaFAh8HwkFwP1F8eToOuS3ah2VAHHcY04jaYD7FpJC5JTXHYRbkzg=="
+        }
       }
     },
     "@octokit/webhooks": {
@@ -1572,7 +1587,8 @@
     "before-after-hook": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-1.3.2.tgz",
-      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w=="
+      "integrity": "sha512-zyPgY5dgbf99c0uGUjhY4w+mxqEGxPKg9RQDl34VvrVh2bM31lFN+mwR1ZHepq/KA3VCPk1gwJZL6IIJqjLy2w==",
+      "dev": true
     },
     "body-parser": {
       "version": "1.18.3",
@@ -2451,6 +2467,11 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-3.0.0.tgz",
+      "integrity": "sha512-a8z8bkgHsAML+uHLqmMS83HHlpy3PvZOOuiTQqaa3wu8ZVg3h0hqHk6aCsGdOnZV2XMM/FRimNGjUh0KCcmHBw=="
+    },
     "default-require-extensions": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-2.0.0.tgz",
@@ -2579,6 +2600,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecation": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-1.0.1.tgz",
+      "integrity": "sha512-ccVHpE72+tcIKaGMql33x5MAjKQIZrk+3x2GbJ7TeraUCZWHoT+KSZpoC+JQFsUBlSTXUrBaGiF0j6zVTepPLg=="
     },
     "destroy": {
       "version": "1.0.4",
@@ -4168,14 +4194,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4197,8 +4221,7 @@
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -4348,7 +4371,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@octokit/plugin-enterprise-compatibility": "^1.0.0",
     "@octokit/plugin-retry": "^2.1.1",
     "@octokit/plugin-throttling": "^2.3.0",
-    "@octokit/rest": "^16.13.3",
+    "@octokit/rest": "^16.17.1",
     "@octokit/webhooks": "^5.3.1",
     "@types/supports-color": "^5.3.0",
     "bottleneck": "^2.15.3",


### PR DESCRIPTION
Thanks for sharing good tool to integrate our work with the well-designed GitHub world!

See #888 for detail of the problem.
This PR bumps up version of `@octokit/rest` then it also bumps up `@octokit/request` to the latest.