### PR TITLE
docs: Correct URL

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -50,4 +50,4 @@ module.exports = app => {
 }
 ```
 
-For more details, explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) or see a list of all the named events in the [@octokit/webhooks.js](https://github.com/octokit/webhooks.js/blob/master/lib/webhook-names.json) npm module.
+For more details, explore the [GitHub webhook documentation](https://developer.github.com/webhooks/#events) or see a list of all the named events in the [@octokit/webhooks.js](https://github.com/octokit/webhooks.js/) npm module.


### PR DESCRIPTION
Current hyperlink takes you to a non-existent page. 
Before Change : https://github.com/octokit/webhooks.js/blob/master/lib/webhook-names.json
After Change : https://github.com/octokit/webhooks.js/

-----
[View rendered docs/webhooks.md](https://github.com/akmalick/probot/blob/patch-1/docs/webhooks.md)