### PR TITLE
ci(docs): fix Git setup on docs action

### DIFF
--- a/script/publish-docs
+++ b/script/publish-docs
@@ -6,7 +6,7 @@ set -e
 # Store the versions
 VERSION=$(git describe --tags --match "v[0-9]*" --abbrev=0 | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
-REPO=https://x-access-token:${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
+https://${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
 
 # Generate docs
 npm run doc

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -6,21 +6,15 @@ set -e
 # Store the versions
 VERSION=$(git describe --tags --match "v[0-9]*" --abbrev=0 | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
+REPO=https://x-access-token:${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
 
 # Generate docs
 npm run doc
 
 # Checkout the website into the tmp directory
 [ -d tmp/website ] || {
-  REPO=https://github.com/probot/probot.github.io
-
-  # If OCTOKITBOT_PAT environment variable is present, use that to push.
-  if [[ -n "$OCTOKITBOT_PAT" ]]; then
-    REPO=${REPO/https:\/\//https://${OCTOKITBOT_PAT}@}
-  fi
-
   mkdir -p tmp
-  git clone $REPO tmp/website
+  git clone "$REPO" tmp/website
 }
 
 # Update the website checkout
@@ -43,7 +37,9 @@ git fetch
 git checkout "$HEAD"
 cd ../..
 
-# Commit and publish
+# Configure Git and commit, and publish
+git config --global user.email "action@github.com"
+git config --global user.name "GitHub Action"
 git add .
-git commit -m "Update docs for v$VERSION"
-git push origin master
+git commit -m "Update docs from Probot v$VERSION" -m "via $GITHUB_REPOSITORY@$HEAD"
+git push "$REPO" master


### PR DESCRIPTION
Okay, so yesterdays *[fix](https://github.com/probot/probot/pull/1124)* wasn't [enough](https://github.com/probot/probot/runs/422571032).

This PR:

* Configures Git to be able to commit changes.
* Sets `REPO` alongside other top-level variables.
* Adds a description to the commit message about which change triggered the update.

This workflow has been [tested successfully](https://github.com/MaximDevoir/probot/runs/423699349) and you can see an example of the new commit message https://github.com/MaximDevoir/probot.io/commit/0c96e3a6a64c508ffe3d1fd700b49ff95e441306

