### PR TITLE
fix: Limit webhook-event-check to known events in `/app` response

### DIFF
--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -44,9 +44,15 @@ async function isSubscribedToEvent (app: Application, baseEventName: string) {
   const knownBaseEvents = [
     'check_run',
     'check_suite',
+    'commit_comment',
+    'content_reference',
+    'create',
+    'delete',
     'deployment',
     'deployment_status',
     'deploy_key',
+    'fork',
+    'gollum',
     'issues',
     'issue_comment',
     'label',
@@ -56,11 +62,17 @@ async function isSubscribedToEvent (app: Application, baseEventName: string) {
     'organization',
     'org_block',
     'page_build',
+    'project',
+    'project_card',
+    'project_column',
     'public',
     'pull_request',
     'pull_request_review',
     'pull_request_review_comment',
+    'push',
+    'release',
     'repository',
+    'repository_dispatch',
     'star',
     'status',
     'team',
@@ -119,6 +131,7 @@ async function retrieveAppMeta (app: Application) {
     }
   })
 
+  console.log(await appMeta)
   return appMeta
 }
 

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -31,9 +31,46 @@ async function webhookEventCheck (app: Application, eventName: string) {
  * @returns Returns `true` when the application is subscribed to a webhook
  * event. Otherwise, returns `false`. Returns `undefined` if Probot failed to
  * retrieve GitHub App metadata.
+ *
+ * **Note**: Probot  will only check against a list of events known to be in the
+ * `/meta` response. Therefore, only the `false` value returned should be
+ * considered truthy.
  */
 async function isSubscribedToEvent (app: Application, baseEventName: string) {
-  if (baseEventName === '*') {
+  // A list of events known to be in the response of `/meta`. This can be
+  // retrieved by calling the `/meta` endpoint on an app subscribed to all
+  // events that has the maximum repository, organization, and user permissions.
+  const knownBaseEvents = [
+    'check_run',
+    'check_suite',
+    'deployment',
+    'deployment_status',
+    'deploy_key',
+    'issues',
+    'issue_comment',
+    'label',
+    'member',
+    'membership',
+    'milestone',
+    'organization',
+    'org_block',
+    'page_build',
+    'public',
+    'pull_request',
+    'pull_request_review',
+    'pull_request_review_comment',
+    'repository',
+    'star',
+    'status',
+    'team',
+    'team_add',
+    'watch'
+  ]
+
+  // Because `/meta` does not include many events (e.g. `fork`, `installation`,
+  // etc.), we don't want to compare `baseEventName` to the results of `/meta`
+  // and instead return `true`.
+  if (!knownBaseEvents.includes(baseEventName)) {
     return true
   }
 

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -34,12 +34,12 @@ async function webhookEventCheck (app: Application, eventName: string) {
  * retrieve GitHub App metadata.
  *
  * **Note**: Probot  will only check against a list of events known to be in the
- * `/meta` response. Therefore, only the `false` value returned should be
+ * `/app` response. Therefore, only the `false` value returned should be
  * considered truthy.
  */
 async function isSubscribedToEvent (app: Application, baseEventName: string) {
-  // A list of events known to be in the response of `/meta`. This can be
-  // retrieved by calling the `/meta` endpoint on an app subscribed to all
+  // A list of events known to be in the response of `/app`. This can be
+  // retrieved by calling the `/app` endpoint on an app subscribed to all
   // events that has the maximum repository, organization, and user permissions.
   const knownBaseEvents = [
     'check_run',
@@ -80,8 +80,8 @@ async function isSubscribedToEvent (app: Application, baseEventName: string) {
     'watch'
   ]
 
-  // Because `/meta` does not include many events (e.g. `fork`, `installation`,
-  // etc.), we don't want to compare `baseEventName` to the results of `/meta`
+  // Because `/app` does not include many events (e.g. `fork`, `installation`,
+  // etc.), we don't want to compare `baseEventName` to the results of `/app`
   // and instead return `true`.
   if (!knownBaseEvents.includes(baseEventName)) {
     return true

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -20,7 +20,8 @@ async function webhookEventCheck (app: Application, eventName: string) {
   if (await isSubscribedToEvent(app, baseEventName)) {
     return true
   } else if (didFailRetrievingAppMeta === false) {
-    app.log.error(`Your app is attempting to listen to "${eventName}", but your GitHub App is not subscribed to the "${baseEventName}" event.`)
+    const userFriendlyBaseEventName = baseEventName.split('_').join(' ')
+    app.log.error(`Your app is attempting to listen to "${eventName}", but your GitHub App is not subscribed to the "${userFriendlyBaseEventName}" event.`)
   }
   return didFailRetrievingAppMeta ? undefined : false
 }

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -38,9 +38,9 @@ async function webhookEventCheck (app: Application, eventName: string) {
  * considered truthy.
  */
 async function isSubscribedToEvent (app: Application, baseEventName: string) {
-  // A list of events known to be in the response of `/app`. This can be
-  // retrieved by calling the `/app` endpoint on an app subscribed to all
-  // events that has the maximum repository, organization, and user permissions.
+  // A list of events known to be in the response of `/app`. This list can be
+  // retrieved by calling `GET /app` from an authenticated app that has maximum
+  // permissions and is subscribed to all available webhook events.
   const knownBaseEvents = [
     'check_run',
     'check_suite',
@@ -80,9 +80,10 @@ async function isSubscribedToEvent (app: Application, baseEventName: string) {
     'watch'
   ]
 
-  // Because `/app` does not include many events (e.g. `fork`, `installation`,
-  // etc.), we don't want to compare `baseEventName` to the results of `/app`
-  // and instead return `true`.
+  // Because `/app` does not include many events - such as events that all
+  // GitHub Apps are subscribed to by default (e.g.`installation`, `meta, or
+  // `marketplace_purchase`) - we can't compare `baseEventName` to the results
+  // of `GET /app`. Instead, we will return `true`.
   if (!knownBaseEvents.includes(baseEventName)) {
     return true
   }

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -29,18 +29,18 @@ async function webhookEventCheck (app: Application, eventName: string) {
 /**
  * @param {string} baseEventName The base event name refers to the part before
  * the first period mark (e.g. the `issues` part in `issues.opened`).
- * @returns Returns `true` when the application is subscribed to a webhook
- * event. Otherwise, returns `false`. Returns `undefined` if Probot failed to
+ * @returns Returns `false` when the application is not subscribed to a webhook
+ * event. Otherwise, returns `true`. Returns `undefined` if Probot failed to
  * retrieve GitHub App metadata.
  *
- * **Note**: Probot  will only check against a list of events known to be in the
- * `/app` response. Therefore, only the `false` value returned should be
- * considered truthy.
+ * **Note**: Probot will only check against a list of events known to be in the
+ * `GET /app` response. Therefore, only the `false` value should be considered
+ * truthy.
  */
 async function isSubscribedToEvent (app: Application, baseEventName: string) {
-  // A list of events known to be in the response of `/app`. This list can be
-  // retrieved by calling `GET /app` from an authenticated app that has maximum
-  // permissions and is subscribed to all available webhook events.
+  // A list of events known to be in the response of `GET /app`. This list can
+  // be retrieved by calling `GET /app` from an authenticated app that has
+  // maximum permissions and is subscribed to all available webhook events.
   const knownBaseEvents = [
     'check_run',
     'check_suite',
@@ -80,11 +80,12 @@ async function isSubscribedToEvent (app: Application, baseEventName: string) {
     'watch'
   ]
 
-  // Because `/app` does not include many events - such as events that all
-  // GitHub Apps are subscribed to by default (e.g.`installation`, `meta, or
-  // `marketplace_purchase`) - we can't compare `baseEventName` to the results
-  // of `GET /app`. Instead, we will return `true`.
-  if (!knownBaseEvents.includes(baseEventName)) {
+  // Because `GET /app` does not include all events - such as default events
+  // that all GitHub Apps are subscribed to (e.g.`installation`, `meta`, or
+  // `marketplace_purchase`) - we can only check `baseEventName` if it is known
+  // to be in the `GET /app` response.
+  const eventMayExistInAppResponse = knownBaseEvents.includes(baseEventName)
+  if (!eventMayExistInAppResponse) {
     return true
   }
 

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -132,7 +132,6 @@ async function retrieveAppMeta (app: Application) {
     }
   })
 
-  console.log(await appMeta)
   return appMeta
 }
 

--- a/test/__snapshots__/webhook-event-check.test.ts.snap
+++ b/test/__snapshots__/webhook-event-check.test.ts.snap
@@ -20,7 +20,7 @@ exports[`webhook-event-check warn user when listening to unsubscribed event 1`] 
 [MockFunction] {
   "calls": Array [
     Array [
-      "Your app is attempting to listen to \\"an-unsubscribed-event.action\\", but your GitHub App is not subscribed to the \\"an-unsubscribed-event\\" event.",
+      "Your app is attempting to listen to \\"label.created\\", but your GitHub App is not subscribed to the \\"label\\" event.",
     ],
   ],
   "results": Array [

--- a/test/__snapshots__/webhook-event-check.test.ts.snap
+++ b/test/__snapshots__/webhook-event-check.test.ts.snap
@@ -20,7 +20,7 @@ exports[`webhook-event-check warn user when listening to unsubscribed event 1`] 
 [MockFunction] {
   "calls": Array [
     Array [
-      "Your app is attempting to listen to \\"label.created\\", but your GitHub App is not subscribed to the \\"label\\" event.",
+      "Your app is attempting to listen to \\"pull_request.opened\\", but your GitHub App is not subscribed to the \\"pull request\\" event.",
     ],
   ],
   "results": Array [

--- a/test/webhook-event-check.test.ts
+++ b/test/webhook-event-check.test.ts
@@ -60,7 +60,7 @@ describe('webhook-event-check', () => {
         .get('/app').reply(200, mockAppMetaRequest())
       app = newApp()
       const spyOnLogError = jest.spyOn(app.log, 'error')
-      expect(await eventCheck(app, unsubscribedEventName)).toStrictEqual(false)
+      expect(await eventCheck(app, 'pull_request.opened')).toStrictEqual(false)
       expect(spyOnLogError).toHaveBeenCalledTimes(1)
       expect(spyOnLogError).toMatchSnapshot()
     })


### PR DESCRIPTION
Because `GET /app` does not include many events (e.g. `fork`, `installation`, etc.), we don't want to compare some events to the results of `GET /app`.

In these cases, webhook-event-check will silently ignore verifying whether the GitHub App is subscribed to the event.

![Screenshot from 2019-12-22 13-47-36](https://user-images.githubusercontent.com/10104630/71329163-70113a80-24d6-11ea-82ea-1ada6e67cce0.png)

Fixes #1091 