### PR TITLE
fix(typescript): log.child options

### DIFF
--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -50,9 +50,4 @@ export interface LoggerWithTarget extends Logger {
   fatal: LoggerWithTarget
 }
 
-export interface ChildArgs {
-  options?: object
-  name?: string
-  id?: string | number | string[]
-  installation?: string
-}
+export type ChildArgs = { [key: string]: any }

--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -50,4 +50,10 @@ export interface LoggerWithTarget extends Logger {
   fatal: LoggerWithTarget
 }
 
-export type ChildArgs = { [key: string]: any }
+export type ChildArgs {
+  options?: object
+  name?: string
+  id?: string | number | string[]
+  installation?: string
+  [key: string]: any
+}

--- a/src/wrap-logger.ts
+++ b/src/wrap-logger.ts
@@ -50,7 +50,7 @@ export interface LoggerWithTarget extends Logger {
   fatal: LoggerWithTarget
 }
 
-export type ChildArgs {
+export interface ChildArgs {
   options?: object
   name?: string
   id?: string | number | string[]


### PR DESCRIPTION
Currently it is not possible to specify any fields for log lines using `child` other than the ones probot already specifies. Looking at the documentation of the underlying logging library used (https://github.com/trentm/node-bunyan#logchild) it shows any attribute can be used.