### PR TITLE
fix: bump cache-manager version to allow Probot compilation by @zeit/ncc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1900,9 +1900,9 @@
       }
     },
     "cache-manager": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-2.10.0.tgz",
-      "integrity": "sha512-IuPx05r5L0uZyBDYicB2Llld1o+/1WYjoHUnrC0TNQejMAnkoYxYS9Y8Uwr+lIBytDiyu7dwwmBCup2M9KugwQ==",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-2.10.1.tgz",
+      "integrity": "sha512-bk17v9IkLqNcbCzggEh82LEJhjHp+COnL57L7a0ESbM/cOuXIIBatdVjD/ps7vOsofI48++zAC14Ye+8v50flg==",
       "requires": {
         "async": "1.5.2",
         "lru-cache": "4.0.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "bunyan": "^1.8.12",
     "bunyan-format": "^0.2.1",
     "bunyan-sentry-stream": "^1.1.0",
-    "cache-manager": "^2.4.0",
+    "cache-manager": "^2.10.1",
     "commander": "^4.0.0",
     "deepmerge": "^4.1.0",
     "dotenv": "~8.2.0",


### PR DESCRIPTION
Hi there! 👋 `cache-manager`, one of the dependencies used by Probot, recently accepted [a PR](https://github.com/BryanDonovan/node-cache-manager/pull/131) that unblocks [`@zeit/ncc`](https://github.com/zeit/ncc) from being able to [compile and run applications that need Probot](https://github.com/zeit/ncc/issues/480).

So I'd request a version bump of `cache-manager` from `^2.4.0` to `^2.10.1` to be able to use this.

Thanks for taking a look!