### PR TITLE
docs: Documents default branch usage of context.config()

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -145,7 +145,7 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
 
   /**
    * Reads the app configuration from the given YAML file in the `.github`
-   * directory of the repository.
+   * directory of the repository's default branch.
    *
    * For example, given a file named `.github/config.yml`:
    *


### PR DESCRIPTION
As asked in #1253, it is not clear what branch is used by `context.config()`. This PR adds a notice to it's JSDoc comment.