### PR TITLE
fix(github): Octokit is optional

### DIFF
--- a/src/github/index.ts
+++ b/src/github/index.ts
@@ -43,7 +43,7 @@ export function GitHubAPI (options: Options = {} as any) {
 export interface Options extends Octokit.Options {
   debug?: boolean
   logger: Logger
-  Octokit: Octokit.Static
+  Octokit?: Octokit.Static
 }
 
 export interface RequestOptions {


### PR DESCRIPTION
Forgot to update the type interface as well. I'm implementing my integration using this new API surface, so found this with VSCode type checking.