### PR TITLE
Use ProbotOctokit as default

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -3,7 +3,6 @@ import enterpriseCompatibility from '@octokit/plugin-enterprise-compatibility'
 import retryPlugin from '@octokit/plugin-retry'
 import throttlePlugin from '@octokit/plugin-throttling'
 import Octokit from '@octokit/rest'
-import deepmerge from 'deepmerge'
 
 import { addGraphQL } from './graphql'
 import { addLogging, Logger } from './logging'
@@ -22,13 +21,19 @@ export const ProbotOctokit = Octokit
  * @see {@link https://github.com/octokit/rest.js}
  */
 export function GitHubAPI (options: Options = {} as any) {
-  const mergedOptions = deepmerge({
+  const defaults = {
     Octokit: ProbotOctokit,
     throttle: {
       onAbuseLimit: (retryAfter: number) => options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`),
       onRateLimit: (retryAfter: number) => options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)
     }
-  }, options)
+  }
+
+  const mergedOptions = Object.assign(
+    defaults,
+    { throttle: Object.assign(defaults.throttle, options.throttle) },
+    options
+  )
 
   const octokit = new mergedOptions.Octokit(mergedOptions) as GitHubAPI
 

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -21,13 +21,15 @@ export const ProbotOctokit = Octokit
  * @see {@link https://github.com/octokit/rest.js}
  */
 export function GitHubAPI (options: Options = {} as any) {
-  const octokit = new options.Octokit(Object.assign(options, {
+  const mergedOptions = Object.assign({
     Octokit: ProbotOctokit,
     throttle: Object.assign({
       onAbuseLimit: (retryAfter: number) => options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`),
       onRateLimit: (retryAfter: number) => options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)
     }, options.throttle)
-  })) as GitHubAPI
+  }, options)
+
+  const octokit = new options.Octokit(mergedOptions) as GitHubAPI
 
   addPagination(octokit)
   addLogging(octokit, options.logger)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -20,8 +20,9 @@ export const ProbotOctokit = Octokit
  * browser.
  * @see {@link https://github.com/octokit/rest.js}
  */
-export function GitHubAPI (options: Options = { Octokit: ProbotOctokit } as any) {
+export function GitHubAPI (options: Options = {} as any) {
   const octokit = new options.Octokit(Object.assign(options, {
+    Octokit: ProbotOctokit,
     throttle: Object.assign({
       onAbuseLimit: (retryAfter: number) => options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`),
       onRateLimit: (retryAfter: number) => options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -47,7 +47,7 @@ export function GitHubAPI (options: Options = {} as any) {
 export interface Options extends Octokit.Options {
   debug?: boolean
   logger: Logger
-  Octokit: Octokit.Static
+  Octokit?: Octokit.Static
 }
 
 export interface RequestOptions {

--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -3,6 +3,7 @@ import enterpriseCompatibility from '@octokit/plugin-enterprise-compatibility'
 import retryPlugin from '@octokit/plugin-retry'
 import throttlePlugin from '@octokit/plugin-throttling'
 import Octokit from '@octokit/rest'
+import deepmerge from 'deepmerge'
 
 import { addGraphQL } from './graphql'
 import { addLogging, Logger } from './logging'
@@ -21,15 +22,15 @@ export const ProbotOctokit = Octokit
  * @see {@link https://github.com/octokit/rest.js}
  */
 export function GitHubAPI (options: Options = {} as any) {
-  const mergedOptions = Object.assign({
+  const mergedOptions = deepmerge({
     Octokit: ProbotOctokit,
-    throttle: Object.assign({
+    throttle: {
       onAbuseLimit: (retryAfter: number) => options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`),
       onRateLimit: (retryAfter: number) => options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)
-    }, options.throttle)
+    }
   }, options)
 
-  const octokit = new options.Octokit(mergedOptions) as GitHubAPI
+  const octokit = new mergedOptions.Octokit(mergedOptions) as GitHubAPI
 
   addPagination(octokit)
   addLogging(octokit, options.logger)

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -30,6 +30,14 @@ describe('GitHubAPI', () => {
     expect((await github.users.getAuthenticated({})).data).toEqual(user)
   })
 
+  test('works without options that do not include Octokit', async () => {
+    github = GitHubAPI({ retry: { enabled: false }, logger })
+    const user = { login: 'ohai' }
+
+    nock('https://api.github.com').get('/user').reply(200, user)
+    expect((await github.users.getAuthenticated({})).data).toEqual(user)
+  })
+
   test('logs request errors', async () => {
     nock('https://api.github.com')
       .get('/')


### PR DESCRIPTION
When calling `GitHubAPI`, we have to pass `Octokit` if we're also passing any other options. The default value of `options` is overwritten if you're passing other things, so you need to provide your own value for `Octokit` - but I don't think that's the intention.

This PR moves the assignment of `Octokit` into the `Object.assign()` call, while allowing it to be overwritten.