### PR TITLE
ci: fixes docs publishing by upgrading typescript dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - "greenkeeper/**"
 
   pull_request:
-    types: 
+    types:
       - opened
       - synchronize
 
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         node-version: [10.x, 12.x]
-        os: [ubuntu-latest, macOS, windows-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     runs-on: ${{ matrix.os }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12870,11 +12870,20 @@
       "integrity": "sha512-9lQs4ZfGukyalFVputnN4IxfbMIAECjf+BqC4gvY8eBUvYcotYIWj4MZyMiXBkN/OJwmMi5jVSnzIexKZQqQYA==",
       "dev": true,
       "requires": {
+        "commander": "^4.1.0",
         "globby": "^11.0.0",
         "lodash.flatten": "^4.4.0",
         "lodash.range": "^3.2.0",
         "ora": "^4.0.3",
         "standard": "^14.3.1"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        }
       }
     },
     "state-toggle": {
@@ -13688,9 +13697,9 @@
       }
     },
     "typescript": {
-      "version": "3.7.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.5.tgz",
-      "integrity": "sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "tslint-config-prettier": "^1.10.0",
     "tslint-config-standard": "^9.0.0",
     "typedoc": "^0.17.0",
-    "typescript": "^3.4.1"
+    "typescript": "^3.9.3"
   },
   "standard": {
     "env": [

--- a/src/context.ts
+++ b/src/context.ts
@@ -181,7 +181,7 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
    * Config files can also specify a base that they extend. `deepMergeOptions` can be used
    * to configure how the target config, extended base, and default configs are merged.
    *
-   * For security reasons, configuration is only loaded from the repository's default branch, 
+   * For security reasons, configuration is only loaded from the repository's default branch,
    * changes made in pull requests from different branches or forks are ignored.
    *
    * @param fileName - Name of the YAML file in the `.github` directory

--- a/test/integration/webhook.test.ts
+++ b/test/integration/webhook.test.ts
@@ -1,7 +1,6 @@
-import fs from 'fs'
 import request from 'supertest'
 import { createProbot, Probot } from '../../src'
-const data = JSON.parse(fs.readFileSync('./test/fixtures/webhook/push.json', 'UTF-8'))
+import * as data from '../fixtures/webhook/push.json'
 
 describe('webhooks', () => {
   let logger: any


### PR DESCRIPTION
This fixes the docs building and publishing by bumping the TypeScript dependency from 3.7.5 to 3.9.3. This is required by `typedoc` >= 0.17.0 (see https://github.com/TypeStrong/typedoc/issues/1257).

It also fixes two trailing spaces and the integration test data import in order to get `npm test` green again (this test was flaky on my machine as well as in the CI). Furthermore, it changes the `macOS` GitHub Actions identifier to `macos-latest` in order to run the tests at all.