### PR TITLE
chore: update bunyan-format and remove earlier type assertion patch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -929,9 +929,9 @@
       }
     },
     "@types/bunyan-format": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@types/bunyan-format/-/bunyan-format-0.2.1.tgz",
-      "integrity": "sha512-cZsXDJwAmrv0sU2jYstt9pzHfgxWli/CC/HiuorgC97nKldj7/bHWOJXyjnuH+R1dlftM04atyMP9YvCnrt7vA==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@types/bunyan-format/-/bunyan-format-0.2.2.tgz",
+      "integrity": "sha512-MLX0MxSHyVse6eLql4J6BYZ3FDrO+jXlimrO209wD9NUul7abfnCLHeQf9/fnNPBDTOi3XTPNykmBcrk8jtc0g==",
       "dev": true,
       "requires": {
         "@types/node": "*"

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
   },
   "devDependencies": {
     "@types/bunyan": "^1.8.4",
-    "@types/bunyan-format": "^0.2.1",
+    "@types/bunyan-format": "^0.2.2",
     "@types/cache-manager": "^2.10.0",
     "@types/dotenv": "^8.2.0",
     "@types/eventsource": "^1.1.0",

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -65,5 +65,5 @@ export const logger = new Logger({
     color: supportsColor.stdout,
     levelInString: !!process.env.LOG_LEVEL_IN_STRING,
     outputMode: toBunyanFormat(process.env.LOG_FORMAT || 'short')
-  }) as NodeJS.WritableStream
+  })
 })


### PR DESCRIPTION
Changes made in @types/bunyan-format 0.2.1 have been rolled-back and are now available in 0.2.2. A solution for @types/bunyan-format to interpret instances of callable/newable and return the correct type is being worked on.

Going forward with this package's updates, we shouldn't have to assert any types when calling with `new`.