### PR TITLE
feat: un-deprecate `(app) => {}`. Deprecate `({ app, getRouter }) => {}` in favor of `(app, { getRouter }) => {}`

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/Bug_report.md
@@ -10,7 +10,7 @@ A clear and concise description of the behavior.
 
 ```js
 // Your code here
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.log.info("There is a bug");
 };
 ```

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you've ever thought, "wouldn't it be cool if GitHub could…"; I'm going to s
 **Probot is a framework for building [GitHub Apps](https://docs.github.com/en/developers/apps) in [Node.js](https://nodejs.org/)**, written in [TypeScript](https://www.typescriptlang.org/). GitHub Apps can listen to webhook events sent by a repository or organization. Probot uses its internal event emitter to perform actions based on those events. A simple Probot App might look like this:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Thanks for opening this issue!",

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -11,7 +11,7 @@ Se você já pensou, "não seria legal se o GitHub pudesse..."; Eu vou parar voc
 **Probot é um framework para construir [GitHub Apps](http://developer.github.com/apps) em [Node.js](https://nodejs.org/)**, escrito em [TypeScript](https://www.typescriptlang.org/). O GitHub Apps pode ouvir eventos de webhook enviados por um repositório ou organização. O Probot usa seu emissor de evento interno para executar ações com base nesses eventos. Um aplicativo Probot simples pode ter esta aparência:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     const issueComment = context.issue({
       body: "Obrigado por abrir esta issue!",

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -15,7 +15,7 @@ For example, users could add labels from comments by typing `/label in-progress`
 ```js
 const commands = require("probot-commands");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // Type `/label foo, bar` in a comment box for an Issue or Pull Request
   commands(app, "label", (context, command) => {
     const labels = command.arguments.split(/, */);
@@ -33,7 +33,7 @@ For example, here is a contrived app that stores the number of times that commen
 ```js
 const metadata = require("probot-metadata");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on(["issues.edited", "issue_comment.edited"], async (context) => {
     const kv = await metadata(context);
     await kv.set("edits", (await kv.get("edits")) || 1);
@@ -57,7 +57,7 @@ module.exports = ({ app }) => {
 ```js
 const attachments = require("probot-attachments");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issue_comment.created", (context) => {
     return attachments(context).add({
       title: "Hello World",

--- a/docs/github-api.md
+++ b/docs/github-api.md
@@ -15,7 +15,7 @@ Your app has access to an authenticated GitHub client that can be used to make A
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:
@@ -46,7 +46,7 @@ const addComment = `
   }
 `;
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // Post a comment on the issue
     context.octokit.graphql(addComment, {
@@ -69,7 +69,7 @@ const pinIssue = `
   }
 `;
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     context.octokit.graphql(pinIssue, {
       id: context.payload.issue.node_id,

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -7,7 +7,7 @@ next: docs/development.md
 A Probot app is just a [Node.js module](https://nodejs.org/api/modules.html) that exports a function:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // your code here
 };
 ```
@@ -17,7 +17,7 @@ The `app` parameter is an instance of [`Probot`](https://probot.github.io/api/la
 `app.on` will listen for any [webhook events triggered by GitHub](./webhooks.md), which will notify you when anything interesting happens on GitHub that your app wants to know about.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // A new issue was opened, what should we do with it?
     context.log.info(context.payload);
@@ -30,7 +30,7 @@ The `context` passed to the event handler includes everything about the event th
 Here is an example of an autoresponder app that comments on opened issues:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // `context` extracts information from the event, which can be passed to
     // GitHub API calls. This will return:

--- a/docs/http.md
+++ b/docs/http.md
@@ -7,7 +7,7 @@ next: docs/simulating-webhooks.md
 Calling `getRouter('/my-app')` will return an [express](http://expressjs.com/) router that you can use to expose HTTP endpoints from your app.
 
 ```js
-module.exports = ({ app, getRouter }) => {
+module.exports = (app, { getRouter }) => {
   // Get an express router to expose new HTTP endpoints
   const router = getRouter("/my-app");
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -9,7 +9,7 @@ A good logger is a good developer's secret weapon. Probot comes with [pino](http
 `app.log`, `context.log` in an event handler, and `req.log` in an HTTP request are all loggers that you can use to get more information about what your app is doing.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.log.info("Yay, my app is loaded");
 
   app.on("issues.opened", (context) => {
@@ -33,7 +33,7 @@ When you start up your app with `npm start`, You should see your log message app
 `app.log` will log messages at the `info` level, which is what your app should use for most relevant messages. Occasionally you will want to log more detailed information that is useful for debugging, but you might not want to see it all the time.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // …
   app.log.trace("Really low-level logging");
   app.log.debug({ data: "here" }, "End-line specs on the rotary girder");
@@ -62,7 +62,7 @@ When `NODE_ENV` is set (as it should be in production), the log output is struct
 For example, given this log:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issue_comment.created", (context) => {
     context.log.info("Comment created");
   });

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -7,7 +7,7 @@ next: docs/extensions.md
 Many GitHub API endpoints are paginated. The [`octokit.paginate` method](https://github.com/octokit/plugin-paginate-rest.js) can be used to get each page of the results.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", (context) => {
     context.octokit.paginate(
       context.octokit.issues.list,
@@ -27,7 +27,7 @@ module.exports = ({ app }) => {
 The return value of the `octokit.paginate` callback will be used to accumulate results.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     const allIssues = await context.octokit.paginate(
       context.octokit.issues.list,
@@ -44,7 +44,7 @@ module.exports = ({ app }) => {
 Sometimes it is desirable to stop fetching pages after a certain condition has been satisfied. A second argument, `done`, is provided to the callback and can be used to stop pagination. After `done` is invoked, no additional pages will be fetched, but you still need to return the mapped value for the current page request.
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", (context) => {
     context.octokit.paginate(
       context.octokit.issues.list,
@@ -68,7 +68,7 @@ module.exports = ({ app }) => {
 If your runtime environment supports async iterators (such as Node 10+), you can iterate through each response
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     for await (const response of octokit.paginate.iterator(
       context.octokit.issues.list,

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -63,7 +63,7 @@ mongoose.connect(mongoUri, {
 // Register the mongoose model
 const People = require("./PeopleSchema");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await People.find().exec();
@@ -104,7 +104,7 @@ module.exports = connection;
 const { sql } = require("@databases/mysql");
 const connection = require("./connection");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await connection.query(sql`SELECT * FROM people`);
@@ -145,7 +145,7 @@ module.exports = connection;
 const { sql } = require("@databases/pg");
 const connection = require("./connection");
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await connection.query(sql`SELECT * FROM people`);
@@ -186,7 +186,7 @@ firebase.initializeApp(config);
 
 const database = firebase.database();
 
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // Find all the people in the database
     const people = await database

--- a/docs/serverless-deployment.md
+++ b/docs/serverless-deployment.md
@@ -86,7 +86,7 @@ A probot middleware function should follow the following conventions:
 
 1. The package exports a synchronous function. The function name should follow the pattern `create[Platform]Middleware`
 2. The exported function should return a function matching the respective platform of the requirements
-3. The first argument should be a probot application function: `async ({ app }) => { ... }`
+3. The first argument should be a probot application function: `async (app) => { ... }`
 4. The 2nd argument should accept an object with at least a `probot` key, which has to be set to a Probot instance.
 
 Please share your own middleware by adding it to this list: [edit this page on GitHub](https://github.com/probot/probot/edit/master/docs/serverless-deployment.md).

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -9,7 +9,7 @@ next: docs/github-api.md
 Many apps will spend their entire day responding to these actions. `app.on` will listen for any GitHub webhook events:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("push", async (context) => {
     // Code was pushed to the repo, what should we do with it?
     app.log.info(context);
@@ -22,7 +22,7 @@ The app can listen to any of the [GitHub webhook events](https://developer.githu
 Most events also include an "action". For example, the [`issues`](https://developer.github.com/v3/activity/events/types/#issuesevent) event has actions of `assigned`, `unassigned`, `labeled`, `unlabeled`, `opened`, `edited`, `milestoned`, `demilestoned`, `closed`, and `reopened`. Often, your app will only care about one type of action, so you can append it to the event name with a `.`:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on("issues.opened", async (context) => {
     // An issue was just opened.
   });
@@ -32,7 +32,7 @@ module.exports = ({ app }) => {
 Sometimes you want to handle multiple webhook events the same way. `app.on` can listen to a list of events and run the same callback:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.on(["issues.opened", "issues.edited"], async (context) => {
     // An issue was opened or edited, what should we do with it?
     app.log.info(context);
@@ -43,7 +43,7 @@ module.exports = ({ app }) => {
 You can also use `app.webhooks.onAny()` to listen for any event that your app is subscribed to:
 
 ```js
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.webhooks.onAny(async (context) => {
     context.log.info({ event: context.event, action: context.payload.action });
   });

--- a/src/application.ts
+++ b/src/application.ts
@@ -40,7 +40,7 @@ export interface Options {
   webhooks?: Webhooks;
 
   /**
-   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"
+   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"
    */
   router?: Router;
   /**
@@ -146,12 +146,12 @@ export class Application {
   }
 
   /**
-   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"
+   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"
    */
   public get router() {
     this.log.warn(
       new Deprecation(
-        `[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"`
+        `[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"`
       )
     );
 
@@ -163,7 +163,7 @@ export class Application {
    * expose HTTP endpoints
    *
    * ```
-   * module.exports = ({ app, getRouter }) => {
+   * module.exports = (app, { getRouter }) => {
    *   // Get an express router to expose new HTTP endpoints
    *   const router = getRouter('/my-app');
    *
@@ -179,12 +179,12 @@ export class Application {
    *
    * @param path - the prefix for the routes* @param path
    *
-   * @deprecated "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"
+   * @deprecated "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"
    */
   route(path?: string) {
     this.log.warn(
       new Deprecation(
-        `[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"`
+        `[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"`
       )
     );
 

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -14,7 +14,7 @@ import { State } from "./types";
  * to wait for the magic to happen.
  *
  * ```js
- *  module.exports = ({ app }) => {
+ *  module.exports = (app) => {
  *    app.on('issues.opened', async context => {
  *      const octokit = await app.auth();
  *    });

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -241,7 +241,7 @@ export class Probot {
     })
 
     // load probot app function
-    await server.load(({ app }) => {})
+    await server.load(app => {})
 
     // start listening to requests
     await server.start()
@@ -283,7 +283,7 @@ If you have more than one app function, combine them in a function instead
     })
 
     // load probot app function
-    await server.load(({ app }) => {})
+    await server.load(app => {})
 
     // start listening to requests
     await server.start()
@@ -337,7 +337,7 @@ If you have more than one app function, combine them in a function instead
    * expose HTTP endpoints
    *
    * ```
-   * module.exports = ({ app, getRouter }) => {
+   * module.exports = (app, { getRouter }) => {
    *   // Get an express router to expose new HTTP endpoints
    *   const router = getRouter('/my-app');
    *
@@ -353,12 +353,12 @@ If you have more than one app function, combine them in a function instead
    *
    * @param path - the prefix for the routes* @param path
    *
-   * @deprecated "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"
+   * @deprecated "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"
    */
   route(path?: string) {
     this.log.warn(
       new Deprecation(
-        `[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"`
+        `[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"`
       )
     );
 
@@ -383,12 +383,12 @@ If you have more than one app function, combine them in a function instead
   }
 
   /**
-   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"
+   * @deprecated "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"
    */
   public get router() {
     this.log.warn(
       new Deprecation(
-        `[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"`
+        `[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"`
       )
     );
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -18,7 +18,7 @@ type AdditionalOptions = {
 
 /**
  *
- * @param appFnOrArgv set to either a probot application function: `({ app }) => { ... }` or to process.argv
+ * @param appFnOrArgv set to either a probot application function: `(app) => { ... }` or to process.argv
  */
 export async function run(
   appFnOrArgv: ApplicationFunction | string[],
@@ -107,7 +107,7 @@ export async function run(
   if (Array.isArray(appFnOrArgv)) {
     const pkg = await pkgConf("probot");
 
-    const combinedApps: ApplicationFunction = ({ app }) => {
+    const combinedApps: ApplicationFunction = (app) => {
       load(app, server.router(), defaultApp);
 
       if (Array.isArray(pkg.apps)) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ import Redis from "ioredis";
 import { Probot } from "./index";
 import { Context } from "./context";
 import { ProbotOctokit } from "./octokit/probot-octokit";
-import { Application } from "./application";
 
 import type { Logger, LogFn } from "pino";
 
@@ -67,21 +66,17 @@ export type ProbotWebhooks = Webhooks<
 
 export type DeprecatedLogger = LogFn & Logger;
 
-type deprecatedKeys =
-  | "router"
-  | "log"
-  | "on"
-  | "receive"
-  | "load"
-  | "route"
-  | "auth";
-
-export type ApplicationFunctionOptions = {
+export type GetRouter = (path?: string) => express.Router;
+export type ApplicationFunctionOptions = Probot & {
   /**
-   * @deprecated "(app) => {}" is deprecated. Use "({ app }) => {}" instead.
+   * @deprecated "({ app }) => {}" is deprecated (sorry!). We reverted back to the previous API "(app) => {}", see reasoning at https://github.com/probot/probot/issues/1286#issuecomment-744094299
    */
-  [K in deprecatedKeys]: Application[K];
-} & { app: Probot; getRouter: (path?: string) => express.Router };
+  app: Probot;
+  /**
+   * @deprecated "({ app, getRouter }) => {}" is deprecated. Use "(app, { getRouter }) => {}" instead
+   */
+  getRouter: GetRouter;
+};
 export type ApplicationFunction = (options: ApplicationFunctionOptions) => void;
 
 export type ServerOptions = {

--- a/test/create-node-middleware.test.ts
+++ b/test/create-node-middleware.test.ts
@@ -37,7 +37,7 @@ describe("createNodeMiddleware", () => {
   test("with createProbot", async () => {
     expect.assertions(1);
 
-    const app: ApplicationFunction = ({ app }) => {
+    const app: ApplicationFunction = (app) => {
       app.on("push", (event) => {
         expect(event.name).toEqual("push");
       });

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -189,9 +189,9 @@ describe("Deprecations", () => {
     );
   });
 
-  it("(app) => { app.on(event, handler) }", () => {
+  it("({ app }) => { app.on(event, handler) }", () => {
     const probot = new Probot({ log: pino(streamLogsToOutput) });
-    probot.load((app) => {
+    probot.load(({ app }) => {
       // test that deprecation is only logged once
       app.auth();
       app.on("push", () => {});
@@ -199,7 +199,19 @@ describe("Deprecations", () => {
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      '[probot] "(app) => {}" is deprecated. Use "({ app }) => {}" instead'
+      '[probot] "({ app }) => {}" is deprecated (sorry!). We reverted back to the previous API "(app) => {}", see reasoning at https://github.com/probot/probot/issues/1286#issuecomment-744094299'
+    );
+  });
+
+  it("({ getRouter }) => {}", () => {
+    const probot = new Probot({ log: pino(streamLogsToOutput) });
+    probot.load(({ getRouter }) => {
+      getRouter("test");
+    });
+
+    expect(output.length).toEqual(1);
+    expect(output[0].msg).toContain(
+      '[probot] "({ app, getRouter }) => {}" is deprecated. Use "(app, { getRouter }) => {}" instead'
     );
   });
 

--- a/test/deprecations.test.ts
+++ b/test/deprecations.test.ts
@@ -223,7 +223,7 @@ describe("Deprecations", () => {
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      '[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "({ app, getRouter }) => { ... }"'
+      '[probot] "app.router" is deprecated, use "getRouter()" from the app function instead: "(app, { getRouter }) => { ... }"'
     );
   });
 
@@ -235,7 +235,7 @@ describe("Deprecations", () => {
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      '[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"'
+      '[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"'
     );
   });
 
@@ -247,7 +247,7 @@ describe("Deprecations", () => {
 
     expect(output.length).toEqual(1);
     expect(output[0].msg).toContain(
-      '[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "({ app, getRouter }) => { ... }"'
+      '[probot] "app.route()" is deprecated, use the "getRouter()" argument from the app function instead: "(app, { getRouter }) => { ... }"'
     );
   });
 
@@ -320,7 +320,7 @@ describe("Deprecations", () => {
     process.env.WEBHOOK_PROXY_URL = "https://smee.io/EfHXC9BFfGAxbM6J";
     process.env.WEBHOOK_SECRET = "secret";
 
-    const probot = await Probot.run(({ app }) => {
+    const probot = await Probot.run((app) => {
       initialized = true;
     });
     expect(initialized).toBeTruthy();
@@ -370,7 +370,7 @@ describe("Deprecations", () => {
     })
 
     // load probot app function
-    await server.load(({ app }) => {})
+    await server.load(app => {})
 
     // start listening to requests
     await server.start()
@@ -397,7 +397,7 @@ describe("Deprecations", () => {
     })
 
     // load probot app function
-    await server.load(({ app }) => {})
+    await server.load(app => {})
 
     // start listening to requests
     await server.start()

--- a/test/e2e/hello-world.js
+++ b/test/e2e/hello-world.js
@@ -2,7 +2,7 @@
  *
  * @param {{app: import('../..').Probot}}
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   // Your code here
   app.log.info("Yay! The app was loaded!");
 

--- a/test/fixtures/example.js
+++ b/test/fixtures/example.js
@@ -1,7 +1,7 @@
 /**
  * @param {{app: import("../..".Probot)}}
  */
-module.exports = ({ app }) => {
+module.exports = (app) => {
   app.log.info("loaded app");
 
   app.on("issue_comment.created", async (context) => {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -71,7 +71,7 @@ describe("Server", () => {
         port: await getPort(),
       });
 
-      await server.load(({ app }) => {
+      await server.load((app) => {
         app.on("push", (event) => {
           expect(event.name).toEqual("push");
         });

--- a/test/webhook-event-check.test.ts
+++ b/test/webhook-event-check.test.ts
@@ -83,7 +83,7 @@ describe("webhook-event-check", () => {
     const probot = new Probot({ appId, privateKey });
     let spyOnLogError;
 
-    probot.load(async ({ app }) => {
+    probot.load(async (app) => {
       spyOnLogError = jest.spyOn(app.log, "error");
 
       app.webhooks.onAny(noop);


### PR DESCRIPTION
see discussion at https://github.com/probot/probot/issues/1286\#issuecomment-744094299

Once this is merged, the `beta` release needs to be adjusted accordingly. It will be a breaking change between beta.3 and beta.4, I will not introduce a deprecation during beta

-----
[View rendered .github/ISSUE_TEMPLATE/Bug_report.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/.github/ISSUE_TEMPLATE/Bug_report.md)
[View rendered README.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/README.md)
[View rendered README.pt-br.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/README.pt-br.md)
[View rendered docs/extensions.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/extensions.md)
[View rendered docs/github-api.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/github-api.md)
[View rendered docs/hello-world.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/hello-world.md)
[View rendered docs/http.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/http.md)
[View rendered docs/logging.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/logging.md)
[View rendered docs/pagination.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/pagination.md)
[View rendered docs/persistence.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/persistence.md)
[View rendered docs/serverless-deployment.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/serverless-deployment.md)
[View rendered docs/webhooks.md](https://github.com/probot/probot/blob/1438/revert-app-function-change/docs/webhooks.md)