### PR TITLE
fix: `app.auth(installationId)` returns `octokit` instance with all required installation authentication settings

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -217,6 +217,8 @@ export class Probot {
     });
 
     this.state = {
+      id: options.id,
+      privateKey: options.privateKey,
       cache,
       githubToken: options.githubToken,
       log: this.log,
@@ -264,6 +266,8 @@ export class Probot {
     }
 
     const app = new Application({
+      id: this.state.id,
+      privateKey: this.state.privateKey,
       log: this.state.log.child({ name: "app" }),
       cache: this.state.cache,
       githubToken: this.state.githubToken,

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ import { ProbotOctokit } from "./octokit/probot-octokit";
 import type { Logger, LogFn } from "pino";
 
 export type State = {
+  id?: number;
+  privateKey?: string;
   githubToken?: string;
   log: Logger;
   Octokit: typeof ProbotOctokit;


### PR DESCRIPTION
reproduces and fixes https://github.com/probot/probot/discussions/1323\#discussioncomment-59322 /cc @shaftoe
