### PR TITLE
feat: log Node.js version at startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -316,7 +316,7 @@ export class Probot {
 
   public start() {
     this.log.info(
-      `Running Probot v${this.version} - Node.js ${process.version}`
+      `Running Probot v${this.version} (Node.js: v${process.version})`
     );
     const port = this.options.port || 3000;
     const { host } = this.options;

--- a/src/index.ts
+++ b/src/index.ts
@@ -315,7 +315,9 @@ export class Probot {
   }
 
   public start() {
-    this.log.info(`Running Probot v${this.version}`);
+    this.log.info(
+      `Running Probot v${this.version} - Node.js ${process.version}`
+    );
     const port = this.options.port || 3000;
     const { host } = this.options;
     const printableHost = host ?? "localhost";


### PR DESCRIPTION
You might not always have access to the host running Probot but in most of the cases (including Heroku and serverless) you can read (startup) logs, I think it's valuable to log interesting runtime information like this at startup