### PR TITLE
feat: `throttleOptions` for Probot constructor

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -12,7 +12,7 @@ For our testing examples, we use [jest](https://facebook.github.io/jest/), but t
 const nock = require('nock')
 // Requiring our app implementation
 const myProbotApp = require('..')
-const { Probot, createProbot } = require('probot')
+const { Probot } = require('probot')
 // Requiring our fixtures
 const payload = require('./fixtures/issues.opened')
 const issueCreatedBody = { body: 'Thanks for opening this issue!' }
@@ -22,7 +22,12 @@ describe('My Probot app', () => {
 
   beforeEach(() => {
     nock.disableNetConnect()
-    probot = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
+    probot = new Probot({
+      id: 1,
+      githubToken: 'test',
+      // disable all request throttling to make tests faster
+      throttleOptions: { enabled: false }
+    })
     probot.load(myProbotApp)
   })
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -518,11 +518,20 @@ export class Application {
     }
 
     const token = this.githubToken || this.app.getSignedJsonWebToken()
+
+    // we assume that if throttling is disabled, retrying requests should be disabled, too.
+    const retryOptions =
+      this.throttleOptions && this.throttleOptions.enabled === false
+      ? this.throttleOptions
+       : undefined
+
     const github = GitHubAPI({
       Octokit: this.Octokit,
       auth: `Bearer ${token}`,
       baseUrl: process.env.GHE_HOST && `${process.env.GHE_PROTOCOL || 'https'}://${process.env.GHE_HOST}/api/v3`,
-      logger: log.child({ name: 'github' })
+      logger: log.child({ name: 'github' }),
+      retry: retryOptions,
+      throttle: this.throttleOptions
     })
 
     return github

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,8 @@ export class Probot {
         privateKey: options.cert as string
       })
     }
+    this.throttleOptions = options.throttleOptions
+
     this.server = createServer({ webhook: (this.webhook as any).middleware, logger })
 
     // Log all received webhooks
@@ -153,10 +155,10 @@ export class Probot {
       const connection = new Bottleneck.IORedisConnection({ client })
       connection.on('error', this.logger.error)
 
-      this.throttleOptions = {
+      this.throttleOptions = Object.assign({
         Bottleneck,
         connection
-      }
+      }, this.throttleOptions)
     }
   }
 
@@ -245,6 +247,7 @@ export interface Options {
   port?: number,
   redisConfig?: Redis.RedisOptions,
   Octokit?: Octokit.Static
+  throttleOptions?: any
 }
 
 export { Logger, Context, Application, Octokit, GitHubAPI }


### PR DESCRIPTION
when set to `{ enabled: fales }`, all throttling from the `throttling` and
`retry` Octokit plugins will be disabled. This is very useful when testing

closes #1271

-----
[View rendered docs/testing.md](https://github.com/probot/probot/blob/disable-throttling/docs/testing.md)