### PR TITLE
fix: disable webhook-event-check in common test environments

### DIFF
--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -141,8 +141,25 @@ function isWebhookEventCheckEnabled () {
     return false
   } else if (process.env.NODE_ENV?.toLowerCase() === 'production') {
     return false
+  } else if (inTestEnvironment()) {
+    // We disable the feature in test environments to avoid requiring developers
+    // to add a stub mocking the `GET /app` route this feature calls.
+    return false
   }
   return true
+}
+
+/**
+ * Detects if Probot is likely running in a test environment.
+ *
+ * **Note**: This method only detects Jest environments or when NODE_ENV starts
+ * with `test`.
+ * @returns Returns `true` if Probot is in a test environment.
+ */
+function inTestEnvironment (): boolean {
+  const nodeEnvContainsTest = process.env.NODE_ENV?.substr(0, 4).toLowerCase() === 'test'
+  const isRunningJest = process.env.JEST_WORKER_ID !== undefined
+  return nodeEnvContainsTest || isRunningJest
 }
 
 export default webhookEventCheck

--- a/src/webhook-event-check.ts
+++ b/src/webhook-event-check.ts
@@ -137,9 +137,9 @@ async function retrieveAppMeta (app: Application) {
 }
 
 function isWebhookEventCheckEnabled () {
-  if (process.env.DISABLE_WEBHOOK_EVENT_CHECK && process.env.DISABLE_WEBHOOK_EVENT_CHECK.toLowerCase() === 'true') {
+  if (process.env.DISABLE_WEBHOOK_EVENT_CHECK?.toLowerCase() === 'true') {
     return false
-  } else if (process.env.NODE_ENV && process.env.NODE_ENV.toLowerCase() === 'production') {
+  } else if (process.env.NODE_ENV?.toLowerCase() === 'production') {
     return false
   }
   return true


### PR DESCRIPTION
Yesterday, @travi brought to my attention that the `GET /app` route this feature calls had to be mocked under certain test conditions (see the linked [PR](https://github.com/probot/settings/commit/dcd7bd69b6534bba739807e2539126bc40d7e00d#diff-1d2e5ba7c00513700e614348ffe1bbb0)). I imagine that took some time to find because we haven't documented how or when the route needs to be mocked.

With this PR, we disable the feature in certain test environments to avoid requiring developers to add a stub mocking the `GET /app` route. This also allows developers to focus on mocking the requests that pertain to their application and *not* the requests from the developer enhancement tools provided by Probot.

Currently, this determines that Probot is in a test environment by looking to see if `NODE_ENV` begins with `test` or if Probot is running within Jest by checking for the `JEST_WORKER_ID` variable. I haven't seen Probot users using testing frameworks outside of Jest - although we can always add checks for other test environments.
