### PR TITLE
docs: link to events list in @octokit/webhooks.js

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -50,4 +50,4 @@ module.exports = app => {
 }
 ```
 
-Explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) to see what events are available to use in your app.
+For more details, explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) or see a list of all the named events in the [@octokit/webhooks.js](https://github.com/octokit/webhooks.js/blob/master/lib/webhook-names.json) npm module.


### PR DESCRIPTION
This list of webhook names is a useful reference and appears to be kept up-to-date by robots and @gr2m: https://github.com/octokit/webhooks.js/blob/master/lib/webhook-names.json

Let's link to it from the Probot webhook docs!

-----
[View rendered docs/webhooks.md](https://github.com/probot/probot/blob/link-to-list-of-webhooks/docs/webhooks.md)