### PR TITLE
fix: merge Octokit throttle options deeply

### DIFF
--- a/bin/probot-receive.js
+++ b/bin/probot-receive.js
@@ -7,13 +7,13 @@ const path = require("path");
 const uuid = require("uuid");
 const program = require("commander");
 
-const { findPrivateKey } = require("../lib/private-key");
+const { findPrivateKey } = require("../lib/helpers/get-private-key");
 const {
-  handleDeprecatedEnvironmentVariables,
-} = require("../lib/handle-deprecated-environment-variables");
+  logWarningsForObsoleteEnvironmentVariables,
+} = require("../lib/helpers/log-warnings-for-obsolete-environment-variables");
 const { Probot } = require("../");
 
-handleDeprecatedEnvironmentVariables();
+logWarningsForObsoleteEnvironmentVariables();
 
 program
   .usage("[options] [path/to/app.js...]")


### PR DESCRIPTION
via Slack ([message](https://probot-talk.slack.com/archives/C6S4FC8AF/p1599143823146400))

> hello i'm unable simulate receiving webhooks with probot v10\
> whenever i run this command\
> `node_modules/.bin/probot receive -e <event-name> -p <path-to-fixture> <path-to-app>`\
>  with either the issue.opened.json fixture or my own i get this error  `Error: Cannot find module '../lib/private-key'`  in `node_modules/probot/bin/probot-receive.js`\
> this is the npm script i ran `"test:issue": "node_modules/.bin/probot receive -e issue -p test/fixtures/issues.opened.json ./lib"`\
> also i didn't face such issue with v9

`probot receive` is currently not covered by tests.