### PR TITLE
fix: Support GitHub Enterprise Server in GitHub App Manifest flow implementation

### DIFF
--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -59,6 +59,7 @@ export class ManifestCreation {
   public async createAppFromCode (code: any) {
     const github = GitHubAPI()
     const response = await github.request('POST /app-manifests/:code/conversions', {
+      baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
       code,
       headers: { accept: 'application/vnd.github.fury-preview+json' }
     })

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -58,11 +58,12 @@ export class ManifestCreation {
 
   public async createAppFromCode (code: any) {
     const github = GitHubAPI()
-    const response = await github.request('POST /app-manifests/:code/conversions', {
-      baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
+    const options: any = {
       code,
-      headers: { accept: 'application/vnd.github.fury-preview+json' }
-    })
+      headers: { accept: 'application/vnd.github.fury-preview+json' },
+      ...process.env.GHE_HOST && { baseUrl: `https://${process.env.GHE_HOST}/api/v3` }
+    }
+    const response = await github.request('POST /app-manifests/:code/conversions', options)
 
     const { id, webhook_secret, pem } = response.data
     await this.updateEnv({

--- a/test/manifest-creation.test.ts
+++ b/test/manifest-creation.test.ts
@@ -62,11 +62,25 @@ describe('ManifestCreation', () => {
       delete process.env.APP_ID
       delete process.env.PRIVATE_KEY
       delete process.env.WEBHOOK_SECRET
+      delete process.env.GHE_HOST
     })
 
     test('creates an app from a code', async () => {
       nock('https://api.github.com')
         .post('/app-manifests/123abc/conversions')
+        .reply(200, response)
+
+      const createdApp = await setup.createAppFromCode('123abc')
+      expect(createdApp).toEqual('https://github.com/apps/testerino0000000')
+      // expect dotenv to be called with id, webhook_secret, pem
+      expect(setup.updateEnv).toHaveBeenCalledWith({ 'APP_ID': '6666', 'PRIVATE_KEY': '"-----BEGIN RSA PRIVATE KEY-----\nsecrets\n-----END RSA PRIVATE KEY-----\n"', 'WEBHOOK_SECRET': '12345abcde' })
+    })
+
+    test('creates an app from a code when github host env is set', async () => {
+      process.env.GHE_HOST = 'swinton.github.com'
+
+      nock('https://swinton.github.com')
+        .post('/api/v3/app-manifests/123abc/conversions')
         .reply(200, response)
 
       const createdApp = await setup.createAppFromCode('123abc')


### PR DESCRIPTION
The [GitHub App manifest flow](https://developer.github.com/apps/building-github-apps/creating-github-apps-from-a-manifest/) is currently not working for _GitHub Enterprise Server_ instances.

When calling [`POST /app-manifests/:code/conversions`](https://developer.github.com/v3/apps/#create-a-github-app-from-a-manifest), we need to configure the `@octokit/rest` client to use the `GHE_HOST` environment variable.

/cc @wilhelmklopp who paired with me on researching this :bow:

____
(Note, I attempted to implement this when we [instantiate a new `GitHubAPI`](https://github.com/probot/probot/blob/23e8eabf4a29ace976f46ad64acd93da08a4af69/src/manifest-creation.ts#L60), but TypeScript was complaining, and I couldn't figure out why 😕)
