### PR TITLE
Fix example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; I'm going to s
 module.exports = (app) => {
   app.on('issues.opened', async context => {
     const issueComment = context.issue({ body: 'Thanks for opening this issue!' })
-    return context.github.issues.createComment(issueComment)
+    await context.github.issues.createComment(issueComment)
   })
 }
 ```


### PR DESCRIPTION
Fixing the example app function in the readme. 
The prior example did not pass typechecking, as [the expected return type](https://github.com/probot/probot/blob/22d8215a631735f42c08b75ecc2657b7dcec2a54/src/application.ts#L24) is `Promise<void>`. 
This fixes it.

-----
[View rendered README.md](https://github.com/rgoldfinger-quizlet/probot/blob/patch-1/README.md)