### PR TITLE
feat: Add support for GHE_PROTOCOL

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -25,6 +25,7 @@ Variable | Description
 `DISABLE_STATS` | Set to `true` to disable the the `/probot/stats` endpoint, which gathers data about each app. Recommend for apps with a lot of installations. <p>_(Example: `true`)_</p>
 `DISABLE_WEBHOOK_EVENT_CHECK` | Set to `true` to disable Probot's webhook-event-check feature. While the feature is enabled, Probot will warn you when your application is attempting to listen to an event that your GitHub App is not subscribed to. <br> Note: webhook-event-check is automatically disabled when `NODE_ENV` is set to `production`. <p>_(Default: `false`)_</p>
 `GHE_HOST` | The hostname of your GitHub Enterprise instance. <p>_(Example: `github.mycompany.com`)_</p>
+`GHE_PROTOCOL` | The protocol of your GitHub Enterprise instance. Defaults to HTTPS. Do not change unless you are certain. <p>_(Example: `https`)_</p>
 `IGNORED_ACCOUNTS` | A comma-separated list of GitHub account names to ignore. This is currently used by the `/probot/stats`. By marking an account as ignored, that account will not be included in data collected on the website. The primary use case for this is spammy or abusive users that the GitHub API sends us but who 404. <p>_(Example: `spammyPerson,abusiveAccount`)_</p>
 `LOG_FORMAT` | By default, logs are formatted for readability in development. You can set this to `short`, `long`, `simple`, `json`, `bunyan`. Default: `short`
 `LOG_LEVEL` | The verbosity of logs to show when running your app, which can be `trace`, `debug`, `info`, `warn`, `error`, or `fatal`. Default: `info`

--- a/src/application.ts
+++ b/src/application.ts
@@ -498,7 +498,7 @@ export class Application {
           const accessToken = await this.app.getInstallationAccessToken({ installationId: id })
           return `token ${accessToken}`
         },
-        baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
+        baseUrl: process.env.GHE_HOST && `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api/v3`,
         logger: log.child({ name: 'github', installation: String(id) })
       }
 
@@ -521,7 +521,7 @@ export class Application {
     const github = GitHubAPI({
       Octokit: this.Octokit,
       auth: `Bearer ${token}`,
-      baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
+      baseUrl: process.env.GHE_HOST && `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api/v3`,
       logger: log.child({ name: 'github' })
     })
 

--- a/src/github/graphql.ts
+++ b/src/github/graphql.ts
@@ -17,7 +17,7 @@ export interface GraphQLError {
 
 export function addGraphQL (client: GitHubAPI) {
   const graphqlRequest = (client.request as any as typeof request).defaults({
-    ...(process.env.GHE_HOST ? { baseUrl: `https://${process.env.GHE_HOST}/api` } : {})
+    ...(process.env.GHE_HOST ? { baseUrl: `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api` } : {})
   })
   const graphql = withCustomRequest(graphqlRequest)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -128,7 +128,7 @@ export class Probot {
       }
 
       this.app = new OctokitApp({
-        baseUrl: process.env.GHE_HOST && `https://${process.env.GHE_HOST}/api/v3`,
+        baseUrl: process.env.GHE_HOST && `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api/v3`,
         id: options.id as number,
         privateKey: options.cert as string
       })

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -61,7 +61,7 @@ export class ManifestCreation {
     const options: any = {
       code,
       headers: { accept: 'application/vnd.github.fury-preview+json' },
-      ...process.env.GHE_HOST && { baseUrl: `https://${process.env.GHE_HOST}/api/v3` }
+      ...process.env.GHE_HOST && { baseUrl: `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api/v3` }
     }
     const response = await github.request('POST /app-manifests/:code/conversions', options)
 
@@ -81,6 +81,6 @@ export class ManifestCreation {
 
   get createAppUrl () {
     const githubHost = process.env.GHE_HOST || `github.com`
-    return `https://${githubHost}/settings/apps/new`
+    return `${process.env.GHE_PROTOCOL || 'https'}://${githubHost}/settings/apps/new`
   }
 }

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -4,6 +4,10 @@ exports[`Probot ghe support throws if the GHE host includes a protocol 1`] = `[E
 
 exports[`Probot ghe support throws if the GHE host includes a protocol 2`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
 
+exports[`Probot ghe support with http throws if the GHE host includes a protocol 1`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
+
+exports[`Probot ghe support with http throws if the GHE host includes a protocol 2`] = `[Error: Your \`GHE_HOST\` environment variable should not begin with https:// or http://]`;
+
 exports[`Probot run runs with a function as argument 1`] = `
 Object {
   "cert": "-----BEGIN RSA PRIVATE KEY-----

--- a/test/github/graphql.test.ts
+++ b/test/github/graphql.test.ts
@@ -108,6 +108,39 @@ describe('github/graphql', () => {
     })
   })
 
+  describe('ghe support with http', () => {
+    const query = 'query { viewer { login } }'
+    let data
+
+    beforeEach(() => {
+      process.env.GHE_HOST = 'notreallygithub.com'
+      process.env.GHE_PROTOCOL = 'http'
+
+      const options: Options = {
+        Octokit: ProbotOctokit,
+        logger
+      }
+
+      github = GitHubAPI(options)
+    })
+
+    afterEach(() => {
+      delete process.env.GHE_HOST
+      delete process.env.GHE_PROTOCOL
+    })
+
+    test('makes a graphql query', async () => {
+      data = { viewer: { login: 'bkeepers' } }
+
+      nock('http://notreallygithub.com', {
+        reqheaders: { 'content-type': 'application/json; charset=utf-8' }
+      }).post('/api/graphql', { query })
+        .reply(200, { data })
+
+      expect(await github.graphql(query)).toEqual(data)
+    })
+  })
+
   describe('deprecations', () => {
     const query = 'query { viewer { login } }'
     let data: any

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -322,6 +322,75 @@ describe('Probot', () => {
     })
   })
 
+  describe('ghe support with http', () => {
+    let app: Application
+
+    beforeEach(() => {
+      process.env.GHE_HOST = 'notreallygithub.com'
+      process.env.GHE_PROTOCOL = 'http'
+
+      nock('http://notreallygithub.com/api/v3')
+        .defaultReplyHeaders({ 'Content-Type': 'application/json' })
+        .get('/app/installations').reply(200, ['I work!'])
+        .post('/app/installations/5/access_tokens').reply(200, { token: 'github_token' })
+
+      app = helper.createApp()
+    })
+
+    afterEach(() => {
+      delete process.env.GHE_HOST
+      delete process.env.GHE_PROTOCOL
+    })
+
+    it('requests from the correct API URL', async () => {
+      const spy = jest.fn()
+
+      const appFn = async (appl: Application) => {
+        const github = await appl.auth()
+        const res = await github.apps.listInstallations({})
+        return spy(res)
+      }
+
+      await appFn(app)
+      await app.receive(event)
+      expect(spy.mock.calls[0][0].data[0]).toBe('I work!')
+    })
+
+    it('passes GHE host to the app', async () => {
+      probot = createProbot({
+        id: 1234,
+        // Some valid RSA key to be able to sign the initial token
+        // tslint:disable-next-line:object-literal-sort-keys
+        cert: '-----BEGIN RSA PRIVATE KEY-----\n' +
+          'MIIBOQIBAAJBAIILhiN9IFpaE0pUXsesuuoaj6eeDiAqCiE49WB1tMB8ZMhC37kY\n' +
+          'Fl52NUYbUxb7JEf6pH5H9vqw1Wp69u78XeUCAwEAAQJAb88urnaXiXdmnIK71tuo\n' +
+          '/TyHBKt9I6Rhfzz0o9Gv7coL7a537FVDvV5UCARXHJMF41tKwj+zlt9EEUw7a1HY\n' +
+          'wQIhAL4F/VHWSPHeTgXYf4EaX2OlpSOk/n7lsFtL/6bWRzRVAiEArzJs2vopJitv\n' +
+          'A1yBjz3q2nX+zthk+GLXrJQkYOnIk1ECIHfeFV8TWm5gej1LxZquBTA5pINoqDVq\n' +
+          'NKZSuZEHqGEFAiB6EDrxkovq8SYGhIQsJeqkTMO8n94xhMRZlFmIQDokEQIgAq5U\n' +
+          'r1UQNnUExRh7ZT0kFbMfO9jKYZVlQdCL9Dn93vo=\n' +
+          '-----END RSA PRIVATE KEY-----'
+      })
+      expect(await probot.app!.getInstallationAccessToken({ installationId: 5 })).toBe('github_token')
+    })
+
+    it('throws if the GHE host includes a protocol', async () => {
+      process.env.GHE_HOST = 'http://notreallygithub.com'
+
+      try {
+        await app.auth()
+      } catch (e) {
+        expect(e).toMatchSnapshot()
+      }
+
+      try {
+        createProbot({ id: 1234, cert: 'xxxx' })
+      } catch (e) {
+        expect(e).toMatchSnapshot()
+      }
+    })
+  })
+
   describe('process.env.REDIS_URL', () => {
     beforeEach(() => {
       process.env.REDIS_URL = 'test'

--- a/test/manifest-creation.test.ts
+++ b/test/manifest-creation.test.ts
@@ -41,6 +41,7 @@ describe('ManifestCreation', () => {
   describe('createAppUrl', () => {
     afterEach(() => {
       delete process.env.GHE_HOST
+      delete process.env.GHE_PROTOCOL
     })
 
     test('creates an app url', () => {
@@ -50,6 +51,12 @@ describe('ManifestCreation', () => {
     test('creates an app url when github host env is set', () => {
       process.env.GHE_HOST = 'hiimbex.github.com'
       expect(setup.createAppUrl).toEqual('https://hiimbex.github.com/settings/apps/new')
+    })
+
+    test('creates an app url when github host env and protocol are set', () => {
+      process.env.GHE_HOST = 'hiimbex.github.com'
+      process.env.GHE_PROTOCOL = 'http'
+      expect(setup.createAppUrl).toEqual('http://hiimbex.github.com/settings/apps/new')
     })
   })
 


### PR DESCRIPTION
This adds support for overriding the `GHE_PROTOCOL` to something like `http`. Although I don't expect this to be used outside of github (using a local github dev env), it can exist here with the warning in the config guide.

-----
[View rendered docs/configuration.md](https://github.com/jules2689/probot/blob/ghe-protocol/docs/configuration.md)