### PR TITLE
fix: Add `publish-docs` stage to Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ stages:
   - test
   - name: release
     if: branch =~ /^(\d+\.x|master|next|beta)$/ AND type IN (push)
+  - name: publish-docs
+    if: branch = master AND type = push
 
 jobs:
   include:
@@ -28,3 +30,6 @@ jobs:
       env: semantic-release
       before_script: npm run build
       script: npx semantic-release
+    - stage: publish-docs
+      node_js: lts/*
+      script: ./script/publish-docs

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -4,7 +4,7 @@
 set -e
 
 # Store the versions
-VERSION=$(node -e "process.stdout.write(require('./package.json').version)")
+VERSION=$(git describe --tags "$(git rev-list --tags='v*' --max-count=1)" | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
 
 # Generate docs

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -28,23 +28,23 @@ cd tmp/website
 git pull origin master
 
 # Delete previously generated docs for this version
-rm -rf api/$VERSION
+rm -rf "api/$VERSION"
 
 # Copy over the new docs
-mv ../../out api/$VERSION
+mv ../../out "api/$VERSION"
 
 # Update the /api/latest link to point to this version
-ln -sfn $VERSION api/latest
+ln -sfn "$VERSION" api/latest
 
 # Update the submodule
 git submodule update --init
 cd _submodules/probot
 git fetch
-git checkout $HEAD
+git checkout "$HEAD"
 cd ../..
 
 # Commit and publish
 git add .
 git commit -m "Update docs for v$VERSION"
-git tag -f v$VERSION
+git tag -f "v$VERSION"
 git push --tags origin master

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -4,7 +4,7 @@
 set -e
 
 # Store the versions
-VERSION=$(git describe --tags "$(git rev-list --tags='v*' --max-count=1)" | sed 's/^v//')
+VERSION=$(git describe --tags "$(git rev-list --tags='v[0-9]*' --max-count=1)" | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
 
 # Generate docs

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -1,5 +1,6 @@
 #!/bin/sh
 
+# Exit if a command returns a non-zero code
 set -e
 
 # Store the versions


### PR DESCRIPTION
Re-enable the `scripts/publish-docs` script by adding a stage to update the `docs/` submodule from [probot.github.io](https://github.com/probot/probot.github.io). 

See and fixes probot/probot.github.io#321.