### PR TITLE
Fix for multiple handlebars advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5103,6 +5103,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.5.tgz",
       "integrity": "sha512-I16T/l8X9DV3sEkY9sK9lsPRgDsj82ayBY/4pAZyP2BcX5WeRM3O06bw9kIs2GLrHvFB/DNzWWJyFvof8wQGqw==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -5192,12 +5193,25 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
     "hbs": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.0.6.tgz",
-      "integrity": "sha512-KFt3Y4zOvVQOp84TmqVaFTpBTYO1sVenBoBY712MI3vPkKxVoO6AsuEyDayIRPRAHRYZHHWnmc4spFa8fhQpLw==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.1.0.tgz",
+      "integrity": "sha512-YDrUBtLpwRl0H5uyCGLE2LGtGJl51VvJFBj/D+Cqyr6XMopCvwXA0ynRpd87u6aVIYCeGYZHESfZzPHbNMkOPA==",
       "requires": {
-        "handlebars": "4.3.5",
+        "handlebars": "4.5.3",
         "walk": "2.3.14"
+      },
+      "dependencies": {
+        "handlebars": {
+          "version": "4.5.3",
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+          "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+          "requires": {
+            "neo-async": "^2.6.0",
+            "optimist": "^0.6.1",
+            "source-map": "^0.6.1",
+            "uglify-js": "^3.1.4"
+          }
+        }
       }
     },
     "highlight.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5099,18 +5099,6 @@
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.5.tgz",
-      "integrity": "sha512-I16T/l8X9DV3sEkY9sK9lsPRgDsj82ayBY/4pAZyP2BcX5WeRM3O06bw9kIs2GLrHvFB/DNzWWJyFvof8wQGqw==",
-      "dev": true,
-      "requires": {
-        "neo-async": "^2.6.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.6.1",
-        "uglify-js": "^3.1.4"
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
@@ -5257,6 +5245,12 @@
       "requires": {
         "whatwg-encoding": "^1.0.1"
       }
+    },
+    "html-escaper": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.0.tgz",
+      "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
+      "dev": true
     },
     "http-cache-semantics": {
       "version": "4.0.3",
@@ -5888,12 +5882,12 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
-      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.7.tgz",
+      "integrity": "sha512-uu1F/L1o5Y6LzPVSVZXNOoD/KXpJue9aeLRd0sM9uMXfZvzomB0WxVamWb5ue8kA2vVWEmW7EG+A5n3f1kqHKg==",
       "dev": true,
       "requires": {
-        "handlebars": "^4.1.2"
+        "html-escaper": "^2.0.0"
       }
     },
     "java-properties": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "eventsource": "^1.0.7",
     "express": "^4.16.2",
     "express-async-errors": "^3.0.0",
-    "hbs": "^4.0.6",
+    "hbs": "^4.1.0",
     "ioredis": "^4.5.1",
     "is-base64": "1.0.0",
     "js-yaml": "^3.13.1",


### PR DESCRIPTION
This PR updates hbs to 4.1.0, which uses safe handlebars version 4.5.3, and updates istanbul-reports to 2.2.7, which drops handlebars completely so that no [prototype access errors are written](https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access) to the console when running `npm test`.

As far as I know, this is only required to mute the `npm audit` errors; I'm not aware of ways to exploit handlebars vulnerabilities on probot.