### PR TITLE
docs: Update creating Probot instance in testing docs

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@ For our testing examples, we use [jest](https://facebook.github.io/jest/), but t
 const nock = require('nock')
 // Requiring our app implementation
 const myProbotApp = require('..')
-const { Probot } = require('probot')
+const { Probot, createProbot } = require('probot')
 // Requiring our fixtures
 const payload = require('./fixtures/issues.opened')
 const issueCreatedBody = { body: 'Thanks for opening this issue!' }
@@ -23,12 +23,8 @@ describe('My Probot app', () => {
   let probot
 
   beforeEach(() => {
-    probot = new Probot({})
-    // Load our app into probot
-    const app = probot.load(myProbotApp)
-
-    // just return a test token
-    app.app = () => 'test'
+    probot = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
+    probot.load(myProbotApp)
   })
 
   test('creates a passing check', async () => {


### PR DESCRIPTION
The previous testing example does not compile with newer versions of Probot (`"probot": "^9.2.15"`) because the type of `app.app` has changed.

```
 TypeScript diagnostics (customize using `[jest-config].globals.ts-jest.diagnostics` option):
    status.test.ts:12:9 - error TS2739: Type '() => string' is missing the following properties from type 'App': getSignedJsonWebToken, getInstallationAccessToken

    12         app.app = () => 'test'
```

-----
[View rendered docs/testing.md](https://github.com/cconstable/probot/blob/patch-1/docs/testing.md)