### PR TITLE
docs: change phrasing on how to get the private key

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -109,14 +109,17 @@ GitHub App Manifests--otherwise known as easy app creation--make it simple to ge
 
 To run your app in development, you will need to configure a GitHub App to deliver webhooks to your local machine.
 
-1. On your local machine, copy `.env.example` to `.env` in the same directory.
-1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` in `.env` to the URL that you are redirected to.
+1. On your local machine, copy `.env.example` to `.env` in the same directory. We're going to be changing a few things in this new file.
+1. Go to [smee.io](https://smee.io) and click **Start a new channel**. Set `WEBHOOK_PROXY_URL` to the URL that you are redirected to.<br/>
+E.g. `https://smee.io/AbCd1234EfGh5678`
 1. [Create a new GitHub App](https://github.com/settings/apps/new) with:
-    - **Webhook URL**: Use your `WEBHOOK_PROXY_URL` from the previous step.
-    - **Webhook Secret:** `development` (Note: For optimal security, Probot apps **require** this secret be set, even though it's optional on GitHub.).
+    - **Webhook URL**: Use the same `WEBHOOK_PROXY_URL` from the previous step.
+    - **Webhook Secret:** `development`, or whatever you set for this in your `.env` file. (Note: For optimal security, Probot apps **require** this secret be set, even though it's optional on GitHub.).
     - **Permissions & events** is located lower down the page and will depend on what data you want your app to have access to. Note: if, for example, you only enable issue events, you will not be able to listen on pull request webhooks with your app. However, for development, we recommend enabling everything.
-1. Download the private key and move it to your project's directory. As long as it's in the root of your project, Probot will find it automatically regardless of the filename.
-1. Edit `.env` and set `APP_ID` to the ID of the app you just created. The App ID can be found in your app settings page here <img width="1048" alt="screen shot 2017-08-20 at 8 31 31 am" src="https://user-images.githubusercontent.com/5713670/42248717-f6bf4f10-7edb-11e8-8dd5-387181c771bc.png">
+1. You must now set `APP_ID` in your `.env` to the ID of the app you just created. The App ID can be found in your app settings page here <img width="1048" alt="screen shot 2017-08-20 at 8 31 31 am" src="https://user-images.githubusercontent.com/5713670/42248717-f6bf4f10-7edb-11e8-8dd5-387181c771bc.png">
+1. Finally, generate and download a private key file (using the button seen in the image above), then move it to your project's directory. As long as it's in the root of your project, Probot will find it automatically regardless of the filename. 
+
+For more information about these and other available keys, head over to the [environmental configuration documentation](https://probot.github.io/docs/configuration/).
 
 ## Installing the app on a repository
 


### PR DESCRIPTION
Based on my recent attempt at following these instructions, I've thought of a couple changes that may make things easier for fellow new users of this app. Great job, everyone. It is pretty awesome!

--
#### Changes:
Having the private key download at the end leverages the image provided for 'APP_ID', in order to cue and instruct the user on how to get the `.PEM` file; and groups the steps to edit `.env` together, leaving the download for last. This enhances both the setup flow and its legibility.

Thought it would also be useful to add a link here to see the additional environmental configurations available.

-----
[View rendered docs/development.md](https://github.com/caravinci/probot/blob/patch-1/docs/development.md)