### PR TITLE
fix: remove redundant string in deprecation warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -248,7 +248,7 @@ export class Probot {
   public get webhook(): Webhooks {
     this.log.warn(
       new Deprecation(
-        `[probot] "probot.webhook" is deprecated. Use "probot.webhooks" instead instead`
+        `[probot] "probot.webhook" is deprecated. Use "probot.webhooks" instead`
       )
     );
 

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -36,7 +36,7 @@ describe("Deprecations", () => {
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      `[probot] "probot.webhook" is deprecated. Use "probot.webhooks" instead instead`
+      `[probot] "probot.webhook" is deprecated. Use "probot.webhooks" instead`
     );
   });
 


### PR DESCRIPTION
Signed-off-by: Frankzhaopku <syzhao1988@126.com>

Remove redundant `instead` in the warning message.