### PR TITLE
normalize payload string before verifying signature (via update to latest @octokit/webhooks)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -226,11 +226,10 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-5.1.2.tgz",
-      "integrity": "sha512-69DqMttU9EtwydKpvItAdRhIry07g2NuEVYFIyLgTtRh39cJBYJK07/cQFcvl1smwgQvEST3xiObvdRzjFVyAA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-6.0.1.tgz",
+      "integrity": "sha512-6xf1lOtq16BJpJ0EclN0IDdmq3jtzTHq7C/nm04Hx9ilqWurmyuwCaoxqTDU45qFXu5j5K/LRwSyWkr7iUg2Fg==",
       "requires": {
-        "buffer-equal-constant-time": "^1.0.1",
         "debug": "^4.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "license": "ISC",
   "dependencies": {
     "@octokit/rest": "^15.18.0",
-    "@octokit/webhooks": "^5.0.2",
+    "@octokit/webhooks": "^6.0.1",
     "@types/supports-color": "^5.3.0",
     "bottleneck": "^2.8.0",
     "bunyan": "^1.8.12",


### PR DESCRIPTION
see https://github.com/octokit/webhooks.js/issues/73