### PR TITLE
fix: Check if err.message exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,7 +147,7 @@ export class Probot {
   }
 
   public errorHandler (err: Error) {
-    const errMessage = err.message.toLowerCase()
+    const errMessage = (err.message || '').toLowerCase()
     if (errMessage.includes('x-hub-signature')) {
       logger.error({ err }, 'Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable.')
     } else if (errMessage.includes('pem') || errMessage.includes('json web token')) {


### PR DESCRIPTION
In `errMessage` the `err.message` may be undefined. We need to do a null check here.