### PR TITLE
fix(ci): publish docs

### DIFF
--- a/script/publish-docs
+++ b/script/publish-docs
@@ -4,7 +4,7 @@
 set -e
 
 # Store the versions
-VERSION=$(git describe --tags "$(git rev-list --tags='v[0-9]*' --max-count=1)" | sed 's/^v//')
+VERSION=$(git describe --tags --match "v[0-9]*" --abbrev=0 | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
 
 # Generate docs

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Exit if a command returns a non-zero code
 set -e


### PR DESCRIPTION
This PR successfully updates [probot.io](https://github.com/MaximDevoir/probot.io) with [this build](https://travis-ci.org/MaximDevoir/probot/builds/631991282).

Take a look at my comment [below](https://github.com/probot/probot/pull/1101#issuecomment-570320071) to see what I believe was causing the previous docs-publish failure.
