### PR TITLE
docs: remove Vercel Now

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -14,7 +14,6 @@ Every app can either be deployed stand-alone, or combined with other apps in one
 1. [Deploy the app](#deploy-the-app)
     1. [Glitch](#glitch)
     1. [Heroku](#heroku)
-    1. [Vercel Now](#vercel-now)
 1. [Share the app](#share-the-app)
 1. [Combining apps](#combining-apps)
 1. [Error tracking](#error-tracking)
@@ -105,59 +104,6 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
 
         $ heroku config:set LOG_LEVEL=trace
         $ heroku logs --tail
-
-### Vercel Now
-
-Deploy Probot as a Serverless Function to [Vercel Now](http://vercel.com). After [creating the GitHub App](#create-the-github-app):
-
-1. Install Now CLI with `npm i -g now` and login with `now login`
-
-1. Clone the app that you want to deploy. e.g. `git clone https://github.com/probot/stale`
-
-1. Install `probot-serverless-now`
-
-        $ npm install probot-serverless-now
-
-1. Update `package.json` and add `build` script to generate your HTML landing page, for example:
-   ```json
-   {
-     "scripts": {
-       "build": "mkdir public && echo 'Hello World' > public/index.html"
-     }
-   }
-   ```
-
-1. Create a new file `/api/index.js` with the following:
-   ```js
-   const { toLambda } = require('probot-serverless-now');
-   const app = require('./path/to/your/app.js');
-   module.exports = toLambda(app);
-   ```
-
-1. Create a new file `now.json` with the following:
-   ```json
-   {
-     "env": {
-       "APP_ID":"@probot-api-id",
-       "WEBHOOK_SECRET": "@probot-webhook-secret",
-       "PRIVATE_KEY": "@probot-private-key"
-     }
-   }
-   ```
-   
-      **NOTE**: Add `LOG_LEVEL=trace` to get verbose logging, or add `LOG_LEVEL=info` instead to show less details.
-
-1. Run `now secrets add probot-api-id aaa`, `now secrets add probot-webhook-secret bbb`, `now secrets add probot-private-key "$(cat ~/Downloads/*.private-key.pem | base64)"` replacing the `aaa` and `bbb` with the values for those variables.
-      
-1. Deploy with `now` or connect your GitHub repository](https://vercel.com/github) to Vercel Now and deploy on `git push`.
-
-1. Once the deploy is started, go back to your [app settings page](https://github.com/settings/apps) and update the **Webhook URL** to the URL of your deployment (which `now` has kindly copied to your clipboard).
-
-1. You can optionally add a [Custom Domain](https://vercel.com/docs/v2/custom-domains) and deploy to production with the following:
-
-        $ now --prod
-
-1. Visit `https://your-deployment.now.sh/api` to invoke the serverless function.
 
 ## Share the app
 


### PR DESCRIPTION
Sadly, probot-serverless-now a) no longer works and b) was archived today

See https://github.com/tibdex/probot-serverless-now/commit/5552cfa45ed4ac0f11e9229d57c9089cb8a55c35 for more information

Corssref to https://github.com/tibdex/probot-serverless-now/issues/12, too

-----
[View rendered docs/deployment.md](https://github.com/timbru31/probot/blob/patch-1/docs/deployment.md)