### PR TITLE
fix: quotation marks in setup description

### DIFF
--- a/test/manifest-creation.test.ts
+++ b/test/manifest-creation.test.ts
@@ -1,3 +1,4 @@
+import fs from 'fs'
 import nock from 'nock'
 import pkg from '../package.json'
 import { ManifestCreation } from '../src/manifest-creation'
@@ -101,6 +102,14 @@ describe('ManifestCreation', () => {
     test('creates an app from a code', () => {
       // checks that getManifest returns a JSON.stringified manifest
       expect(setup.getManifest(pkg, 'localhost://3000')).toEqual('{"description":"🤖 A framework for building GitHub Apps to automate and improve your workflow","hook_attributes":{"url":"localhost://3000/"},"name":"probot","public":true,"redirect_url":"localhost://3000/probot/setup","url":"https://probot.github.io","version":"v1"}')
+    })
+
+    test('creates an app from a code with overrided values from app.yml', () => {
+      const appYaml = 'name: cool-app\ndescription: A description for a cool app'
+      jest.spyOn(fs, 'readFileSync').mockReturnValue(appYaml)
+
+      // checks that getManifest returns the correct JSON.stringified manifest
+      expect(setup.getManifest(pkg, 'localhost://3000')).toEqual('{"description":"A description for a cool app","hook_attributes":{"url":"localhost://3000/"},"name":"cool-app","public":true,"redirect_url":"localhost://3000/probot/setup","url":"https://probot.github.io","version":"v1"}')
     })
   })
 })

--- a/test/manifest-creation.test.ts
+++ b/test/manifest-creation.test.ts
@@ -99,6 +99,10 @@ describe('ManifestCreation', () => {
   })
 
   describe('getManifest', () => {
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
     test('creates an app from a code', () => {
       // checks that getManifest returns a JSON.stringified manifest
       expect(setup.getManifest(pkg, 'localhost://3000')).toEqual('{"description":"🤖 A framework for building GitHub Apps to automate and improve your workflow","hook_attributes":{"url":"localhost://3000/"},"name":"probot","public":true,"redirect_url":"localhost://3000/probot/setup","url":"https://probot.github.io","version":"v1"}')

--- a/views/setup.hbs
+++ b/views/setup.hbs
@@ -32,7 +32,7 @@
           <br>
 
           <form action="{{ createAppUrl }}" method="post" target="_blank">
-            <button class="btn btn-outline" name="manifest" id="manifest" value='{{{ manifest }}}' >Register GitHub App</button>
+            <button class="btn btn-outline" name="manifest" id="manifest" value='{{ manifest }}' >Register GitHub App</button>
           </form>
         </div>
       </div>


### PR DESCRIPTION
Fixes #1115. Instead of complaining that it's been closed I figured I'd give it a shot at fixing it myself.

It was a bit of a pain to track down but in the end the fix is quite simple. The issue doesn't lie in the manifest being created incorrectly or the quotes aren't being escaped, it's actually in the template that's being rendered. See the below screenshot in the HTML, this value is being posted to Github and is obviously invalid JSON.

<img width="462" alt="Screenshot 2020-04-10 at 11 49 35" src="https://user-images.githubusercontent.com/45660/78985794-90b2de00-7b21-11ea-94db-bb2a4c858c1f.png">

Changing the value to `{{ manifest }}` resolves the problem. While investigating this I also found some uncovered code in `getManifest`, so I added a unit test. I can move this to a separate PR if preferred though.