### PR TITLE
docs: Deployment instructions for Platform.sh

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -262,7 +262,7 @@ You can branch the template above, add your application's code to it, and merge 
 
 1. Add Platform.sh configuration files
 
-  Each project on Platform.sh requires at least [three configuration files](https://docs.platform.sh/overview/structure.html) to describe and application. From your project root, run
+  Each project on Platform.sh requires at least [three configuration files](https://docs.platform.sh/overview/structure.html) to describe and application. From your project root, run the following commands to create them:
 
   ```
   mkdir .platform
@@ -270,7 +270,7 @@ You can branch the template above, add your application's code to it, and merge 
   touch .platform.app.yaml
   ```
 
-  Unless your Probot app depends on [database storage](https://probot.github.io/docs/persistence/), the `services.yaml` file can be left empty. If a database is needed, visit Platform.sh [Services documentation](https://docs.platform.sh/configuration/services.html) for more detailed information on how to configure the service your app depends on.
+  Unless your Probot app depends on [database storage](https://probot.github.io/docs/persistence/), the `services.yaml` file can be left empty. If a database is needed, visit the Platform.sh [Services documentation](https://docs.platform.sh/configuration/services.html) for more detailed information on how to configure the service your app depends on.
 
   In your [`routes.yaml`](https://docs.platform.sh/configuration/routes.html) file, copy the following:
 
@@ -284,7 +284,7 @@ You can branch the template above, add your application's code to it, and merge 
       to: "https://{default}/"
   ```
 
-  This configuration directs requests to an application called `app`, and sets an additional redirect for requests that do not include the `www` prefix.
+  This configuration directs requests to an application container called `app`, and sets an additional redirect for requests that do not include the `www` prefix.
 
   Lastly, in the [`.platform.app.yaml`](https://docs.platform.sh/configuration/app-containers.html) file, include the settings below:
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -162,7 +162,7 @@ Deploy Probot as a Serverless Function to [ZEIT Now](http://zeit.co). After [cre
 
 ### Platform.sh
 
-There are two ways to deploy your Probot app to [Platform.sh](https://platform.sh/): [manually](#deploying-an-existing-project) or by modifying an existing [template project](#quickstart-deploying-a-template). Either will work, however the template has been design to set the environment variables retrieved from GitHub during registration automatically, for every branch of your project, and may prove easier for migration in the long run.
+There are two ways to deploy your Probot app to [Platform.sh](https://platform.sh/): [manually](#deploying-an-existing-project) or by modifying an existing [template project](#quickstart-deploying-a-template). Either will work, however the template has been designed to set the environment variables retrieved from GitHub during registration automatically, for every branch of your project, and may prove easier for migration in the long run.
 
 #### Quickstart: Deploying a template
 
@@ -194,29 +194,7 @@ After that, there are only a few steps left to set up and register the app:
 
   Platform.sh allows you to branch your production application and deploy an exact copy of that application on staging and development environments that themselves can be registered with GitHub, becoming fully testable apps in their own right.
 
-  The [README](https://github.com/platformsh-templates/probot/blob/master/README.md) contains all of the commands to set this up, but briefly those steps include:
-
-    1. Cloning the project locally.
-
-      ```
-      git clone --branch master <PROJECT ID>@git.<PROJECT REGION>.platform.sh:<PROJECT ID>.git <PROJECT NAME>
-      ```
-
-    1. [Obtaining an API token](https://docs.platform.sh/development/cli/api-tokens.html#obtaining-a-token) and adding it to the project, which makes automatically setting the GitHub app environment variables across branches possible.
-
-      ```
-      platform variable:create --level project --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value YOUR_API_TOKEN
-      ```
-
-    1. Registering the App with GitHub.
-    1. Setting the "Master" environment for production.
-
-      ```
-      echo 'export NODE_ENV="production"' > .environment
-      git add .environment && git commit -m "Set app for production."
-      ```
-
-    1. Verifying deliveries and installing the app on a repository to test.
+  Follow the remaining steps in the [README](https://github.com/platformsh-templates/probot/blob/master/README.md) to finish setting up the template.
 
 1. Migrate your code
 
@@ -284,14 +262,14 @@ You can branch the template above, add your application's code to it, and merge 
       to: "https://{default}/"
   ```
 
-  This configuration directs requests to an application container called `app`, and sets an additional redirect for requests that do not include the `www` prefix.
+  This configuration directs requests to an application container called `app`, and sets an additional redirect for requests that include the `www` prefix.
 
   Lastly, in the [`.platform.app.yaml`](https://docs.platform.sh/configuration/app-containers.html) file, include the settings below:
 
   ```yaml
   name: app
 
-  type: 'nodejs:X'
+  type: 'nodejs:12'
 
   variables:
       env:
@@ -306,7 +284,7 @@ You can branch the template above, add your application's code to it, and merge 
 
   This file defines your Probot app to run in a Node.js application container called `app`, with 256Mb of persistent storage. Feel free to modify the `web.commands.start` to match the start command of your app.
 
-  If you would like to run the Probot app on Node.js 12, simply modify the `type` key to read `'nodejs:12'` instead of the `X` placeholder shown above. You can set the application container to use a number of Node.js versions, so visit the [documentation](https://docs.platform.sh/languages/nodejs.html#supported-versions) for a full list of those supported. 
+  You can set the application container to use a number of Node.js versions (defined in `type`), so visit the [documentation](https://docs.platform.sh/languages/nodejs.html#supported-versions) for a full list of those supported.
 
 
 1. Register the app on GitHub

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -238,7 +238,7 @@ You can branch the template above, add your application's code to it, and merge 
 
   When you create a new account, the setup wizard will direct you to create a new project. Name it, and select a region for the project to be served from.
 
-1. Install the Platform.sh CLI
+1. Install the [Platform.sh CLI]([Platform.sh CLI](https://docs.platform.sh/development/cli.html))
 
   Run the command
 
@@ -291,7 +291,7 @@ You can branch the template above, add your application's code to it, and merge 
   ```yaml
   name: app
 
-  type: 'nodejs:12'
+  type: 'nodejs:X'
 
   variables:
       env:
@@ -304,7 +304,10 @@ You can branch the template above, add your application's code to it, and merge 
       start: "npm start"
   ```
 
-  This file defines your Probot app to run in a Node.js 12 application container called `app`, with 256Mb of persistent storage. Feel free to modify the `web.commands.start` to match the start command of your app.
+  This file defines your Probot app to run in a Node.js application container called `app`, with 256Mb of persistent storage. Feel free to modify the `web.commands.start` to match the start command of your app.
+
+  If you would like to run the Probot app on Node.js 12, simply modify the `type` key to read `'nodejs:12'` instead of the `X` placeholder shown above. You can set the application container to use a number of Node.js versions, so visit the [documentation](https://docs.platform.sh/languages/nodejs.html#supported-versions) for a full list of those supported. 
+
 
 1. Register the app on GitHub
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -15,6 +15,7 @@ Every app can either be deployed stand-alone, or combined with other apps in one
     1. [Glitch](#glitch)
     1. [Heroku](#heroku)
     1. [ZEIT Now](#zeit-now)
+    1. [Platform.sh](#platformsh)
 1. [Share the app](#share-the-app)
 1. [Combining apps](#combining-apps)
 1. [Error tracking](#error-tracking)
@@ -144,11 +145,11 @@ Deploy Probot as a Serverless Function to [ZEIT Now](http://zeit.co). After [cre
      }
    }
    ```
-   
+
       **NOTE**: Add `LOG_LEVEL=trace` to get verbose logging, or add `LOG_LEVEL=info` instead to show less details.
 
 1. Run `now secrets add probot-api-id aaa`, `now secrets add probot-webhook-secret bbb`, `now secrets add probot-private-key "$(cat ~/Downloads/*.private-key.pem | base64)"` replacing the `aaa` and `bbb` with the values for those variables.
-      
+
 1. Deploy with `now` or connect your GitHub repository](https://zeit.co/github) to ZEIT Now and deploy on `git push`.
 
 1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
@@ -158,6 +159,102 @@ Deploy Probot as a Serverless Function to [ZEIT Now](http://zeit.co). After [cre
         $ now --prod
 
 1. Visit `https://your-deployment.now.sh/api` to invoke the serverless function.
+
+### Platform.sh
+
+#### Deploying a template
+
+You can easily deploy Probot's [Hello world](https://probot.github.io/docs/hello-world/) app on Platform.sh, which delivers a comment onto newly opened issues, by clicking the button below.
+
+<p align="center">
+<a href="https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/probot/.platform.template.yaml&utm_content=probot&utm_source=github&utm_medium=button&utm_campaign=deploy_on_platform">
+    <img src="https://platform.sh/images/deploy/lg-blue.svg" alt="Deploy on Platform.sh" width="180px" />
+</a>
+</p>
+
+The link will create a free trial account on Platform.sh, create a new project to host the app, and initialize it with the [Probot template repository](https://github.com/platformsh-templates/probot).
+
+After that, there are only a few steps left to set up and register the app:
+
+1. Install the Platform.sh CLI
+
+  Setting relevant environment variables and retrieving information about the Probot project will be much easier once you install the [Platform.sh CLI](https://docs.platform.sh/development/cli.html). Run the following command:
+
+  ```
+  curl -sS https://platform.sh/cli/installer | php
+  ```
+
+  You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
+
+1. Clone the project locally
+
+  The new project is now accessible from the Platform.sh management console. Click on the "Master" environment, and then at the top of the page click the "GIT" dropdown button to retrieve the command to clone locally, which should look something like this:
+
+  ```
+  git clone --branch master <PROJECT ID>@git.<PROJECT REGION>.platform.sh:<PROJECT ID>.git <PROJECT NAME>
+  ```
+
+2. Add an API token to the project
+
+  The template is designed to set the `APP_ID`, `PRIVATE_KEY`, and `WEBHOOK_SECRET` environment variables automatically for you during the registration process, by installing and using the [Platform.sh CLI](https://docs.platform.sh/development/cli.html) within your application container.
+
+  In order give the CLI access to set these variables and finish setting up your application, you will need to first need to create an API token associated with your account.
+
+  You can follow the instructions in the [Platform.sh documentation](https://docs.platform.sh/development/cli/api-tokens.html#obtaining-a-token) to create one through the UI. Copy the API token that as generated, and then from the project directory run
+
+  ```
+  platform variable:create --level project --name env:PLATFORMSH_CLI_TOKEN --sensitive true --value YOUR_API_TOKEN
+  ```
+
+  This may seem like an odd step, instead of just setting the variables manually, at first. But Platform.sh allows you to create live environments, complete with exact copies of production code and its data, for every branch or pull request. By setting this value now, an app's registration information will also be saved automatically for staging and development versions of your app.
+
+3. Register the app on GitHub
+
+  You can click the "URL" dropdown button on the "Master" environment (or run the command `platform url` locally) to view the deployed app. Register the app with GitHub as you normally would. GitHub will retrieve the `APP_ID`, `PRIVATE_KEY`, and `WEBHOOK_SECRET` values and save them to a folder with write access on your project.
+
+4. Trigger environment variables to be set
+
+  Inside the local repository, find the `.environment` file. You will see that `NODE_ENV` is currently set for development.
+
+  Update that file to read `NODE_ENV="production"`. Once you have done that, commit and push the change.
+
+  ```
+  git commit -am "Set for production" && git push origin master
+  ```
+
+  Now that you have done that, you will see that as soon as the build of your commit completes, all of the important environment variables described above will be set for the project.
+
+5. Verify
+
+  When the final redeployment has completed, and all of your environment variables have been added, go to your GitHub App's advanced settings.
+
+  You will see that the first delivery it attempted to deliver to Platform.sh failed while you were registering.
+
+  Expand the previous failed delivery by clicking the three dots, and then click Redeliver and then Yes, repeat this delivery to repeat the delivery. Since you have set up the app for production, it should now show a 200 successful response.
+
+  Scroll to the bottom of the "General" settings page and click the "Active" checkbox so that GitHub can start sending more deliveries once it's installed on a repository.
+
+6. Test on a repository
+
+  Visit your application's public page (https://github.com/apps/APPLICATION_NAME) and click Install. Install it on the repository of your choice, and you will see that once you open a new issue the app will deliver a new response comment onto it.
+
+#### Setting up an existing project
+
+You can create the same above functionality on your own Probot app, and host it on Platform.sh.
+
+1. [Create a free trial account](https://accounts.platform.sh/platform/trial/general/setup)
+
+2. Create a new project
+
+  When you create a new account, the setup wizard will direct you to create a new project. Name it, and select a region for the project to be served from.
+
+  
+
+3. Install the Platform.sh CLI
+
+4. Initialize the project with the app
+
+  If your app already exists on a GitHub repository, you can find instructions in the public documentation for setting up a new
 
 ## Share the app
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -248,13 +248,19 @@ You can create the same above functionality on your own Probot app, and host it 
 
   When you create a new account, the setup wizard will direct you to create a new project. Name it, and select a region for the project to be served from.
 
-  
-
 3. Install the Platform.sh CLI
+
+  Run the command
+
+  ```
+  curl -sS https://platform.sh/cli/installer | php
+  ```
 
 4. Initialize the project with the app
 
-  If your app already exists on a GitHub repository, you can find instructions in the public documentation for setting up a new
+  If your app already exists on a GitHub repository, you can find instructions in the public documentation for [setting up a new integration](https://docs.platform.sh/administration/integrations/github.html) to it.
+
+  Otherwise, run
 
 ## Share the app
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -180,31 +180,31 @@ After that, there are only a few steps left to set up and register the app:
 
 1. Install the Platform.sh CLI
 
-  Setting relevant environment variables and retrieving information about the Probot project will be much easier once you install the [Platform.sh CLI](https://docs.platform.sh/development/cli.html). Run the following command:
+   Setting relevant environment variables and retrieving information about the Probot project will be much easier once you install the [Platform.sh CLI](https://docs.platform.sh/development/cli.html). Run the following command:
 
-  ```
-  curl -sS https://platform.sh/cli/installer | php
-  ```
+   ```
+   curl -sS https://platform.sh/cli/installer | php
+   ```
 
-  You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
+   You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
 
 1. Follow the remaining steps in the README
 
-  The template is designed to set the `APP_ID`, `PRIVATE_KEY`, and `WEBHOOK_SECRET` environment variables automatically for you during the registration process, by installing and using the [Platform.sh CLI](https://docs.platform.sh/development/cli.html) within your application container.
+   The template is designed to set the `APP_ID`, `PRIVATE_KEY`, and `WEBHOOK_SECRET` environment variables automatically for you during the registration process, by installing and using the [Platform.sh CLI](https://docs.platform.sh/development/cli.html) within your application container.
 
-  Platform.sh allows you to branch your production application and deploy an exact copy of that application on staging and development environments that themselves can be registered with GitHub, becoming fully testable apps in their own right.
+   Platform.sh allows you to branch your production application and deploy an exact copy of that application on staging and development environments that themselves can be registered with GitHub, becoming fully testable apps in their own right.
 
-  Follow the remaining steps in the [README](https://github.com/platformsh-templates/probot/blob/master/README.md) to finish setting up the template.
+   Follow the remaining steps in the [README](https://github.com/platformsh-templates/probot/blob/master/README.md) to finish setting up the template.
 
 1. Migrate your code
 
-    After you have completed the above steps, you can branch your local repository and move your code onto that branch. You can revert the `NODE_ENV` variable to go through registration again for that environment
+   After you have completed the above steps, you can branch your local repository and move your code onto that branch. You can revert the `NODE_ENV` variable to go through registration again for that environment
 
-    ```
-    echo 'export NODE_ENV="development"' > .environment
-    ```
+   ```
+   echo 'export NODE_ENV="development"' > .environment
+   ```
 
-    and then repeat the steps above to register test the app on that development environment. When you're satisfied that your app is working as expected, merge it into the production application.
+   and then repeat the steps above to register test the app on that development environment. When you're satisfied that your app is working as expected, merge it into the production application.
 
 #### Deploying an existing project
 
@@ -214,127 +214,127 @@ You can branch the template above, add your application's code to it, and merge 
 
 1. Create a new project
 
-  When you create a new account, the setup wizard will direct you to create a new project. Name it, and select a region for the project to be served from.
+   When you create a new account, the setup wizard will direct you to create a new project. Name it, and select a region for the project to be served from.
 
 1. Install the [Platform.sh CLI]([Platform.sh CLI](https://docs.platform.sh/development/cli.html))
 
-  Run the command
+   Run the command
 
-  ```
-  curl -sS https://platform.sh/cli/installer | php
-  ```
+   ```
+   curl -sS https://platform.sh/cli/installer | php
+   ```
 
-  You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
+   You can find the system requirements and more information in the [installation instructions on GitHub](https://github.com/platformsh/platformsh-cli/blob/master/README.md#installation).
 
 1. Importing your application code
 
-  If you are just testing out Platform.sh, feel free to push a local copy of your repository directly.
+   If you are just testing out Platform.sh, feel free to push a local copy of your repository directly.
 
-  First, retrieve the project ID for the project you just created with the command `platform project:list`. Then, set Platform.sh as a remote for your repository:
+   First, retrieve the project ID for the project you just created with the command `platform project:list`. Then, set Platform.sh as a remote for your repository:
 
-  ```
-  platform project:set-remote <PROJECT ID>
-  ```
+   ```
+   platform project:set-remote <PROJECT ID>
+   ```
 
-  Alternatively, you can also set up an integration to GitHub, triggering environment deployments with every pull request. Follow the steps in the [public documentation](https://docs.platform.sh/administration/integrations/github.html) to set up the integration.
+   Alternatively, you can also set up an integration to GitHub, triggering environment deployments with every pull request. Follow the steps in the [public documentation](https://docs.platform.sh/administration/integrations/github.html) to set up the integration.
 
 1. Add Platform.sh configuration files
 
-  Each project on Platform.sh requires at least [three configuration files](https://docs.platform.sh/overview/structure.html) to describe and application. From your project root, run the following commands to create them:
+   Each project on Platform.sh requires at least [three configuration files](https://docs.platform.sh/overview/structure.html) to describe and application. From your project root, run the following commands to create them:
 
-  ```
-  mkdir .platform
-  touch .platform/routes.yaml && touch .platform/services.yaml
-  touch .platform.app.yaml
-  ```
+   ```
+   mkdir .platform
+   touch .platform/routes.yaml && touch .platform/services.yaml
+   touch .platform.app.yaml
+   ```
 
-  Unless your Probot app depends on [database storage](https://probot.github.io/docs/persistence/), the `services.yaml` file can be left empty. If a database is needed, visit the Platform.sh [Services documentation](https://docs.platform.sh/configuration/services.html) for more detailed information on how to configure the service your app depends on.
+   Unless your Probot app depends on [database storage](https://probot.github.io/docs/persistence/), the `services.yaml` file can be left empty. If a database is needed, visit the Platform.sh [Services documentation](https://docs.platform.sh/configuration/services.html) for more detailed information on how to configure the service your app depends on.
 
-  In your [`routes.yaml`](https://docs.platform.sh/configuration/routes.html) file, copy the following:
+   In your [`routes.yaml`](https://docs.platform.sh/configuration/routes.html) file, copy the following:
 
-  ```yaml
-  "https://{default}/":
-    type: upstream
-    upstream: "app:http"
+   ```yaml
+   "https://{default}/":
+      type: upstream
+      upstream: "app:http"
 
-  "https://www.{default}/":
+   "https://www.{default}/":
       type: redirect
       to: "https://{default}/"
-  ```
+   ```
 
-  This configuration directs requests to an application container called `app`, and sets an additional redirect for requests that include the `www` prefix.
+   This configuration directs requests to an application container called `app`, and sets an additional redirect for requests that include the `www` prefix.
 
-  Lastly, in the [`.platform.app.yaml`](https://docs.platform.sh/configuration/app-containers.html) file, include the settings below:
+   Lastly, in the [`.platform.app.yaml`](https://docs.platform.sh/configuration/app-containers.html) file, include the settings below:
 
-  ```yaml
-  name: app
+   ```yaml
+   name: app
 
-  type: 'nodejs:12'
+   type: 'nodejs:12'
 
-  variables:
+   variables:
       env:
-          NODE_ENV: development
+         NODE_ENV: development
 
-  disk: 256
+   disk: 256
 
-  web:
-    commands:
-      start: "npm start"
-  ```
+   web:
+      commands:
+         start: "npm start"
+   ```
 
-  This file defines your Probot app to run in a Node.js application container called `app`, with 256Mb of persistent storage. Feel free to modify the `web.commands.start` to match the start command of your app.
+   This file defines your Probot app to run in a Node.js application container called `app`, with 256Mb of persistent storage. Feel free to modify the `web.commands.start` to match the start command of your app.
 
-  You can set the application container to use a number of Node.js versions (defined in `type`), so visit the [documentation](https://docs.platform.sh/languages/nodejs.html#supported-versions) for a full list of those supported.
+   You can set the application container to use a number of Node.js versions (defined in `type`), so visit the [documentation](https://docs.platform.sh/languages/nodejs.html#supported-versions) for a full list of those supported.
 
 
 1. Register the app on GitHub
 
-  Commit and push these changes. In your Platform.sh management console, when the branch's deployment has finished, you can visit the deployed app by clicking the "URL" dropdown button at the bottom of the page.
+   Commit and push these changes. In your Platform.sh management console, when the branch's deployment has finished, you can visit the deployed app by clicking the "URL" dropdown button at the bottom of the page.
 
-  At this point, you can register the app with GitHub. After you do so however, the registration will fail to complete, because  GitHub is attempting to write to Platform.sh's read-only file system. The template above contains a work-around for this step, so feel free to consult [that project](https://github.com/platformsh-templates/probot) if you'd like to streamline this step.
+   At this point, you can register the app with GitHub. After you do so however, the registration will fail to complete, because  GitHub is attempting to write to Platform.sh's read-only file system. The template above contains a work-around for this step, so feel free to consult [that project](https://github.com/platformsh-templates/probot) if you'd like to streamline this step.
 
-  Visit the settings page for the app you have just registered. You will need the settings there to set your project's environment variables to complete registration.
+   Visit the settings page for the app you have just registered. You will need the settings there to set your project's environment variables to complete registration.
 
 1. Set environment variables
 
-  Using the CLI, set the following environment variables you retrieved from the registration steps:
+   Using the CLI, set the following environment variables you retrieved from the registration steps:
 
-  ```
-  platform variable:create --level environment --environment master env:APP_ID --value <APP_ID> --inheritable false --json false --sensitive false --enabled true --no-wait
-  platform variable:create --level environment --environment $PLATFORM_BRANCH env:WEBHOOK_SECRET --value <WEBHOOK_SECRET> --sensitive true --inheritable false --json false --enabled true --no-wait
-  ```
+   ```
+   platform variable:create --level environment --environment master env:APP_ID --value <APP_ID> --inheritable false --json false --sensitive false --enabled true --no-wait
+   platform variable:create --level environment --environment $PLATFORM_BRANCH env:WEBHOOK_SECRET --value <WEBHOOK_SECRET> --sensitive true --inheritable false --json false --enabled true --no-wait
+   ```
 
-  Write your private key to a temporary file in the project root called `temp-key.txt`. Once you have created the variable for it, you are free to delete it.
+   Write your private key to a temporary file in the project root called `temp-key.txt`. Once you have created the variable for it, you are free to delete it.
 
-  ```
-  platform variable:create --level environment --environment master env:PRIVATE_KEY --value="$(cat registration/temp-key.txt)" --sensitive true --inheritable false --json false --enabled true --no-wait
-  ```
+   ```
+   platform variable:create --level environment --environment master env:PRIVATE_KEY --value="$(cat registration/temp-key.txt)" --sensitive true --inheritable false --json false --enabled true --no-wait
+   ```
 
 1. Set for production
 
-  Each time you add a new variable to the project, the environment will be redeployed. When all of the redeployments have finished, modify the `variables.env.NODE_ENV` variable to read:
+   Each time you add a new variable to the project, the environment will be redeployed. When all of the redeployments have finished, modify the `variables.env.NODE_ENV` variable to read:
 
-  ```yaml
-  variables:
+   ```yaml
+   variables:
       env:
-          NODE_ENV: production
-  ```
+         NODE_ENV: production
+   ```
 
-  Then commit and push the change to the project.
+   Then commit and push the change to the project.
 
 1. Verify
 
-  When the final redeployment has completed, and all of your environment variables have been added, go to your GitHub App's advanced settings.
+   When the final redeployment has completed, and all of your environment variables have been added, go to your GitHub App's advanced settings.
 
-  You will see that the first delivery it attempted to deliver to Platform.sh failed while you were registering.
+   You will see that the first delivery it attempted to deliver to Platform.sh failed while you were registering.
 
-  Expand the previous failed delivery by clicking the three dots, and then click Redeliver and then Yes, repeat this delivery to repeat the delivery. Since you have set up the app for production, it should now show a 200 successful response.
+   Expand the previous failed delivery by clicking the three dots, and then click Redeliver and then Yes, repeat this delivery to repeat the delivery. Since you have set up the app for production, it should now show a 200 successful response.
 
-  Scroll to the bottom of the "General" settings page and click the "Active" checkbox so that GitHub can start sending more deliveries once it's installed on a repository.
+   Scroll to the bottom of the "General" settings page and click the "Active" checkbox so that GitHub can start sending more deliveries once it's installed on a repository.
 
 1. Test on a repository
 
-  Visit your application's public page (https://github.com/apps/APPLICATION_NAME) and click Install. Install it on the repository of your choice, and you will see that once you open a new issue the app will deliver a new response comment onto it.
+   Visit your application's public page (https://github.com/apps/APPLICATION_NAME) and click Install. Install it on the repository of your choice, and you will see that once you open a new issue the app will deliver a new response comment onto it.
 
 ## Share the app
 


### PR DESCRIPTION
We recently created a [template project](https://github.com/platformsh-templates/probot) for Probot on Platform.sh, and we wanted to share it along with general deployment instructions. 

Let me know if I'm missing anything! All the best.

-----
[View rendered docs/deployment.md](https://github.com/chadwcarlson/probot/blob/deploy-platform/docs/deployment.md)