### PR TITLE
ci: run codecov only on `ubuntu-latest` and node 12.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,7 @@ jobs:
     - run: npm test
     - name: codecov
       run: npx codecov
+      # run codecov only once
+      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '12.x'
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
fixes #1184 