### PR TITLE
refactor: use `WebhookEvents` export instead of an internal one.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1383,9 +1383,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "7.12.2",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.12.2.tgz",
-      "integrity": "sha512-mkNeIdXsSr5do5ISSiGGYceWJ3K73kABPBeOwgWc+bKIi7oqU7oPvl6Ij5F8KxW1LL84tHaGPhVRfYOHxsCKsA==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.13.0.tgz",
+      "integrity": "sha512-v+020Zf4kFmGnQS5I3pvzJM3g8tQncCJHczhKqCI5WB2p+kIbb3PnNxNsuQ62DGNHDcE1CLUpARLaDSvh5lCOA==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@pika/plugin-ts-standard-pkg": "^0.9.2",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@octokit/plugin-throttling": "^3.3.0",
     "@octokit/request": "^5.1.0",
     "@octokit/types": "^5.0.1",
-    "@octokit/webhooks": "^7.11.0",
+    "@octokit/webhooks": "^7.13.0",
     "@probot/octokit-plugin-config": "^1.0.0",
     "@probot/pino": "^1.1.2",
     "@types/express": "^4.17.2",

--- a/src/context.ts
+++ b/src/context.ts
@@ -8,7 +8,7 @@ import type { Logger } from "pino";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 import { aliasLog } from "./helpers/alias-log";
 import { DeprecatedLogger } from "./types";
-import { All } from "@octokit/webhooks/dist-types/generated/get-webhook-payload-type-from-event";
+import { WebhookEvents } from "@octokit/webhooks";
 
 export type MergeOptions = merge.Options;
 
@@ -56,7 +56,7 @@ export interface WebhookPayloadWithRepository {
  */
 export class Context<E extends WebhookPayloadWithRepository = any>
   implements WebhookEvent<E> {
-  public name: All;
+  public name: WebhookEvents;
   public id: string;
   public payload: E;
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -6,7 +6,7 @@ import nock from "nock";
 import { Application, Probot, ProbotOctokit } from "../src";
 
 import path = require("path");
-import { All } from "@octokit/webhooks/dist-types/generated/get-webhook-payload-type-from-event";
+import { WebhookEvents } from "@octokit/webhooks";
 
 const id = 1;
 const privateKey = `-----BEGIN RSA PRIVATE KEY-----
@@ -24,7 +24,7 @@ describe("Probot", () => {
   let probot: Probot;
   let event: {
     id: string;
-    name: All;
+    name: WebhookEvents;
     payload: any;
   };
 


### PR DESCRIPTION
Follow up of https://github.com/octokit/webhooks.js/pull/321

- [x] bump up @octokit/webhooks.js so that the new import is available to use