### PR TITLE
feat: `createProbot()`, `createNodeMiddleware(app, { probot })`. Deprecates `getOptions`, `createNodeMiddleware(app, { Probot })`

### DIFF
--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -23,7 +23,7 @@ Every deployment will need an [App](https://developer.github.com/apps/). If you 
 
 ## Deploy the app
 
-To deploy an app to any cloud provider, you will have to pass a custom `Probot` constructor:
+To deploy an app to any cloud provider, you will have to pass a `probot` instance:
 
 ```js
 const { Probot } = require("probot");
@@ -31,7 +31,7 @@ const { createMyMiddleware } = require("my-probot-middleware");
 const myApp = require("./my-app.js");
 
 module.exports = createMyMiddleware(myApp, {
-  Probot: Probot.defaults({
+  probot: new Probot({
     appId: 1,
     privateKey: process.env.PRIVATE_KEY,
     secret: process.env.WEBHOOK_SECRET,
@@ -39,15 +39,19 @@ module.exports = createMyMiddleware(myApp, {
 });
 ```
 
-Or use the `getOptions` method and define the according [environment variables](https://probot.github.io/docs/configuration/)
+Creating the instance outside the `createMyMiddleware` function enables the reuse of the `probot` instance across multiple requests, see [Understanding Container Reuse in AWS Lambda](https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/).
+
+If you want to configure the created `probot` instance based on [environment variables](https://probot.github.io/docs/configuration/), use the `createProbot` method
 
 ```js
-const { getOptions } = require("probot");
+const { createProbot } = require("probot");
 const { createMyMiddleware } = require("my-probot-middleware");
 const myApp = require("./my-app.js");
 
-module.exports = createMyMiddleware(myApp, getOptions());
+module.exports = createMyMiddleware(myApp, { probot: createProbot() });
 ```
+
+You can optionall pass `defaults` and `overrides` as `createProbot({ defaults, overrides })` to customize the options passed to the Probot constructor.
 
 Choosing a FaaS provider is mostly dependent on developer preference. Each Probot plugin interacts similarly, but the plugins implementation is dealing with different requests and responses specific to the provider. If you do not have a preference for a provider, choose the solution you have the most familiarity.
 
@@ -56,10 +60,10 @@ Choosing a FaaS provider is mostly dependent on developer preference. Each Probo
 Probot exports a standard Node.js middleware by default, you can use it like this:
 
 ```js
-const { createNodeMiddleware, getOptions } = require("probot");
+const { createNodeMiddleware, createProbot } = require("probot");
 const myApp = require("./my-app.js");
 
-module.exports = createNodeMiddleware(myApp, getOptions());
+module.exports = createNodeMiddleware(myApp, { probot: createProbot() });
 ```
 
 The returned middleware includes an optional 3rd `next` argument for compatibility with [express middleware](https://expressjs.com/en/guide/using-middleware.html).
@@ -83,6 +87,6 @@ A probot middleware function should follow the following conventions:
 1. The package exports a synchronous function. The function name should follow the pattern `create[Platform]Middleware`
 2. The exported function should return a function matching the respective platform of the requirements
 3. The first argument should be a probot application function: `async ({ app }) => { ... }`
-4. The 2nd argument should accept an object with at least a `Probot` key, which has to be set to a Probot constructor with the options preset using `Probot.defaults({ appId, privateKey, secret, ... })`. If environment variables can be set on the platform, the package should export a `getOptions()` function, wich the same signature as the one exported by `probot`. It can be the exact same one, or you can add custom logic useful to the respective platform.
+4. The 2nd argument should accept an object with at least a `probot` key, which has to be set to a Probot instance.
 
 Please share your own middleware by adding it to this list: [edit this page on GitHub](https://github.com/probot/probot/edit/master/docs/serverless-deployment.md).

--- a/src/create-node-middleware.ts
+++ b/src/create-node-middleware.ts
@@ -2,18 +2,17 @@ import { RequestListener, IncomingMessage, ServerResponse } from "http";
 import { NextFunction } from "express";
 
 import { ApplicationFunction } from "./types";
-import { ServerOptions } from "./types";
+import { MiddlewareOptions } from "./types";
 
 export function createNodeMiddleware(
   appFn: ApplicationFunction,
-  options: ServerOptions
+  { probot }: MiddlewareOptions
 ): RequestListener {
   return (
     request: IncomingMessage,
     response: ServerResponse,
     next?: NextFunction
   ) => {
-    const probot = new options.Probot();
     probot.load(appFn);
     probot.webhooks.middleware(request, response, next);
   };

--- a/src/create-node-middleware.ts
+++ b/src/create-node-middleware.ts
@@ -1,4 +1,6 @@
 import { RequestListener, IncomingMessage, ServerResponse } from "http";
+
+import { Deprecation } from "deprecation";
 import { NextFunction } from "express";
 
 import { ApplicationFunction } from "./types";
@@ -6,13 +8,22 @@ import { MiddlewareOptions } from "./types";
 
 export function createNodeMiddleware(
   appFn: ApplicationFunction,
-  { probot }: MiddlewareOptions
+  { probot, Probot }: MiddlewareOptions
 ): RequestListener {
   return (
     request: IncomingMessage,
     response: ServerResponse,
     next?: NextFunction
   ) => {
+    if (Probot) {
+      probot = new Probot();
+      probot.log.warn(
+        new Deprecation(
+          `"createNodeMiddleware(app, { Probot })" is deprecated. Use "createNodeMiddleware(app, { probot })" instead`
+        )
+      );
+    }
+
     probot.load(appFn);
     probot.webhooks.middleware(request, response, next);
   };

--- a/src/create-probot.ts
+++ b/src/create-probot.ts
@@ -1,0 +1,112 @@
+import { Deprecation } from "deprecation";
+import { LogLevel, Options as PinoOptions } from "@probot/pino";
+import { getPrivateKey } from "@probot/get-private-key";
+
+import { getLog, GetLogOptions } from "./helpers/get-log";
+import { Options } from "./types";
+import { Probot } from "./probot";
+
+type CreateProbotOptions = {
+  overrides?: Options;
+  defaults?: Options;
+  env?: NodeJS.ProcessEnv;
+};
+
+const DEFAULTS = {
+  APP_ID: "",
+  WEBHOOK_SECRET: "",
+  GHE_HOST: "",
+  GHE_PROTOCOL: "",
+  LOG_FORMAT: "",
+  LOG_LEVEL: "warn",
+  LOG_LEVEL_IN_STRING: "",
+  REDIS_URL: "",
+  SENTRY_DSN: "",
+};
+
+/**
+ * Merges configuration from defaults/environment variables/overrides and returns
+ * a Probot instance. Finds private key using [`@probot/get-private-key`](https://github.com/probot/get-private-key).
+ *
+ * @see https://probot.github.io/docs/configuration/
+ * @param defaults default Options, will be overwritten if according environment variable is set
+ * @param overrides overwrites defaults and according environment variables
+ * @param env defaults to process.env
+ */
+export function createProbot(options: Options | CreateProbotOptions) {
+  if (isDeprecated(options)) {
+    return deprecatedCreateProbot(options);
+  }
+
+  const { overrides = {}, defaults = {}, env = process.env } = options;
+
+  const privateKey = getPrivateKey({ env });
+  const envWithDefaults = { ...DEFAULTS, ...env };
+
+  const envOptions: Options = {
+    logLevel: envWithDefaults.LOG_LEVEL as LogLevel,
+    appId: Number(envWithDefaults.APP_ID),
+    privateKey: (privateKey && privateKey.toString()) || undefined,
+    secret: envWithDefaults.WEBHOOK_SECRET,
+    redisConfig: envWithDefaults.REDIS_URL,
+    baseUrl: envWithDefaults.GHE_HOST
+      ? `${envWithDefaults.GHE_PROTOCOL || "https"}://${
+          envWithDefaults.GHE_HOST
+        }/api/v3`
+      : "https://api.github.com",
+  };
+
+  const probotOptions = {
+    ...defaults,
+    ...envOptions,
+    ...overrides,
+  };
+
+  const logOptions: GetLogOptions = {
+    level: probotOptions.logLevel,
+    logFormat: envWithDefaults.LOG_FORMAT as PinoOptions["logFormat"],
+    logLevelInString: envWithDefaults.LOG_LEVEL_IN_STRING === "true",
+    sentryDsn: envWithDefaults.SENTRY_DSN,
+  };
+
+  const log = getLog(logOptions).child({ name: "server" });
+
+  return new Probot({
+    log: log.child({ name: "probot" }),
+    ...probotOptions,
+  });
+}
+
+function isDeprecated(
+  options: Options | CreateProbotOptions
+): options is Options {
+  const keys = Object.keys(options);
+
+  return (
+    keys.length > 0 &&
+    !keys.includes("overrides") &&
+    !keys.includes("defaults") &&
+    !keys.includes("env")
+  );
+}
+
+function deprecatedCreateProbot(options: Options) {
+  options.log =
+    options.log ||
+    getLog({
+      level: process.env.LOG_LEVEL as LogLevel,
+      logFormat: process.env.LOG_FORMAT as PinoOptions["logFormat"],
+      logLevelInString: process.env.LOG_LEVEL_IN_STRING === "true",
+      sentryDsn: process.env.SENTRY_DSN,
+    });
+
+  const deprecatedKey = Object.keys(options).join(", ");
+  options.log.warn(
+    new Deprecation(
+      `[probot] "createProbot({ ${deprecatedKey} })" is deprecated, use "new Probot(options)" instead.
+      
+"createProbot(options)" will be repurposed with probot v11 and only accept {defaults, overrides, env} option keys`
+    )
+  );
+  return new Probot(options);
+}

--- a/src/get-options.ts
+++ b/src/get-options.ts
@@ -1,3 +1,4 @@
+import { Deprecation } from "deprecation";
 import { getPrivateKey } from "@probot/get-private-key";
 import { Options as PinoOptions, LogLevel } from "@probot/pino";
 
@@ -72,7 +73,7 @@ export function getOptions(
     log: log.child({ name: "probot" }),
   });
 
-  return {
+  const options = {
     ...defaults,
     host: envWithDefaults.HOST,
     port: Number(envWithDefaults.PORT),
@@ -82,4 +83,17 @@ export function getOptions(
     Probot: ProbotWithDefaults,
     ...overrides,
   };
+
+  options.log.warn(
+    new Deprecation(
+      `[probot] "getOptions()" is deprecated, use "{ probot: createProbot() }" instead:
+
+    const { createNodeMiddleware, createProbot } = require("probot");
+    const myApp = require("./my-app.js");
+
+    module.exports = createNodeMiddleware(myApp, { probot: createProbot() });`
+    )
+  );
+
+  return options;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
-import { Deprecation } from "deprecation";
 import { Logger } from "pino";
-import { LogLevel, Options as PinoOptions } from "@probot/pino";
 
 import { Application } from "./application";
 import { Context, WebhookPayloadWithRepository } from "./context";
-import { getLog } from "./helpers/get-log";
 import { Options } from "./types";
 import { Probot } from "./probot";
 import { Server } from "./server/server";
@@ -12,23 +9,7 @@ import { ProbotOctokit } from "./octokit/probot-octokit";
 import { run } from "./run";
 import { getOptions } from "./get-options";
 import { createNodeMiddleware } from "./create-node-middleware";
-
-export const createProbot = (options: Options) => {
-  options.log =
-    options.log ||
-    getLog({
-      level: process.env.LOG_LEVEL as LogLevel,
-      logFormat: process.env.LOG_FORMAT as PinoOptions["logFormat"],
-      logLevelInString: process.env.LOG_LEVEL_IN_STRING === "true",
-      sentryDsn: process.env.SENTRY_DSN,
-    });
-  options.log.warn(
-    new Deprecation(
-      `[probot] "createProbot(options)" is deprecated, use "new Probot(options)" instead`
-    )
-  );
-  return new Probot(options);
-};
+import { createProbot } from "./create-probot";
 
 export {
   Logger,
@@ -40,6 +21,7 @@ export {
   Server,
   getOptions,
   createNodeMiddleware,
+  createProbot,
 };
 
 /** NOTE: exported types might change at any point in time */

--- a/src/types.ts
+++ b/src/types.ts
@@ -92,3 +92,8 @@ export type ServerOptions = {
   webhookProxy?: string;
   Probot: typeof Probot;
 };
+
+export type MiddlewareOptions = {
+  probot: Probot;
+  [key: string]: unknown;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -96,4 +96,9 @@ export type ServerOptions = {
 export type MiddlewareOptions = {
   probot: Probot;
   [key: string]: unknown;
+
+  /**
+   * @deprecated "Probot" option is deprecated. Pass a "probot" instance instead, see https://github.com/probot/probot/pull/1431
+   */
+  Probot?: typeof Probot;
 };

--- a/test/create-node-middleware.test.ts
+++ b/test/create-node-middleware.test.ts
@@ -6,7 +6,7 @@ import getPort from "get-port";
 import got from "got";
 import { sign } from "@octokit/webhooks";
 
-import { createNodeMiddleware, getOptions } from "../src";
+import { createNodeMiddleware, createProbot } from "../src";
 import { ApplicationFunction } from "../src/types";
 
 const APP_ID = "1";
@@ -34,7 +34,7 @@ describe("createNodeMiddleware", () => {
     output = [];
   });
 
-  test("with getOptions", async () => {
+  test("with createProbot", async () => {
     expect.assertions(1);
 
     const app: ApplicationFunction = ({ app }) => {
@@ -42,9 +42,8 @@ describe("createNodeMiddleware", () => {
         expect(event.name).toEqual("push");
       });
     };
-    const middleware = createNodeMiddleware(
-      app,
-      getOptions({
+    const middleware = createNodeMiddleware(app, {
+      probot: createProbot({
         overrides: {
           log: pino(streamLogsToOutput),
         },
@@ -53,8 +52,8 @@ describe("createNodeMiddleware", () => {
           PRIVATE_KEY,
           WEBHOOK_SECRET,
         },
-      })
-    );
+      }),
+    });
 
     const server = createServer(middleware);
     const port = await getPort();

--- a/test/create-probot.test.ts
+++ b/test/create-probot.test.ts
@@ -1,4 +1,4 @@
-import { getOptions } from "../src";
+import { createProbot, Probot } from "../src";
 
 const env = {
   APP_ID: "1",
@@ -14,60 +14,51 @@ r1UQNnUExRh7ZT0kFbMfO9jKYZVlQdCL9Dn93vo=
   WEBHOOK_SECRET: "secret",
 };
 // tslint:disable:no-empty
-describe("getOptions", () => {
-  test("getOptions()", () => {
-    const options = getOptions({ env });
-    expect(Object.keys(options).sort()).toStrictEqual([
-      "Probot",
-      "host",
-      "log",
-      "port",
-      "webhookPath",
-      "webhookProxy",
-    ]);
-
-    expect(options.port).toEqual(3000);
+describe("createProbot", () => {
+  test("createProbot()", () => {
+    const probot = createProbot({ env });
+    expect(probot).toBeInstanceOf(Probot);
   });
 
   test("defaults, env", () => {
-    const options = getOptions({
+    const probot = createProbot({
       env: {
         ...env,
-        PORT: "2222",
+        LOG_LEVEL: "debug",
       },
-      defaults: { port: 1111 },
+      defaults: { logLevel: "trace" },
     });
-    expect(options.port).toEqual(2222);
+    expect(probot.log.level).toEqual("debug");
   });
 
   test("defaults, overrides", () => {
-    const options = getOptions({
-      defaults: { port: 1111 },
-      overrides: { port: 3333 },
+    const probot = createProbot({
+      defaults: { logLevel: "debug" },
+      overrides: { logLevel: "trace" },
     });
-    expect(options.port).toEqual(3333);
+    expect(probot.log.level).toEqual("trace");
   });
 
   test("env, overrides", () => {
-    const options = getOptions({
+    const probot = createProbot({
       env: {
         ...env,
-        PORT: "2222",
+        LOG_LEVEL: "fatal",
       },
-      overrides: { port: 3333 },
+      overrides: { logLevel: "trace" },
     });
-    expect(options.port).toEqual(3333);
+    expect(probot.log.level).toEqual("trace");
   });
 
   test("defaults, env, overrides", () => {
-    const options = getOptions({
+    const probot = createProbot({
       env: {
         ...env,
-        PORT: "2222",
+        LOG_LEVEL: "fatal",
       },
-      defaults: { port: 1111 },
-      overrides: { port: 3333 },
+      defaults: { logLevel: "debug" },
+      overrides: { logLevel: "trace" },
     });
-    expect(options.port).toEqual(3333);
+    expect(probot.log.level).toEqual("trace");
   });
 });

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -10,6 +10,7 @@ import {
   Probot,
   ProbotOctokit,
   Context,
+  getOptions,
 } from "../src";
 
 const pushEvent = require("./fixtures/webhook/push.json");
@@ -33,13 +34,15 @@ describe("Deprecations", () => {
     process.env = env;
   });
 
-  it("createProbot", () => {
+  it("createProbot({ log })", () => {
     const probot = createProbot({ log: pino(streamLogsToOutput) });
     expect(probot).toBeInstanceOf(Probot);
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      '[probot] "createProbot(options)" is deprecated, use "new Probot(options)" instead'
+      `[probot] "createProbot({ log })" is deprecated, use "new Probot(options)" instead.
+      
+"createProbot(options)" will be repurposed with probot v11 and only accept {defaults, overrides, env} option keys`
     );
   });
 
@@ -399,6 +402,19 @@ If you have more than one app function, combine them in a function instead
 
     expect(output[0].msg).toContain(
       `[probot] passing a string to "probot.load()" is deprecated. Pass the function from "./test/fixtures/example.js" instead.`
+    );
+  });
+
+  it("getOptions", () => {
+    getOptions({ overrides: { log: pino(streamLogsToOutput) } });
+
+    expect(output[0].msg).toContain(
+      `[probot] "getOptions()" is deprecated, use "{ probot: createProbot() }" instead:
+
+    const { createNodeMiddleware, createProbot } = require("probot");
+    const myApp = require("./my-app.js");
+
+    module.exports = createNodeMiddleware(myApp, { probot: createProbot() });`
     );
   });
 });

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -11,7 +11,9 @@ import {
   ProbotOctokit,
   Context,
   getOptions,
+  createNodeMiddleware,
 } from "../src";
+import { IncomingMessage, ServerResponse } from "http";
 
 const pushEvent = require("./fixtures/webhook/push.json");
 
@@ -415,6 +417,21 @@ If you have more than one app function, combine them in a function instead
     const myApp = require("./my-app.js");
 
     module.exports = createNodeMiddleware(myApp, { probot: createProbot() });`
+    );
+  });
+
+  it("createNodeMiddleware(app, { Probot })", () => {
+    // @ts-ignore
+    const middleware = createNodeMiddleware(() => {}, {
+      Probot: Probot.defaults({
+        log: pino(streamLogsToOutput),
+      }),
+    });
+
+    middleware({} as IncomingMessage, { end() {} } as ServerResponse);
+
+    expect(output[0].msg).toContain(
+      `"createNodeMiddleware(app, { Probot })" is deprecated. Use "createNodeMiddleware(app, { probot })" instead`
     );
   });
 });


### PR DESCRIPTION
addresses https://github.com/probot/probot/issues/1286#issuecomment-739597798

With this change, a `probot` instance is created outside of the request handler method, which makes it reusable across multiple requsets, see https://aws.amazon.com/blogs/compute/container-reuse-in-lambda/

-----
[View rendered docs/serverless-deployment.md](https://github.com/probot/probot/blob/deprecate-get-options/docs/serverless-deployment.md)