### PR TITLE
fix: assert stream type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -929,9 +929,9 @@
       }
     },
     "@types/bunyan-format": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@types/bunyan-format/-/bunyan-format-0.2.0.tgz",
-      "integrity": "sha512-e87MeYM9rZUaQ7UgNU5webttfTlJWhc8oFU/hQBe/GGcf3bspY4ajVHqF1YgbysXnCwZDZgAq1FEe8ufFZZsLw==",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/bunyan-format/-/bunyan-format-0.2.1.tgz",
+      "integrity": "sha512-cZsXDJwAmrv0sU2jYstt9pzHfgxWli/CC/HiuorgC97nKldj7/bHWOJXyjnuH+R1dlftM04atyMP9YvCnrt7vA==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.4",
-    "@types/bunyan-format": "^0.2.0",
+    "@types/bunyan-format": "^0.2.1",
     "@types/cache-manager": "^2.10.0",
     "@types/dotenv": "^8.2.0",
     "@types/eventsource": "^1.1.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -61,5 +61,9 @@ export const logger = new Logger({
   level: toBunyanLogLevel(process.env.LOG_LEVEL || 'info'),
   name: 'probot',
   serializers,
-  stream: new bunyanFormat({ outputMode: toBunyanFormat(process.env.LOG_FORMAT || 'short'), color: supportsColor.stdout, levelInString: !!process.env.LOG_LEVEL_IN_STRING })
+  stream: new bunyanFormat({
+    color: supportsColor.stdout,
+    levelInString: !!process.env.LOG_LEVEL_IN_STRING,
+    outputMode: toBunyanFormat(process.env.LOG_FORMAT || 'short')
+  }) as NodeJS.WritableStream
 })


### PR DESCRIPTION
#1070  looks like a misconfigured type from `bunyan-format`.

`bunyan-format` returns the `stream.Writable` type:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf01cf33d2db0f25558413ce3ba98b472c4dd07/types/node/globals.d.ts#L640-L647

Meanwhile, `bunyan`'s `stream` option expects `NodeJS.WritableStream` from here:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/cdf01cf33d2db0f25558413ce3ba98b472c4dd07/types/node/stream.d.ts#L119-L125

We'll just assert the return type as `NodeJS.WriteableStream`.

Issue is being tracked DefinitelyTyped/DefinitelyTyped#40444.

Fixes #1070 