### PR TITLE
fix(types): set correct type for `context` passed to event handler

### DIFF
--- a/src/octokit/get-webhooks.ts
+++ b/src/octokit/get-webhooks.ts
@@ -7,7 +7,7 @@ import { webhookTransform } from "./octokit-webhooks-transform";
 import { Context } from "../context";
 
 export function getWebhooks(state: State) {
-  const webhooks = new Webhooks<WebhookEvent, Pick<Context, "github" | "log">>({
+  const webhooks = new Webhooks<WebhookEvent, Context>({
     path: state.webhooks.path,
     secret: state.webhooks.secret,
     transform: webhookTransform.bind(null, state),

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,7 +22,7 @@ export type State = {
 
 export type ProbotWebhooks = Webhooks<
   WebhookEvent,
-  Pick<Context, "github" | "log">
+  Context
 >;
 
 export type DeprecatedLogger = LogFn & Logger;


### PR DESCRIPTION
follow up to https://github.com/probot/probot/pull/1374/files\#r501871740

@ankeetmaini I tested it locally with `create-probot-app` and it resolved the problem. But maybe I'm misisng something why you added the `Pick<...>` there?