### PR TITLE
docs(webhooks): typo in usage example

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -40,11 +40,11 @@ module.exports = ({ app }) => {
 };
 ```
 
-You can also use `app.onAny()` to listen for any event that your app is subscribed to:
+You can also use `app.webhooks.onAny()` to listen for any event that your app is subscribed to:
 
 ```js
 module.exports = ({ app }) => {
-  app.onAny(async (context) => {
+  app.webhooks.onAny(async (context) => {
     context.log.info({ event: context.event, action: context.payload.action });
   });
 };


### PR DESCRIPTION
Hi maintainers!! 👋🏽 

This is just a small typo in the [webhooks documentation](https://probot.github.io/docs/webhooks/).

-----
[View rendered docs/webhooks.md](https://github.com/homeles/probot/blob/master/docs/webhooks.md)