### PR TITLE
fix(typescript): add runtime types as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     "@octokit/request": "^5.1.0",
     "@octokit/rest": "^16.43.1",
     "@octokit/webhooks": "^6.0.0",
+    "@types/bunyan": "^1.8.4",
+    "@types/express": "^4.17.2",
+    "@types/ioredis": "^4.0.6",
     "@types/supports-color": "^5.3.0",
     "bottleneck": "^2.15.3",
     "bunyan": "^1.8.12",
@@ -88,12 +91,9 @@
     "uuid": "^7.0.0"
   },
   "devDependencies": {
-    "@types/bunyan": "^1.8.4",
     "@types/bunyan-format": "^0.2.2",
     "@types/cache-manager": "^2.10.0",
     "@types/eventsource": "^1.1.0",
-    "@types/express": "^4.17.2",
-    "@types/ioredis": "^4.0.6",
     "@types/jest": "^25.1.3",
     "@types/js-yaml": "^3.10.1",
     "@types/jsonwebtoken": "^8.3.0",


### PR DESCRIPTION
These typings are used and reexported by probot and therefore are
dependencies which need to be installed by users as well.

Relates to #759