### PR TITLE
docs: remove probot-messages extension

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -68,7 +68,3 @@ module.exports = (app) => {
 ```
 
 Check out [probot/unfurl](https://github.com/probot/unfurl) to see it in action.
-
-## Community Created Extensions
-
-[probot-messages](https://github.com/dessant/probot-messages) was created by [@dessant](https://github.com/dessant) to deliver messages that require user action to ensure the correct operation of the app.


### PR DESCRIPTION
I won't have time to support the extension in the future, so it's best to remove it from the Probot docs.

-----
[View rendered docs/extensions.md](https://github.com/dessant/probot/blob/patch-1/docs/extensions.md)