### PR TITLE
fix: propagate errors to @octokit/webhooks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,7 @@ export class Probot {
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })
 
     // Log all received webhooks
-    this.webhook.on('*', async (event: Webhooks.WebhookEvent<any>) => this.receive(event))
+    this.webhook.on('*', (event: Webhooks.WebhookEvent<any>) => this.receive(event))
 
     // Log all webhook errors
     this.webhook.on('error', this.errorHandler)

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,9 @@ export class Probot {
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })
 
     // Log all received webhooks
-    this.webhook.on('*', (event: Webhooks.WebhookEvent<any>) => this.receive(event))
+    this.webhook.on('*', async (event: Webhooks.WebhookEvent<any>) => {
+      await this.receive(event)
+    })
 
     // Log all webhook errors
     this.webhook.on('error', this.errorHandler)

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,13 +122,7 @@ export class Probot {
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })
 
     // Log all received webhooks
-    this.webhook.on('*', async (event: Webhooks.WebhookEvent<any>) => {
-      try {
-        await this.receive(event)
-      } catch {
-        // Errors have already been logged.
-      }
-    })
+    this.webhook.on('*', async (event: Webhooks.WebhookEvent<any>) => this.receive(event))
 
     // Log all webhook errors
     this.webhook.on('error', this.errorHandler)


### PR DESCRIPTION
Probot "eats" errors from application code. These are logged, but not propagated to `@octokit/webhooks` and not reported to Github. `@octokit/webhooks` responds with `200 OK` instead.

With this change the error is propagated to `@octokit/webhooks` and it correctly respond with error code `500`.