### PR TITLE
Add option to opt-out from fallback to base repo when config file is not found

### DIFF
--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -597,6 +597,37 @@ describe("Context", () => {
       });
     });
 
+    it("does not defaults to .github repo if no config found and loadBaseWhenMissing is false", async () => {
+      jest
+        .spyOn(github, "request")
+        .mockReturnValueOnce(Promise.reject(notFoundError))
+        .mockReturnValueOnce(responseFromConfig("basic.yml"));
+      const config = await context.config(
+        "test-file.yml",
+        undefined,
+        undefined,
+        false
+      );
+
+      expect(github.request).toHaveBeenCalledWith(
+        "GET /repos/{owner}/{repo}/contents/{path}",
+        {
+          owner: "bkeepers",
+          path: ".github/test-file.yml",
+          repo: "probot",
+        }
+      );
+      expect(github.request).not.toHaveBeenCalledWith(
+        "GET /repos/{owner}/{repo}/contents/{path}",
+        {
+          owner: "bkeepers",
+          path: ".github/test-file.yml",
+          repo: ".github",
+        }
+      );
+      expect(config).toEqual(null);
+    });
+
     it("deep merges the base config", async () => {
       jest
         .spyOn(github, "request")


### PR DESCRIPTION
When config file is not found in the current repository, currently probot tries to load file from `.github` repository.

This has two issues:
* This adds latancy and one more request to GitHub to check that file. In environment where we do not use the base repository, this is wasted.
* It is adds option for mistakes when someone in the organization creates repository `.github` which may be tricky to trace.

Change:

Adding `loadBaseWhenMissing` to the `config` function as opt-out. By default the base will be loaded to maintain backward compatiblity.

Adding `Context.configStrict` as shortcut to the `config` with the opt-out option.