### PR TITLE
fix: remove `GHE_HOST` deprecation message when using `probot run` cli

### DIFF
--- a/src/probot.ts
+++ b/src/probot.ts
@@ -149,6 +149,7 @@ export class Probot {
       log: this.log,
       redisConfig: options.redisConfig,
       throttleOptions: options.throttleOptions,
+      baseUrl: options.baseUrl,
     });
     const octokit = new Octokit();
 


### PR DESCRIPTION
fixes #1422
