### PR TITLE
Throw at startup in prod if misconfigured

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,19 @@ export class Probot {
     const options = readOptions()
     const probot = new Probot(options)
     if (!options.id || !options.cert) {
+      if (process.env.NODE_ENV === 'production') {
+        if (!options.id) {
+          throw new Error(
+            'Application ID is missing, and is required to run in production mode. ' +
+            'To resolve, ensure the APP_ID environment variable is set.'
+          )
+        } else if (!options.cert) {
+          throw new Error(
+            'Certificate is missing, and is required to run in production mode. ' +
+            'To resolve, ensure either the PRIVATE_KEY or PRIVATE_KEY_PATH environment variable is set and contains a valid certificate'
+          )
+        }
+      }
       probot.load(setupApp)
     } else if (Array.isArray(appFn)) {
       const pkg = await pkgConf('probot')


### PR DESCRIPTION
Throw errors during startup if `NODE_ENV === 'production'` and the application is not in a usable state (defining "usable state" as conditions that prevent entering setup mode)

Fixes #1044 