### PR TITLE
export the GitHubAPI interface

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ import { Application } from './application'
 import setupApp from './apps/setup'
 import { createDefaultCache } from './cache'
 import { Context } from './context'
-import { ProbotOctokit } from './github'
+import { GitHubAPI, ProbotOctokit } from './github'
 import { logger } from './logger'
 import { logRequestErrors } from './middleware/log-request-errors'
 import { findPrivateKey } from './private-key'
@@ -226,4 +226,4 @@ export interface Options {
   Octokit?: Octokit.Static
 }
 
-export { Logger, Context, Application, Octokit }
+export { Logger, Context, Application, Octokit, GitHubAPI }


### PR DESCRIPTION
This PR exports the GitHubAPI Interface so that it may be used with typing the public properties of the Context class.
