### PR TITLE
Set the callbacks on throttle options

### DIFF
--- a/src/octokit/get-octokit-throttle-options.ts
+++ b/src/octokit/get-octokit-throttle-options.ts
@@ -1,6 +1,8 @@
 import Bottleneck from "bottleneck";
 import Redis from "ioredis";
 import type { Logger } from "pino";
+import { Octokit } from "@octokit/core";
+import { RequestOptions } from "@octokit/types";
 
 type Options = {
   log: Logger;
@@ -21,6 +23,26 @@ export function getOctokitThrottleOptions(options: Options) {
   return {
     Bottleneck,
     connection,
+    onAbuseLimit: (
+      retryAfter: number,
+      options: RequestOptions,
+      octokit: Octokit
+    ) => {
+      octokit.log.warn(
+        `Abuse limit hit with "${options.method} ${options.url}", retrying in ${retryAfter} seconds.`
+      );
+      return true;
+    },
+    onRateLimit: (
+      retryAfter: number,
+      options: RequestOptions,
+      octokit: Octokit
+    ) => {
+      octokit.log.warn(
+        `Rate limit hit with "${options.method} ${options.url}", retrying in ${retryAfter} seconds.`
+      );
+      return true;
+    },
   };
 }
 

--- a/test/octokit/get-octokit-throttle-options.test.ts
+++ b/test/octokit/get-octokit-throttle-options.test.ts
@@ -1,0 +1,21 @@
+import pino from "pino";
+import { getOctokitThrottleOptions } from "../../src/octokit/get-octokit-throttle-options";
+
+describe(".getOctokitThrottleOptions()", () => {
+  test("No redis configured in options or env", () => {
+    expect(getOctokitThrottleOptions({ log: pino() })).toBeUndefined();
+  });
+
+  test("redis configured in options", () => {
+    const redisConfig = {
+      host: "test",
+    };
+    const throttleOptions = getOctokitThrottleOptions({
+      log: pino(),
+      redisConfig,
+    });
+    throttleOptions?.connection.disconnect();
+    expect(throttleOptions?.onAbuseLimit).toBeDefined();
+    expect(throttleOptions?.onRateLimit).toBeDefined();
+  });
+});


### PR DESCRIPTION
Fixes #1311

When Octokit is instantiated and `throttle` options are passed to it, we must specify both the `onAbuseLimit` and `onRateLimit` callbacks. We initially do this when setting up octokit with the defaults, but if we have redis configured, these defaults are clobbered and the callback functions are lost. This PR adds them to the redis based configuration object to ensure they're set appropriately.