### PR TITLE
docs: Update minimum Node version

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@ next: docs/webhooks.md
 
 # Developing an app
 
-To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Open a terminal and run `node -v` to verify that it is installed and is at least 8.3.0 or later. Otherwise, [install the latest version](https://nodejs.org/).
+To develop a Probot app, you will first need a recent version of [Node.js](https://nodejs.org/) installed. Open a terminal and run `node -v` to verify that it is installed and is at least 10.0.0 or later. Otherwise, [install the latest version](https://nodejs.org/).
 
 ## Generating a new app
 


### PR DESCRIPTION
As of [this commit](https://github.com/probot/create-probot-app/commit/a6d4b9ad10aaacae168a0b0e7867445c2e5d516c), create-probot-app requires fs-extras v9, which in turn [requires Node 10](https://github.com/jprichardson/node-fs-extra/blob/master/CHANGELOG.md).

-----
[View rendered docs/development.md](https://github.com/ruricolist/probot/blob/patch-1/docs/development.md)