### PR TITLE
chore(ci): Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,12 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
     strategy:
       matrix:
         node-version: [10.x, 12.x]
+        os: [ubuntu-latest, macOS, windows]
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - master
+
+  pull_request:
+    types: 
+      - opened
+      - synchronize
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm run build
+    - run: npm test
+    - name: codecov
+      run: npx codecov
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x]
-        os: [ubuntu-latest, macOS, windows]
+        os: [ubuntu-latest, macOS, windows-latest]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This PR adds a GitHub Actions workflow file to start using it for CI. This is mostly to standardize with other projects we're working on, and for all the benefits of Actions (logs in GitHub, speed of execution, no additional management controls).

I'd love to run this in addition to our Travis setup for a hot minute - we use Semantic Release through Travis, and I'd like to get this going for CI before tackling that.