### PR TITLE
feat: log Probot version at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -145,8 +145,7 @@ export class Probot {
   public log: DeprecatedLogger;
   public version: String;
 
-  // These 3 need to be public for the tests to work.
-  // FIXME the above comment is not clear about which these 3 are, only two `public` follow
+  // These need to be public for the tests to work.
   public options: Options;
   public throttleOptions: any;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -143,8 +143,10 @@ export class Probot {
   public server: express.Application;
   public webhooks: ProbotWebhooks;
   public log: DeprecatedLogger;
+  public version: String;
 
   // These 3 need to be public for the tests to work.
+  // FIXME the above comment is not clear about which these 3 are, only two `public` follow
   public options: Options;
   public throttleOptions: any;
 
@@ -234,6 +236,9 @@ export class Probot {
       webhook: (this.webhooks as any).middleware,
       logger: this.log,
     });
+
+    const { version } = require("../package.json");
+    this.version = version;
   }
 
   /**
@@ -298,6 +303,7 @@ export class Probot {
   }
 
   public start() {
+    this.log.info(`Running Probot v${this.version}`);
     this.httpServer = this.server
       .listen(this.options.port, () => {
         if (this.options.webhookProxy) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,6 +7,7 @@ import { Application, Probot } from "../src";
 import { ProbotOctokit } from "../src/octokit/probot-octokit";
 
 import path = require("path");
+import { version } from "../package.json";
 
 const id = 1;
 const privateKey = `-----BEGIN RSA PRIVATE KEY-----
@@ -111,6 +112,16 @@ describe("Probot", () => {
         });
         expect(probot.options).toMatchSnapshot();
         expect(initialized).toBeFalsy();
+        probot.stop();
+
+        resolve();
+      });
+    });
+
+    it("has version", async () => {
+      return new Promise(async (resolve) => {
+        probot = await Probot.run((app) => {});
+        expect(probot.version).toBe(version);
         probot.stop();
 
         resolve();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,6 @@ import { Application, Probot } from "../src";
 import { ProbotOctokit } from "../src/octokit/probot-octokit";
 
 import path = require("path");
-import { version } from "../package.json";
 
 const id = 1;
 const privateKey = `-----BEGIN RSA PRIVATE KEY-----
@@ -121,7 +120,7 @@ describe("Probot", () => {
     it("has version", async () => {
       return new Promise(async (resolve) => {
         probot = await Probot.run((app) => {});
-        expect(probot.version).toBe(version);
+        expect(probot.version).toBe("0.0.0-development");
         probot.stop();
 
         resolve();


### PR DESCRIPTION
I'm new to TypeScript so please forgive in advance any silly mistake here.

I believe it's valuable to know which version of Probot a Probot-application instance is based on, AFAIK the only way at the moment is to inspect `node_modules/probot/package.json` but I believe at least logging it at startup is a good thing.

Probably is also a good idea to expose that via `GET /version`, together with the actual application version, something like this maybe?

```json
{
  "appVersion": "0.1.2",
  "probotVersion": "3.4.5"
}
```
