### PR TITLE
fix: Include dotenv config as early as possible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// tslint:disable-next-line: no-var-requires
+require('dotenv').config()
+
 import { App as OctokitApp } from '@octokit/app'
 import Octokit from '@octokit/rest'
 import Webhooks from '@octokit/webhooks'
@@ -31,8 +34,6 @@ const defaultAppFns: ApplicationFunction[] = [
 
 export class Probot {
   public static async run (appFn: ApplicationFunction | string[]) {
-    require('dotenv').config()
-
     const pkgConf = require('pkg-conf')
     const program = require('commander')
 


### PR DESCRIPTION
Probot is processing the `.env` file after the logger is [created (under the hood)](https://github.com/probot/probot/blob/fd6d6febf113d9be846785efceb2de812870b4fe/src/logger.ts#L61). This leads to bugs like #1032, where `LOG_LEVEL` is set in `.env` but its *level* is not being used.

By requiring `.env` config at the top, `logger.ts` will have the `LOG_LEVEL` environment variable.

**Fixes**

Fixes #1032 