### PR TITLE
fix: Port in use error handling (#767)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -210,17 +210,24 @@ export class Probot {
   }
 
   public start () {
-    if (this.options.webhookProxy) {
-      createWebhookProxy({
-        logger,
-        path: this.options.webhookPath,
-        port: this.options.port,
-        url: this.options.webhookProxy
-      })
-    }
-
-    this.httpServer = this.server.listen(this.options.port)
-    logger.info('Listening on http://localhost:' + this.options.port)
+    return this.httpServer = this.server.listen(this.options.port, () => {
+      if (this.options.webhookProxy) {
+        createWebhookProxy({
+          logger,
+          path: this.options.webhookPath,
+          port: this.options.port,
+          url: this.options.webhookProxy
+        })
+      }
+      logger.info('Listening on http://localhost:' + this.options.port)
+    }).on('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        logger.error(`Port ${this.options.port} is already in use. You can define the PORT environment variable to use a different port.`)
+      } else {
+        logger.error(err)
+      }
+      process.exit(1)
+    })
   }
 }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -438,4 +438,38 @@ describe('Probot', () => {
       expect(githubApi.foo).toBe('bar')
     })
   })
+
+  describe('start', () => {
+
+    beforeEach(() => {
+      process.exit = jest.fn() as any // we dont want to terminate the test
+    })
+    it('should expect the correct error if port already in use', (next) => {
+      expect.assertions(2)
+
+      // block port 3001
+      const http = require('http')
+      const blockade = http.createServer().listen(3001, () => {
+
+        const testApp = createProbot({ port: 3001 })
+        testApp.logger.error = jest.fn()
+
+        const server = testApp.start().addListener('error', () => {
+          expect(testApp.logger.error).toHaveBeenCalledWith('Port 3001 is already in use. You can define the PORT environment variable to use a different port.')
+          expect(process.exit).toHaveBeenCalledWith(1)
+          server.close(() => blockade.close(() => next()))
+        })
+      })
+    })
+
+    it('should listen to port when not in use', (next) => {
+      expect.assertions(1)
+      const testApp = createProbot({ port: 3001, webhookProxy: undefined })
+      testApp.logger.info = jest.fn()
+      const server = testApp.start().on('listening', () => {
+        expect(testApp.logger.info).toHaveBeenCalledWith('Listening on http://localhost:3001')
+        server.close(() => next())
+      })
+    })
+  })
 })


### PR DESCRIPTION
@NikhilM98 opened a PR (#784) in 2018 and it had no activity since Feb 2019. All of the credit goes to @NikhilM98, I just added the missing test

closes #784