### PR TITLE
feat: mention that app must be activated after install

### DIFF
--- a/views/success.hbs
+++ b/views/success.hbs
@@ -15,7 +15,7 @@
         <div class="text-center">
           <h1 class="alt-h3 mb-2">Congrats! You have successfully installed your app!
             <br>
-            Checkout <a href="https://probot.github.io/docs/webhooks/">Receiving webhooks</a> and <a href="https://probot.github.io/docs/github-api/">Interacting with GitHub</a> to learn more!</h1>
+            Make sure to activate your app in the app settings and then checkout <a href="https://probot.github.io/docs/webhooks/">Receiving webhooks</a> and <a href="https://probot.github.io/docs/github-api/">Interacting with GitHub</a> to learn more!</h1>
         </div>
       </div>
 

--- a/views/success.hbs
+++ b/views/success.hbs
@@ -13,9 +13,13 @@
       <img src="/probot/static/robot.svg" alt="Probot Logo" width="100" class="mb-6">
       <div class="box-shadow rounded-2 border p-6 bg-white">
         <div class="text-center">
-          <h1 class="alt-h3 mb-2">Congrats! You have successfully installed your app!
-            <br>
-            Make sure to activate your app in the app settings and then checkout <a href="https://probot.github.io/docs/webhooks/">Receiving webhooks</a> and <a href="https://probot.github.io/docs/github-api/">Interacting with GitHub</a> to learn more!</h1>
+          <h1 class="alt-h3 mb-2">Congrats! You have successfully installed your app!<h1>
+
+          <p class="flash flash-warn">
+            <strong>Important</strong>. Check the "active" checkbox in your GitHub App settings page in order to retrieve webhooks.
+          </p>
+
+          <p>Checkout <a href="https://probot.github.io/docs/webhooks/">Receiving webhooks</a> and <a href="https://probot.github.io/docs/github-api/">Interacting with GitHub</a> to learn more!</p>
         </div>
       </div>
 


### PR DESCRIPTION
Recent change in the GitHub app installation workflow now 
requires that an app must be activated after installation. That
should be mentioned in the "success" page.