### PR TITLE
fix: remove broken `start` script from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   },
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
-    "start": "node ./bin/probot run",
     "lint": "prettier --check 'src/**/*.ts' 'test/**/*.ts' 'docs/*.md' *.md package.json tsconfig.json",
     "lint:fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts' 'docs/*.md' *.md package.json tsconfig.json",
     "pretest": "tsc --noEmit -p test",


### PR DESCRIPTION
Suggested by @gr2m via https://github.com/probot/probot/issues/1319