### PR TITLE
ci: updates docs push action by fetching tags & setting the correct tag

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: git fetch --depth=20 origin +refs/tags/*:refs/tags/*
       - uses: actions/setup-node@v1
         with:
           node-version: "12.x"

--- a/script/publish-docs
+++ b/script/publish-docs
@@ -4,9 +4,12 @@
 set -e
 
 # Store the versions
-VERSION=$(git describe --tags --match "v[0-9]*" --abbrev=0 | sed 's/^v//')
+VERSION=$(git describe --tags $(git rev-list --tags --max-count=1) | sed 's/^v//')
 HEAD=$(git rev-parse HEAD)
 REPO=https://${OCTOKITBOT_PAT}@github.com/probot/probot.github.io.git
+
+echo "Version is $VERSION"
+echo "Head is $HEAD"
 
 # Generate docs
 npm run doc


### PR DESCRIPTION
This should (finally) fix the docs pushing - due to #1230  the deployment broke because the `actions/checkout@2` does not fetch the tags per default anymore. 

I've updated the CI script to fetch the last 20 commits and the tags and updates the `VERSION` detection a bit (the `--match` would still require the full history) - to detect such issues earlier I've added a simple `echo` of the variables.