### PR TITLE
feat: `(app) => {}` is now `({ app }) => {}`

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -10,7 +10,7 @@ A clear and concise description of the behavior.
 
 ```js
 // Your code here
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.log.info("There is a bug");
 };
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; I'm going to s
 **Probot is a framework for building [GitHub Apps](https://docs.github.com/en/developers/apps) in [Node.js](https://nodejs.org/)**, written in [TypeScript](https://www.typescriptlang.org/). GitHub Apps can listen to webhook events sent by a repository or organization. Probot uses its internal event emitter to perform actions based on those events. A simple Probot App might look like this:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Thanks for opening this issue!",

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -11,7 +11,7 @@ Se você já pensou, "não seria legal se o GitHub pudesse..."; Eu vou parar voc
 **Probot é um framework para construir [GitHub Apps](http://developer.github.com/apps) em [Node.js](https://nodejs.org/)**, escrito em [TypeScript](https://www.typescriptlang.org/). O GitHub Apps pode ouvir eventos de webhook enviados por um repositório ou organização. O Probot usa seu emissor de evento interno para executar ações com base nesses eventos. Um aplicativo Probot simples pode ter esta aparência:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Obrigado por abrir esta issue!",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,7 +15,7 @@ For example, users could add labels from comments by typing `/label in-progress`
 ```js
 const commands = require("probot-commands");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   // Type `/label foo, bar` in a comment box for an Issue or Pull Request
   commands(app, "label", (context, command) => {
     const labels = command.arguments.split(/, */);
@@ -33,7 +33,7 @@ For example, here is a contrived app that stores the number of times that commen
 ```js
 const metadata = require("probot-metadata");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on(["issues.edited", "issue_comment.edited"], async (context) => {
     const kv = await metadata(context);
     await kv.set("edits", (await kv.get("edits")) || 1);
@@ -57,7 +57,7 @@ module.exports = (app) => {
 ```js
 const createScheduler = require("probot-scheduler");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   createScheduler(app);
 
   app.on("schedule.repository", (context) => {
@@ -75,7 +75,7 @@ Check out [stale](https://github.com/probot/stale) to see it in action.
 ```js
 const attachments = require("probot-attachments");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issue_comment.created", (context) => {
     return attachments(context).add({
       title: "Hello World",

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -15,7 +15,7 @@ Your app has access to an authenticated GitHub client that can be used to make A
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:
@@ -46,7 +46,7 @@ const addComment = `
   }
 `;
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // Post a comment on the issue
     context.github.graphql(addComment, {
@@ -69,7 +69,7 @@ const pinIssue = `
   }
 `;
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     context.github.graphql(pinIssue, {
       id: context.payload.issue.node_id,

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -7,7 +7,7 @@ next: docs/development.md
 A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   // your code here
 };
 ```
@@ -17,7 +17,7 @@ The `app` parameter is an instance of [`Application`](https://probot.github.io/a
 `app.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // A new issue was opened, what should we do with it?
     context.log.info(context.payload);
@@ -30,7 +30,7 @@ The `context` passed to the event handler includes everything about the event th
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:

--- a/docs/http.md
+++ b/docs/http.md
@@ -7,7 +7,7 @@ next: docs/simulating-webhooks.md
 Calling `app.route('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   // Get an express router to expose new HTTP endpoints
   const router = app.route("/my-app");
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -9,7 +9,7 @@ A good logger is a good developer's secret weapon. Probot comes with [pino](http
 `app.log`, `context.log` in an event handler, and `req.log` in an HTTP request are all loggers that you can use to get more information about what your app is doing.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.log.info("Yay, my app is loaded");
 
   app.on("issues.opened", (context) => {
@@ -33,7 +33,7 @@ When you start up your app with `npm start`, You should see your log message app
 `app.log` will log messages at the `info` level, which is what your app should use for most relevant messages. Occasionally you will want to log more detailed information that is useful for debugging, but you might not want to see it all the time.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   // …
   app.log.trace("Really low-level logging");
   app.log.debug({ data: "here" }, "End-line specs on the rotary girder");
@@ -62,7 +62,7 @@ When `NODE_ENV` is set (as it should be in production), the log output is struct
 For example, given this log:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issue_comment.created", (context) => {
     context.log.info("Comment created");
   });

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -7,7 +7,7 @@ next: docs/extensions.md
 Many GitHub API endpoints are paginated. The `github.paginate` method can be used to get each page of the results.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", (context) => {
     context.github.paginate(
       context.github.issues.list,
@@ -27,7 +27,7 @@ module.exports = (app) => {
 The return value of the `github.paginate` callback will be used to accumulate results.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     const allIssues = await context.github.paginate(
       context.github.issues.list,
@@ -44,7 +44,7 @@ module.exports = (app) => {
 Sometimes it is desirable to stop fetching pages after a certain condition has been satisfied. A second argument, `done`, is provided to the callback and can be used to stop pagination. After `done` is invoked, no additional pages will be fetched, but you still need to return the mapped value for the current page request.
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", (context) => {
     context.github.paginate(
       context.github.issues.list,
@@ -68,7 +68,7 @@ module.exports = (app) => {
 If your runtime environment supports async iterators (such as Node 10+), you can iterate through each response
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     for await (const response of octokit.paginate.iterator(
       context.github.issues.list,

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -63,7 +63,7 @@ mongoose.connect(mongoUri, {
 // Register the mongoose model
 const People = require("./PeopleSchema");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await People.find().exec();
@@ -104,7 +104,7 @@ module.exports = connection;
 const { sql } = require("@databases/mysql");
 const connection = require("./connection");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await connection.query(sql`SELECT * FROM people`);
@@ -145,7 +145,7 @@ module.exports = connection;
 const { sql } = require("@databases/pg");
 const connection = require("./connection");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await connection.query(sql`SELECT * FROM people`);
@@ -186,7 +186,7 @@ firebase.initializeApp(config);
 
 const database = firebase.database();
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await database

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -9,7 +9,7 @@ next: docs/github-api.md
 Many apps will spend their entire day responding to these actions. `app.on` will listen for any GitHub webhook events:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("push", async (context) => {
     // Code was pushed to the repo, what should we do with it?
     app.log.info(context);
@@ -22,7 +22,7 @@ The app can listen to any of the [GitHub webhook events](https://developer.githu
 Most events also include an "action". For example, the [`issues`](https://developer.github.com/v3/activity/events/types/#issuesevent) event has actions of `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `milestoned`, `demilestoned`, `closed`, and `reopened`. Often, your app will only care about one type of action, so you can append it to the event name with a `.`:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("issues.opened", async (context) => {
     // An issue was just opened.
   });
@@ -32,7 +32,7 @@ module.exports = (app) => {
 Sometimes you want to handle multiple webhook events the same way. `app.on` can listen to a list of events and run the same callback:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on(["issues.opened", "issues.edited"], async (context) => {
     // An issue was opened or edited, what should we do with it?
     app.log.info(context);
@@ -43,7 +43,7 @@ module.exports = (app) => {
 You can also use the wildcard event (`*`) to listen for any event that your app is subscribed to:
 
 ```js
-module.exports = (app) => {
+module.exports = ({ app }) => {
   app.on("*", async (context) => {
     context.log.info({ event: context.event, action: context.payload.action });
   });

--- a/src/application.ts
+++ b/src/application.ts
@@ -173,7 +173,7 @@ export class Application {
    * to wait for the magic to happen.
    *
    * ```js
-   *  module.exports = (app) => {
+   *  module.exports = ({ app }) => {
    *    app.on('issues.opened', async context => {
    *      const github = await app.auth();
    *    });

--- a/src/apps/default.ts
+++ b/src/apps/default.ts
@@ -1,7 +1,7 @@
 import path from "path";
 import { Application } from "../application";
 
-export = (app: Application) => {
+export = ({ app }: { app: Application }) => {
   const route = app.route();
 
   route.get("/probot", (req, res) => {

--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -11,7 +11,7 @@ export const setupAppFactory = (
   host: string | undefined,
   port: number | undefined
 ) =>
-  async function setupApp(app: Application) {
+  async function setupApp({ app }: { app: Application }) {
     const setup: ManifestCreation = new ManifestCreation();
 
     // If not on Glitch or Production, create a smee URL

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,41 @@
+import type { Logger } from "pino";
+
+import { getAuthenticatedOctokit } from "./octokit/get-authenticated-octokit";
+import { ProbotOctokit } from "./octokit/probot-octokit";
+import { State } from "./types";
+
+/**
+ * Authenticate and get a GitHub client that can be used to make API calls.
+ *
+ * You'll probably want to use `context.github` instead.
+ *
+ * **Note**: `app.auth` is asynchronous, so it needs to be prefixed with a
+ * [`await`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/await)
+ * to wait for the magic to happen.
+ *
+ * ```js
+ *  module.exports = ({ app }) => {
+ *    app.on('issues.opened', async context => {
+ *      const github = await app.auth();
+ *    });
+ *  };
+ * ```
+ *
+ * @param id - ID of the installation, which can be extracted from
+ * `context.payload.installation.id`. If called without this parameter, the
+ * client wil authenticate [as the app](https://developer.github.com/apps/building-integrations/setting-up-and-registering-github-apps/about-authentication-options-for-github-apps/#authenticating-as-a-github-app)
+ * instead of as a specific installation, which means it can only be used for
+ * [app APIs](https://developer.github.com/v3/apps/).
+ *
+ * @returns An authenticated GitHub API client
+ */
+export async function auth(
+  state: State,
+  installationId?: number,
+  log?: Logger
+): Promise<InstanceType<typeof ProbotOctokit>> {
+  return getAuthenticatedOctokit(
+    Object.assign({}, state, log ? { log } : null),
+    installationId
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,12 @@ import { resolveAppFunction } from "./helpers/resolve-app-function";
 import { createServer } from "./server/create-server";
 import { createWebhookProxy } from "./helpers/webhook-proxy";
 import { getErrorHandler } from "./helpers/get-error-handler";
-import { DeprecatedLogger, ProbotWebhooks, State } from "./types";
+import {
+  ApplicationFunction,
+  DeprecatedLogger,
+  ProbotWebhooks,
+  State,
+} from "./types";
 import { getProbotOctokitWithDefaults } from "./octokit/get-probot-octokit-with-defaults";
 import { aliasLog } from "./helpers/alias-log";
 import { logWarningsForObsoleteEnvironmentVariables } from "./helpers/log-warnings-for-obsolete-environment-variables";
@@ -354,8 +359,6 @@ export const createProbot = (options: Options) => {
   );
   return new Probot(options);
 };
-
-export type ApplicationFunction = (app: Application) => void;
 
 export { Logger, Context, Application, ProbotOctokit };
 

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,0 +1,67 @@
+import { Deprecation } from "deprecation";
+
+import { Application } from "./application";
+import { ApplicationFunction, ApplicationFunctionOptions } from "./types";
+
+type DeprecatedKey =
+  | "auth"
+  | "load"
+  | "log"
+  | "on"
+  | "receive"
+  | "route"
+  | "router";
+
+const DEPRECATED_APP_KEYS: DeprecatedKey[] = [
+  "auth",
+  "load",
+  "log",
+  "on",
+  "receive",
+  "route",
+  "router",
+];
+let didDeprecate = false;
+
+/**
+ * Loads an ApplicationFunction into the current Application
+ * @param appFn - Probot application function to load
+ */
+export function load(
+  app: Application,
+  appFn: ApplicationFunction | ApplicationFunction[]
+) {
+  const deprecatedApp = DEPRECATED_APP_KEYS.reduce(
+    (api: Record<string, unknown>, key: DeprecatedKey) => {
+      Object.defineProperty(api, key, {
+        get() {
+          if (didDeprecate) return app[key];
+
+          app.log.warn(
+            new Deprecation(
+              '[probot] "(app) => {}" is deprecated. Use "({ app }) => {}" instead'
+            )
+          );
+          didDeprecate = true;
+
+          return app[key];
+        },
+      });
+
+      return api;
+    },
+    {}
+  );
+
+  if (Array.isArray(appFn)) {
+    appFn.forEach((fn) => load(app, fn));
+  } else {
+    appFn(
+      (Object.assign(deprecatedApp, {
+        app,
+      }) as unknown) as ApplicationFunctionOptions
+    );
+  }
+
+  return app;
+}

--- a/src/route.ts
+++ b/src/route.ts
@@ -1,0 +1,35 @@
+import express from "express";
+
+import { Application } from "./application";
+
+/**
+ * Get an {@link http://expressjs.com|express} router that can be used to
+ * expose HTTP endpoints
+ *
+ * ```
+ * module.exports = app => {
+ *   // Get an express router to expose new HTTP endpoints
+ *   const route = app.route('/my-app');
+ *
+ *   // Use any middleware
+ *   route.use(require('express').static(__dirname + '/public'));
+ *
+ *   // Add a new route
+ *   route.get('/hello-world', (req, res) => {
+ *     res.end('Hello World');
+ *   });
+ * };
+ * ```
+ *
+ * @param path - the prefix for the routes
+ * @returns an [express.Router](http://expressjs.com/en/4x/api.html#router)
+ */
+export function route(app: Application, path?: string): express.Router {
+  if (path) {
+    const router = express.Router();
+    app.router.use(path, router);
+    return router;
+  } else {
+    return app.router;
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,6 +3,7 @@ import LRUCache from "lru-cache";
 
 import { Context } from "./context";
 import { ProbotOctokit } from "./octokit/probot-octokit";
+import { Application } from "./application";
 
 import type { Logger, LogFn } from "pino";
 
@@ -26,3 +27,19 @@ export type ProbotWebhooks = Webhooks<
 >;
 
 export type DeprecatedLogger = LogFn & Logger;
+
+type deprecatedKeys =
+  | "router"
+  | "log"
+  | "on"
+  | "receive"
+  | "load"
+  | "route"
+  | "auth";
+export type ApplicationFunctionOptions = {
+  /**
+   * @deprecated "(app) => {}" is deprecated. Use "({ app }) => {}" instead.
+   */
+  [K in deprecatedKeys]: Application[K];
+} & { app: Application };
+export type ApplicationFunction = (options: ApplicationFunctionOptions) => void;

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -248,7 +248,8 @@ describe("Application", () => {
   describe("load", () => {
     it("loads one app", async () => {
       const spy = jest.fn();
-      const myApp = (a: any) => a.on("pull_request", spy);
+      const myApp = ({ app }: { app: Application }) =>
+        app.on("pull_request", spy);
 
       app.load(myApp);
       await app.receive(event);
@@ -258,8 +259,10 @@ describe("Application", () => {
     it("loads multiple apps", async () => {
       const spy = jest.fn();
       const spy2 = jest.fn();
-      const myApp = (a: any) => a.on("pull_request", spy);
-      const myApp2 = (a: any) => a.on("pull_request", spy2);
+      const myApp = ({ app }: { app: Application }) =>
+        app.on("pull_request", spy);
+      const myApp2 = ({ app }: { app: Application }) =>
+        app.on("pull_request", spy2);
 
       app.load([myApp, myApp2]);
       await app.receive(event);

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -150,4 +150,18 @@ describe("Deprecations", () => {
       `Using the \"*\" event with the regular Webhooks.on() function is deprecated. Please use the Webhooks.onAny() method instead`
     );
   });
+
+  it("(app) => { app.on(event, handler) }", () => {
+    const probot = new Probot({ log: pino(streamLogsToOutput) });
+    probot.load((app) => {
+      // test that deprecation is only logged once
+      app.auth();
+      app.on("push", () => {});
+    });
+
+    expect(output.length).toEqual(1);
+    expect(output[0].msg).toContain(
+      `[probot] "(app) => {}" is deprecated. Use "({ app }) => {}" instead`
+    );
+  });
 });

--- a/test/e2e/hello-world.js
+++ b/test/e2e/hello-world.js
@@ -1,6 +1,6 @@
 console.log("waddafugg");
 
-module.exports = (app) => {
+module.exports = ({ app }) => {
   // Your code here
   app.log.info("Yay! The app was loaded!");
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -85,7 +85,7 @@ describe("Probot", () => {
     it("runs with a function as argument", async () => {
       let initialized = false;
 
-      probot = await Probot.run((app) => {
+      probot = await Probot.run(({ app }) => {
         initialized = true;
       });
       expect(probot.options).toMatchSnapshot();
@@ -103,7 +103,7 @@ describe("Probot", () => {
       process.env.REDIS_URL = "redis://test:test@localhost:6379";
 
       await new Promise(async (resolve, reject) => {
-        const probot = await Probot.run((app) => {
+        const probot = await Probot.run(({ app }) => {
           app.auth(1).then(resolve, reject);
         });
         probot.stop();
@@ -116,7 +116,7 @@ describe("Probot", () => {
       process.env.PORT = "3003";
 
       return new Promise(async (resolve) => {
-        probot = await Probot.run((app) => {
+        probot = await Probot.run(({ app }) => {
           initialized = true;
         });
         expect(probot.options).toMatchSnapshot();
@@ -129,7 +129,7 @@ describe("Probot", () => {
 
     it("has version", async () => {
       return new Promise(async (resolve) => {
-        probot = await Probot.run((app) => {});
+        probot = await Probot.run(({ app }) => {});
         expect(probot.version).toBe("0.0.0-development");
         probot.stop();
 
@@ -223,7 +223,7 @@ describe("Probot", () => {
 
   describe("server", () => {
     it("prefixes paths with route name", () => {
-      probot.load((app) => {
+      probot.load(({ app }) => {
         const route = app.route("/my-app");
         route.get("/foo", (req, res) => res.end("foo"));
       });
@@ -232,7 +232,7 @@ describe("Probot", () => {
     });
 
     it("allows routes with no path", () => {
-      probot.load((app) => {
+      probot.load(({ app }) => {
         const route = app.route();
         route.get("/foo", (req, res) => res.end("foo"));
       });
@@ -241,7 +241,7 @@ describe("Probot", () => {
     });
 
     it("allows you to overwrite the root path", () => {
-      probot.load((app) => {
+      probot.load(({ app }) => {
         const route = app.route();
         route.get("/", (req, res) => res.end("foo"));
       });
@@ -251,7 +251,7 @@ describe("Probot", () => {
 
     it("isolates apps from affecting eachother", async () => {
       ["foo", "bar"].forEach((name) => {
-        probot.load((app) => {
+        probot.load(({ app }) => {
           const route = app.route("/" + name);
 
           route.use((req, res, next) => {
@@ -285,7 +285,7 @@ describe("Probot", () => {
         (error: any, req: Request, res: Response, next: NextFunction) => {}
       );
 
-      probot.load((app) => {
+      probot.load(({ app }) => {
         const route = app.route();
         route.get("/webhook", (req, res) => res.end("get-webhook"));
         route.post("/webhook", (req, res) => res.end("post-webhook"));
@@ -330,7 +330,7 @@ describe("Probot", () => {
     it("forwards events to each app", async () => {
       const spy = jest.fn();
 
-      probot.load((app) => app.on("push", spy));
+      probot.load(({ app }) => app.on("push", spy));
 
       await probot.receive(event);
 
@@ -348,8 +348,8 @@ describe("Probot", () => {
     });
 
     it("requests from the correct API URL", async () => {
-      const appFn = async (appl: Application) => {
-        const github = await appl.auth();
+      const appFn = async ({ app }: { app: Application }) => {
+        const github = await app.auth();
         expect(github.request.endpoint.DEFAULTS.baseUrl).toEqual(
           "https://notreallygithub.com/api/v3"
         );
@@ -381,8 +381,8 @@ describe("Probot", () => {
     });
 
     it("requests from the correct API URL", async () => {
-      const appFn = async (appl: Application) => {
-        const github = await appl.auth();
+      const appFn = async ({ app }: { app: Application }) => {
+        const github = await app.auth();
         expect(github.request.endpoint.DEFAULTS.baseUrl).toEqual(
           "http://notreallygithub.com/api/v3"
         );
@@ -540,7 +540,7 @@ describe("Probot", () => {
       });
 
       await new Promise((resolve, reject) => {
-        probot.load(async (app) => {
+        probot.load(async ({ app }) => {
           const octokit = await app.auth();
           try {
             const { data: appData } = await octokit.apps.getAuthenticated();
@@ -573,7 +573,7 @@ describe("Probot", () => {
         privateKey,
       });
 
-      const app = (app: Application) => {
+      const app = ({ app }: { app: Application }) => {
         expect(app).toBeInstanceOf(Application);
       };
 

--- a/test/webhook-event-check.test.ts
+++ b/test/webhook-event-check.test.ts
@@ -63,7 +63,7 @@ describe("webhook-event-check", () => {
     const probot = new Probot({ id, privateKey });
 
     let spyOnLogError;
-    probot.load(async (app) => {
+    probot.load(async ({ app }) => {
       spyOnLogError = jest.spyOn(app.log, "error");
 
       app.on("label.edited", noop);
@@ -86,7 +86,7 @@ describe("webhook-event-check", () => {
     const probot = new Probot({ id, privateKey });
     let spyOnLogError;
 
-    probot.load(async (app) => {
+    probot.load(async ({ app }) => {
       spyOnLogError = jest.spyOn(app.log, "error");
 
       app.on("*", noop);
@@ -108,7 +108,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
 
         app.on("pull_request.opened", noop);
@@ -130,7 +130,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
 
         app.on("pull_request.opened", noop);
@@ -157,7 +157,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
         app.on("pull_request.opened", noop);
       });
@@ -174,7 +174,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
         app.on("pull_request.opened", noop);
       });
@@ -191,7 +191,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
         app.on("pull_request.opened", noop);
       });
@@ -208,7 +208,7 @@ describe("webhook-event-check", () => {
       const probot = new Probot({ id, privateKey });
       let spyOnLogError;
 
-      probot.load(async (app) => {
+      probot.load(async ({ app }) => {
         spyOnLogError = jest.spyOn(app.log, "error");
         app.on("pull_request.opened", noop);
       });


### PR DESCRIPTION
part of #1398, in preparation of separating server APIs from the `app` instance. We will pass a separate `({ app, router }) => {}` argument in future

-----
[View rendered .github/ISSUE_TEMPLATE/Bug_report.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/.github/ISSUE_TEMPLATE/Bug_report.md)
[View rendered README.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/README.md)
[View rendered README.pt-br.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/README.pt-br.md)
[View rendered docs/extensions.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/extensions.md)
[View rendered docs/github-api.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/github-api.md)
[View rendered docs/hello-world.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/hello-world.md)
[View rendered docs/http.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/http.md)
[View rendered docs/logging.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/logging.md)
[View rendered docs/pagination.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/pagination.md)
[View rendered docs/persistence.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/persistence.md)
[View rendered docs/webhooks.md](https://github.com/probot/probot/blob/1398/deprecate-app-fn/docs/webhooks.md)