### PR TITLE
Fix js-yaml code injection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5422,9 +5422,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "hbs": "^4.0.3",
     "ioredis": "^4.5.1",
     "is-base64": "0.1.0",
-    "js-yaml": "^3.9.1",
+    "js-yaml": "^3.13.1",
     "jsonwebtoken": "^8.1.0",
     "octokit-pagination-methods": "1.1.0",
     "pkg-conf": "^3.0.0",


### PR DESCRIPTION
I've updated the js-yaml version to 3.13.1 to fix the code injection.
See https://www.npmjs.com/advisories/813
