### PR TITLE
Log NODE_ENV and LOG_LEVEL values at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -135,6 +135,13 @@ export class Probot {
     } else {
       probot.load(appFn);
     }
+    probot.log.info(
+      {
+        env: process.env.NODE_ENV || "development",
+        logLevel: probot.log.level,
+      },
+      `Running Probot v${probot.version}`
+    );
     probot.start();
 
     return probot;
@@ -306,7 +313,6 @@ export class Probot {
   }
 
   public start() {
-    this.log.info(`Running Probot v${this.version}`);
     this.httpServer = this.server
       .listen(this.options.port, () => {
         if (this.options.webhookProxy) {


### PR DESCRIPTION
I'm thinking that another valuable information to know when starting up a Probot process is the NODE_ENV value, probably something like this would help.