### PR TITLE
Nock not properly setup

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,12 +17,11 @@ const { Probot, createProbot } = require('probot')
 const payload = require('./fixtures/issues.opened')
 const issueCreatedBody = { body: 'Thanks for opening this issue!' }
 
-nock.disableNetConnect()
-
 describe('My Probot app', () => {
   let probot
 
   beforeEach(() => {
+    nock.disableNetConnect()
     probot = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
     probot.load(myProbotApp)
   })
@@ -43,6 +42,11 @@ describe('My Probot app', () => {
 
     // Receive a webhook event
     await probot.receive({ name: 'issues', payload })
+  })
+  
+  afterEach(() => {
+    nock.cleanAll()
+    nock.enableNetConnect()
   })
 })
 ```

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -43,7 +43,7 @@ describe('My Probot app', () => {
     // Receive a webhook event
     await probot.receive({ name: 'issues', payload })
   })
-  
+
   afterEach(() => {
     nock.cleanAll()
     nock.enableNetConnect()


### PR DESCRIPTION
Nock should be setup properly so that net connect ONLY gets disabled before each test and then gets enabled and reset again AFTER each test. This is recommended by them here: https://github.com/nock/nock#resetting-netconnect

I bring this up because this really bit me as I used this example in the Probot docs for my Probot tests and when I was testing my express code in a complete separate test, when running `npm test` it would fail. But running the test by itself wouldn't.

This was because `nock.disableNetConnect()` was _bleeding_ onto other tests because it wasn't encapsulated properly.

-----
[View rendered docs/testing.md](https://github.com/moltenice/probot/blob/patch-1/docs/testing.md)