### PR TITLE
feat: `context.pullRequest()`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -120,13 +120,13 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
   }
 
   /**
-   * Return the `owner`, `repo`, and `number` params for making API requests
-   * against an issue or pull request. The object passed in will be merged with
-   * the repo params.
+   * Return the `owner`, `repo`, and `issue_number` params for making API requests
+   * against an issue. The object passed in will be merged with the repo params.
+   *
    *
    * ```js
    * const params = context.issue({body: 'Hello World!'})
-   * // Returns: {owner: 'username', repo: 'reponame', number: 123, body: 'Hello World!'}
+   * // Returns: {owner: 'username', repo: 'reponame', issue_number: 123, body: 'Hello World!'}
    * ```
    *
    * @param object - Params to be merged with the issue params.
@@ -134,7 +134,26 @@ export class Context<E extends WebhookPayloadWithRepository = any> implements We
   public issue<T> (object?: T) {
     const payload = this.payload
     return Object.assign({
-      number: (payload.issue || payload.pull_request || payload).number
+      issue_number: (payload.issue || payload.pull_request || payload).number
+    }, this.repo(object))
+  }
+
+  /**
+   * Return the `owner`, `repo`, and `issue_number` params for making API requests
+   * against an issue. The object passed in will be merged with the repo params.
+   *
+   *
+   * ```js
+   * const params = context.pullRequest({body: 'Hello World!'})
+   * // Returns: {owner: 'username', repo: 'reponame', pull_number: 123, body: 'Hello World!'}
+   * ```
+   *
+   * @param object - Params to be merged with the pull request params.
+   */
+  public pullRequest<T> (object?: T) {
+    const payload = this.payload
+    return Object.assign({
+      pull_number: (payload.issue || payload.pull_request || payload).number
     }, this.repo(object))
   }
 

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -87,18 +87,36 @@ describe('Context', () => {
 
   describe('issue', () => {
     it('returns attributes from repository payload', () => {
-      expect(context.issue()).toEqual({ owner: 'bkeepers', repo: 'probot', number: 4 })
+      expect(context.issue()).toEqual({ owner: 'bkeepers', repo: 'probot', issue_number: 4 })
     })
 
     it('merges attributes', () => {
       expect(context.issue({ foo: 1, bar: 2 })).toEqual({
-        bar: 2, foo: 1, number: 4, owner: 'bkeepers', repo: 'probot'
+        bar: 2, foo: 1, issue_number: 4, owner: 'bkeepers', repo: 'probot'
       })
     })
 
     it('overrides repo attributes', () => {
-      expect(context.issue({ owner: 'muahaha', number: 5 })).toEqual({
-        number: 5, owner: 'muahaha', repo: 'probot'
+      expect(context.issue({ owner: 'muahaha', issue_number: 5 })).toEqual({
+        issue_number: 5, owner: 'muahaha', repo: 'probot'
+      })
+    })
+  })
+
+  describe('pullRequest', () => {
+    it('returns attributes from repository payload', () => {
+      expect(context.pullRequest()).toEqual({ owner: 'bkeepers', repo: 'probot', pull_number: 4 })
+    })
+
+    it('merges attributes', () => {
+      expect(context.pullRequest({ foo: 1, bar: 2 })).toEqual({
+        bar: 2, foo: 1, owner: 'bkeepers', pull_number: 4, repo: 'probot'
+      })
+    })
+
+    it('overrides repo attributes', () => {
+      expect(context.pullRequest({ owner: 'muahaha', pull_number: 5 })).toEqual({
+        owner: 'muahaha', pull_number: 5, repo: 'probot'
       })
     })
   })


### PR DESCRIPTION
closes #917
closes #926
closes #1168

BREAKING CHANGE: `context.issue()` now returns `.issue_number` instead of `.number`