### PR TITLE
Address deprecation in Octokit

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -131,7 +131,7 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
   public issue<T> (object?: T) {
     const payload = this.payload
     return Object.assign({
-      number: (payload.issue || payload.pull_request || payload).number
+      issue_number: (payload.issue || payload.pull_request || payload).number
     }, this.repo(object))
   }
 


### PR DESCRIPTION
```
Deprecation: [@octokit/rest] "number" parameter is deprecated for
".issues.createComment()". Use "issue_number" instead
```