### PR TITLE
fix(typescript): add done callback to Paginate interface

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -64,7 +64,7 @@ export interface OctokitError extends Error {
 interface Paginate extends Octokit.Paginate {
   (
     responsePromise: Promise<Octokit.AnyResponse>,
-    callback?: (response: Octokit.AnyResponse) => any
+    callback?: (response: Octokit.AnyResponse, done: () => void) => any
   ): Promise<any[]>
 }
 

--- a/src/github/pagination.ts
+++ b/src/github/pagination.ts
@@ -14,7 +14,7 @@ export function addPagination (octokit: Octokit) {
   )
 }
 
-const defaultCallback = (response: Octokit.AnyResponse, done?: () => void) => response
+const defaultCallback = (response: Octokit.AnyResponse, done: () => void) => response
 
 async function paginate (octokit: Octokit, octokitPaginate: Octokit.Paginate, ...args: any[]) {
   // Until we fully deprecate the old paginate method, we need to check if the


### PR DESCRIPTION
When using `github.paginate` in TypeScript, you cannot write a callback function that takes the `done` callback because this is missing in the `Paginate` interface. This PR adds the callback to that interface. Values for `callback` that only take one parameter still satisfy this type.