### PR TITLE
fix: Correctly retry requests after hitting rate or abuse limits

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -23,8 +23,14 @@ export const ProbotOctokit = Octokit
 export function GitHubAPI (options: Options = { Octokit: ProbotOctokit } as any) {
   const octokit = new options.Octokit(Object.assign(options, {
     throttle: Object.assign({
-      onAbuseLimit: (retryAfter: number) => options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`),
-      onRateLimit: (retryAfter: number) => options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)
+      onAbuseLimit: (retryAfter: number) => {
+        options.logger.warn(`Abuse limit hit, retrying in ${retryAfter} seconds`)
+        return true
+      },
+      onRateLimit: (retryAfter: number) => {
+        options.logger.warn(`Rate limit hit, retrying in ${retryAfter} seconds`)
+        return true
+      }
     }, options.throttle)
   })) as GitHubAPI
 

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -5,21 +5,21 @@ import { logger } from '../src/logger'
 describe('GitHubAPI', () => {
   let github: GitHubAPI
 
-  beforeEach(() => {
-    const options: Options = {
-      Octokit: ProbotOctokit,
-      logger,
-      retry: {
-        // disable retries to test error states
-        enabled: false
-      },
-      throttle: {
-        // disable throttling, otherwise tests are _slow_
-        enabled: false
-      }
+  const defaultOptions: Options = {
+    Octokit: ProbotOctokit,
+    logger,
+    retry: {
+      // disable retries to test error states
+      enabled: false
+    },
+    throttle: {
+      // disable throttling, otherwise tests are _slow_
+      enabled: false
     }
+  }
 
-    github = GitHubAPI(options)
+  beforeEach(() => {
+    github = GitHubAPI(defaultOptions)
   })
 
   test('works without options', async () => {
@@ -46,14 +46,9 @@ describe('GitHubAPI', () => {
   describe('with retry enabled', () => {
     beforeEach(() => {
       const options: Options = {
-        Octokit: ProbotOctokit,
-        logger,
+        ...defaultOptions,
         retry: {
           enabled: true
-        },
-        throttle: {
-          // disable throttling, otherwise tests are _slow_
-          enabled: false
         }
       }
 
@@ -79,12 +74,7 @@ describe('GitHubAPI', () => {
   describe('with throttling enabled', () => {
     beforeEach(() => {
       const options: Options = {
-        Octokit: ProbotOctokit,
-        logger,
-        retry: {
-          // disable retries to test error states
-          enabled: false
-        },
+        ...defaultOptions,
         throttle: {
           enabled: true,
           minimumAbuseRetryAfter: 1

--- a/test/github.test.ts
+++ b/test/github.test.ts
@@ -43,6 +43,92 @@ describe('GitHubAPI', () => {
     }
   })
 
+  describe('with retry enabled', () => {
+    beforeEach(() => {
+      const options: Options = {
+        Octokit: ProbotOctokit,
+        logger,
+        retry: {
+          enabled: true
+        },
+        throttle: {
+          // disable throttling, otherwise tests are _slow_
+          enabled: false
+        }
+      }
+
+      github = GitHubAPI(options)
+    })
+
+    test('retries failed requests', async () => {
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(500, {})
+
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(200, {})
+
+      const response = await github.request('/')
+      expect(response.status).toBe(200)
+    })
+  })
+
+  describe('with throttling enabled', () => {
+    beforeEach(() => {
+      const options: Options = {
+        Octokit: ProbotOctokit,
+        logger,
+        retry: {
+          // disable retries to test error states
+          enabled: false
+        },
+        throttle: {
+          enabled: true,
+          minimumAbuseRetryAfter: 1
+        }
+      }
+
+      github = GitHubAPI(options)
+    })
+
+    test('retries requests when being rate limited', async () => {
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(403, {}, {
+          'X-RateLimit-Limit': '60',
+          'X-RateLimit-Remaining': '0',
+          'X-RateLimit-Reset': `${new Date().getTime() / 1000}`
+        })
+
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(200, {})
+
+      const response = await github.request('/')
+      expect(response.status).toBe(200)
+    })
+
+    test('retries requests when hitting the abuse limiter', async () => {
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(403, { message: 'The throttle plugin just looks for the word abuse in the error message' })
+
+      nock('https://api.github.com')
+        .get('/')
+        .once()
+        .reply(200, {})
+
+      const response = await github.request('/')
+      expect(response.status).toBe(200)
+    })
+  })
+
   describe('paginate', () => {
     // Prepare an array of issue objects
     const issues = new Array(5).fill(0).map((_, i, arr) => {


### PR DESCRIPTION
The `onAbuseLimit` and `onRateLimit` provided by default with Probot return `undefined` and thus do not cause the throttling plugin to actually retry the request. This PR fixes those two callbacks, and also adds tests for both the throttle and retry behaviors.

I suppose this is technically a breaking change if someone is relying on the current behavior (e.g. not retrying by default)?