### PR TITLE
feat: update to `@octokit/webhooks` v7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1121,9 +1121,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "6.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-6.3.2.tgz",
-      "integrity": "sha512-qirhkNoOWwQF0IHZ+9nobfcM/LMRhsJ2FUrexzzJZIDTXLAGZLVpUnXUZ86hSlYfCluyTccIFOz+SFFzodft0g==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.6.5.tgz",
+      "integrity": "sha512-FoVtLSNVaQ2lWZosDLtAn2mdIGsQlmr2BarlNp3owg1C77LRqfWtGLNHnHyyzgPHCDZHk2g/zGwAKW0qj7VktA==",
       "requires": {
         "debug": "^4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@octokit/plugin-throttling": "^3.3.0",
     "@octokit/request": "^5.1.0",
     "@octokit/types": "^5.0.1",
-    "@octokit/webhooks": "^6.0.0",
+    "@octokit/webhooks": "^7.6.5",
     "@types/bunyan": "^1.8.4",
     "@types/express": "^4.17.2",
     "@types/ioredis": "^4.0.6",

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,5 +1,5 @@
 import { Endpoints } from '@octokit/types'
-import Webhooks, { PayloadRepository } from '@octokit/webhooks'
+import Webhooks from '@octokit/webhooks'
 import merge from 'deepmerge'
 import yaml from 'js-yaml'
 import path from 'path'
@@ -25,7 +25,7 @@ export type MergeOptions = merge.Options
 
 interface WebhookPayloadWithRepository {
   [key: string]: any
-  repository?: PayloadRepository
+  repository?: Webhooks.PayloadRepository
   issue?: {
     [key: string]: any
     number: number

--- a/src/serializers.ts
+++ b/src/serializers.ts
@@ -1,10 +1,10 @@
-import { PayloadRepository, WebhookEvent } from '@octokit/webhooks'
+import Webhooks from '@octokit/webhooks'
 import bunyan from 'bunyan'
 import express from 'express'
 
 export const serializers: bunyan.StdSerializers = {
 
-  event: (event: WebhookEvent<any> | any) => {
+  event: (event: Webhooks.WebhookEvent<any> | any) => {
     if (typeof event !== 'object' || !event.payload) {
       return event
     } else {
@@ -31,7 +31,7 @@ export const serializers: bunyan.StdSerializers = {
 
   err: bunyan.stdSerializers.err,
 
-  repository: (repository: PayloadRepository) => repository.full_name,
+  repository: (repository: Webhooks.PayloadRepository) => repository.full_name,
 
   req: bunyan.stdSerializers.req,
 


### PR DESCRIPTION
closes #1080

BREAKING CHANGE: `registry_package` event was renamed to `package`