### PR TITLE
ci(docs): correctly set `REPO`

### DIFF
--- a/script/publish-docs
+++ b/script/publish-docs
@@ -6,7 +6,7 @@ set -e
 # Store the versions
 VERSION=$(git describe --tags --match "v[0-9]*" --abbrev=0 | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
-https://${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
+REPO=https://${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
 
 # Generate docs
 npm run doc


### PR DESCRIPTION
These PRs are endless... REPO declaration was removed in 0748bc6a83f81b95538d06fdd366e97723123f3b.