### PR TITLE
feat: deprecate `{ Application }` export. Use `{ Probot }` instead, it has the same APIs now.

### DIFF
--- a/src/application.ts
+++ b/src/application.ts
@@ -38,8 +38,11 @@ export interface Options {
   cache?: LRUCache<number, string>;
   octokit?: InstanceType<typeof ProbotOctokit>;
   webhooks?: Webhooks;
-  router?: Router;
 
+  /**
+   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"
+   */
+  router?: Router;
   /**
    * @deprecated set `Octokit` to `ProbotOctokit.defaults({ throttle })` instead
    */
@@ -71,6 +74,10 @@ export class Application {
 
   constructor(options: Options) {
     this.log = aliasLog(options.log || getLog());
+
+    this.log.warn(
+      `[probot] "import { Application } from 'probot'" is deprecated. Use "import { Probot } from 'probot'" instead, the APIs are the same.`
+    );
 
     // TODO: support redis backend for access token cache if `options.redisConfig || process.env.REDIS_URL`
     const cache =
@@ -130,6 +137,7 @@ export class Application {
     this.receive = this.webhooks.receive;
 
     const router = options.router || Router();
+    // @ts-ignore
     this.load = load.bind(null, this, router);
     this.auth = auth.bind(null, this.state);
 

--- a/src/apps/default.ts
+++ b/src/apps/default.ts
@@ -1,12 +1,12 @@
 import path from "path";
 import express from "express";
-import { Application } from "../application";
+import { Probot } from "../index";
 
 export = ({
   app,
   getRouter,
 }: {
-  app: Application;
+  app: Probot;
   getRouter: () => express.Router;
 }) => {
   const router = getRouter();

--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -1,8 +1,9 @@
+import express from "express";
 import bodyParser from "body-parser";
 import { exec } from "child_process";
 import { Request, Response } from "express";
 import updateDotenv from "update-dotenv";
-import { Application } from "../application";
+import { Probot } from "../index";
 import { ManifestCreation } from "../manifest-creation";
 
 import { getLoggingMiddleware } from "../server/logging-middleware";
@@ -11,7 +12,13 @@ export const setupAppFactory = (
   host: string | undefined,
   port: number | undefined
 ) =>
-  async function setupApp({ app }: { app: Application }) {
+  async function setupApp({
+    app,
+    getRouter,
+  }: {
+    app: Probot;
+    getRouter: () => express.Router;
+  }) {
     const setup: ManifestCreation = new ManifestCreation();
 
     // If not on Glitch or Production, create a smee URL
@@ -22,7 +29,7 @@ export const setupAppFactory = (
       await setup.createWebhookChannel();
     }
 
-    const route = app.route();
+    const route = getRouter();
 
     route.use(getLoggingMiddleware(app.log));
 
@@ -84,7 +91,7 @@ export const setupAppFactory = (
   };
 
 function printWelcomeMessage(
-  app: Application,
+  app: Probot,
   host: string | undefined,
   port: number | undefined
 ) {
@@ -108,7 +115,7 @@ function printWelcomeMessage(
   });
 }
 
-function printRestartMessage(app: Application) {
+function printRestartMessage(app: Probot) {
   app.log.info("");
   app.log.info("Probot has been set up, please restart the server!");
   app.log.info("");

--- a/src/load.ts
+++ b/src/load.ts
@@ -1,6 +1,7 @@
 import { Deprecation } from "deprecation";
 import { Router } from "express";
 
+import { Probot } from "./index";
 import { Application } from "./application";
 import { ApplicationFunction, ApplicationFunctionOptions } from "./types";
 import { getRouter } from "./get-router";
@@ -22,7 +23,7 @@ let didDeprecate = false;
  * @param appFn - Probot application function to load
  */
 export function load(
-  app: Application,
+  app: Application | Probot,
   router: Router | null,
   appFn: ApplicationFunction | ApplicationFunction[]
 ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import express from "express";
 import { WebhookEvent, Webhooks } from "@octokit/webhooks";
 import LRUCache from "lru-cache";
 
+import { Probot } from "./index";
 import { Context } from "./context";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 import { Application } from "./application";
@@ -37,10 +38,11 @@ type deprecatedKeys =
   | "load"
   | "route"
   | "auth";
+
 export type ApplicationFunctionOptions = {
   /**
    * @deprecated "(app) => {}" is deprecated. Use "({ app }) => {}" instead.
    */
   [K in deprecatedKeys]: Application[K];
-} & { app: Application; getRouter: (path?: string) => express.Router };
+} & { app: Probot; getRouter: (path?: string) => express.Router };
 export type ApplicationFunction = (options: ApplicationFunctionOptions) => void;

--- a/test/application.test.ts
+++ b/test/application.test.ts
@@ -2,6 +2,7 @@ import { WebhookEvent } from "@octokit/webhooks";
 import nock from "nock";
 import pino from "pino";
 
+import { Probot } from "../src/";
 import { Application } from "../src/application";
 import { Context } from "../src/context";
 import { ProbotOctokit } from "../src/octokit/probot-octokit";
@@ -111,7 +112,7 @@ describe("Application", () => {
         expect(context.log.info).toBeDefined();
         context.log.info("testing");
 
-        expect(output[0]).toEqual(
+        expect(output[1]).toEqual(
           expect.objectContaining({
             id: context.id,
             msg: "testing",
@@ -248,8 +249,7 @@ describe("Application", () => {
   describe("load", () => {
     it("loads one app", async () => {
       const spy = jest.fn();
-      const myApp = ({ app }: { app: Application }) =>
-        app.on("pull_request", spy);
+      const myApp = ({ app }: { app: Probot }) => app.on("pull_request", spy);
 
       app.load(myApp);
       await app.receive(event);
@@ -259,10 +259,8 @@ describe("Application", () => {
     it("loads multiple apps", async () => {
       const spy = jest.fn();
       const spy2 = jest.fn();
-      const myApp = ({ app }: { app: Application }) =>
-        app.on("pull_request", spy);
-      const myApp2 = ({ app }: { app: Application }) =>
-        app.on("pull_request", spy2);
+      const myApp = ({ app }: { app: Probot }) => app.on("pull_request", spy);
+      const myApp2 = ({ app }: { app: Probot }) => app.on("pull_request", spy2);
 
       app.load([myApp, myApp2]);
       await app.receive(event);
@@ -318,10 +316,10 @@ describe("Application", () => {
         // Expected
       }
 
-      expect(output.length).toBe(1);
+      expect(output.length).toEqual(2); // 2 because the Application constructor logs a deprecation message
 
-      expect(output[0].msg).toMatch(/testing/);
-      expect(output[0].event.id).toEqual(event.id);
+      expect(output[1].msg).toMatch(/testing/);
+      expect(output[1].event.id).toEqual(event.id);
     });
 
     it("logs errors from rejected promises", async () => {
@@ -333,9 +331,10 @@ describe("Application", () => {
         // Expected
       }
 
-      expect(output.length).toBe(1);
-      expect(output[0].msg).toMatch(/testing/);
-      expect(output[0].event.id).toEqual(event.id);
+      expect(output.length).toEqual(2); // 2 because the Application constructor logs a deprecation message
+
+      expect(output[1].msg).toMatch(/testing/);
+      expect(output[1].event.id).toEqual(event.id);
     });
   });
 });

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -127,8 +127,8 @@ describe("Deprecations", () => {
     const installationOctokit = await app.auth(1);
     installationOctokit.test();
 
-    expect(output.length).toEqual(1);
-    expect(output[0].msg).toContain(
+    expect(output.length).toEqual(2); // 2 because Application itself is now deprecated
+    expect(output[1].msg).toContain(
       '[probot] "new Application({ throttleOptions })" is deprecated. Use "new Application({Octokit: ProbotOctokit.defaults({ throttle }) })" instead'
     );
   });
@@ -186,6 +186,35 @@ describe("Deprecations", () => {
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
       '[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"'
+    );
+  });
+
+  it("Application", () => {
+    // const testLog = pino(streamLogsToOutput);
+    // const log = ({
+    //   fatal: testLog.fatal.bind(testLog),
+    //   error: testLog.error.bind(testLog),
+    //   warn: testLog.warn.bind(testLog),
+    //   info: testLog.info.bind(testLog),
+    //   debug: testLog.debug.bind(testLog),
+    //   trace: testLog.trace.bind(testLog),
+    //   child: () => log,
+    // } as unknown) as pino.Logger;
+
+    new Application({
+      secret: "secret",
+      id: 1,
+      privateKey:
+        "-----BEGIN RSA PRIVATE KEY-----\nMIIBOQIBAAJBAIILhiN9IFpaE0pUXsesuuoaj6eeDiAqCiE49WB1tMB8ZMhC37kY\nFl52NUYbUxb7JEf6pH5H9vqw1Wp69u78XeUCAwEAAQJAb88urnaXiXdmnIK71tuo\n/TyHBKt9I6Rhfzz0o9Gv7coL7a537FVDvV5UCARXHJMF41tKwj+zlt9EEUw7a1HY\nwQIhAL4F/VHWSPHeTgXYf4EaX2OlpSOk/n7lsFtL/6bWRzRVAiEArzJs2vopJitv\nA1yBjz3q2nX+zthk+GLXrJQkYOnIk1ECIHfeFV8TWm5gej1LxZquBTA5pINoqDVq\nNKZSuZEHqGEFAiB6EDrxkovq8SYGhIQsJeqkTMO8n94xhMRZlFmIQDokEQIgAq5U\nr1UQNnUExRh7ZT0kFbMfO9jKYZVlQdCL9Dn93vo=\n-----END RSA PRIVATE KEY-----",
+      Octokit: ProbotOctokit.defaults({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+      }),
+      log: pino(streamLogsToOutput),
+    });
+    expect(output.length).toEqual(1);
+    expect(output[0].msg).toContain(
+      `[probot] "import { Application } from 'probot'" is deprecated. Use "import { Probot } from 'probot'" instead, the APIs are the same.`
     );
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ import request = require("supertest");
 import nock from "nock";
 import pino from "pino";
 
-import { Application, Probot, ProbotOctokit, Context } from "../src";
+import { Probot, ProbotOctokit, Context } from "../src";
 
 import path = require("path");
 import { WebhookEvents } from "@octokit/webhooks";
@@ -361,7 +361,7 @@ describe("Probot", () => {
     });
 
     it("requests from the correct API URL", async () => {
-      const appFn = async ({ app }: { app: Application }) => {
+      const appFn = async ({ app }: { app: Probot }) => {
         const github = await app.auth();
         expect(github.request.endpoint.DEFAULTS.baseUrl).toEqual(
           "https://notreallygithub.com/api/v3"
@@ -394,7 +394,7 @@ describe("Probot", () => {
     });
 
     it("requests from the correct API URL", async () => {
-      const appFn = async ({ app }: { app: Application }) => {
+      const appFn = async ({ app }: { app: Probot }) => {
         const github = await app.auth();
         expect(github.request.endpoint.DEFAULTS.baseUrl).toEqual(
           "http://notreallygithub.com/api/v3"
@@ -586,8 +586,8 @@ describe("Probot", () => {
         privateKey,
       });
 
-      const app = ({ app }: { app: Application }) => {
-        expect(app).toBeInstanceOf(Application);
+      const app = ({ app }: { app: Probot }) => {
+        expect(app).toBeInstanceOf(Probot);
       };
 
       probot.load([app, app]);


### PR DESCRIPTION
closes #1398