### PR TITLE
fix: correctly import (transpiled) app function for run and receive

### DIFF
--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -9,85 +9,95 @@ import { getPrivateKey } from "@probot/get-private-key";
 import { getLog } from "../helpers/get-log";
 
 import { Probot } from "../";
+import { resolveAppFunction } from "../helpers/resolve-app-function";
 
-program
-  .usage("[options] [path/to/app.js...]")
-  .option(
-    "-e, --event <event-name>",
-    "Event name",
-    process.env.GITHUB_EVENT_NAME
-  )
-  .option(
-    "-p, --payload-path <payload-path>",
-    "Path to the event payload",
-    process.env.GITHUB_EVENT_PATH
-  )
-  .option(
-    "-t, --token <access-token>",
-    "Access token",
-    process.env.GITHUB_TOKEN
-  )
-  .option("-a, --app <id>", "ID of the GitHub App", process.env.APP_ID)
-  .option(
-    "-P, --private-key <file>",
-    "Path to private key file (.pem) for the GitHub App",
-    process.env.PRIVATE_KEY_PATH
-  )
-  .option(
-    "-L, --log-level <level>",
-    'One of: "trace" | "debug" | "info" | "warn" | "error" | "fatal"',
-    process.env.LOG_LEVEL
-  )
-  .option(
-    "--log-format <format>",
-    'One of: "pretty", "json"',
-    process.env.LOG_LEVEL || "pretty"
-  )
-  .option(
-    "--log-level-in-string",
-    "Set to log levels (trace, debug, info, ...) as words instead of numbers (10, 20, 30, ...)",
-    process.env.LOG_LEVEL_IN_STRING === "true"
-  )
-  .option(
-    "--sentry-dsn <dsn>",
-    'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"',
-    process.env.SENTRY_DSN
-  )
-  .parse(process.argv);
+async function main() {
+  program
+    .usage("[options] [path/to/app.js...]")
+    .option(
+      "-e, --event <event-name>",
+      "Event name",
+      process.env.GITHUB_EVENT_NAME
+    )
+    .option(
+      "-p, --payload-path <payload-path>",
+      "Path to the event payload",
+      process.env.GITHUB_EVENT_PATH
+    )
+    .option(
+      "-t, --token <access-token>",
+      "Access token",
+      process.env.GITHUB_TOKEN
+    )
+    .option("-a, --app <id>", "ID of the GitHub App", process.env.APP_ID)
+    .option(
+      "-P, --private-key <file>",
+      "Path to private key file (.pem) for the GitHub App",
+      process.env.PRIVATE_KEY_PATH
+    )
+    .option(
+      "-L, --log-level <level>",
+      'One of: "trace" | "debug" | "info" | "warn" | "error" | "fatal"',
+      process.env.LOG_LEVEL
+    )
+    .option(
+      "--log-format <format>",
+      'One of: "pretty", "json"',
+      process.env.LOG_LEVEL || "pretty"
+    )
+    .option(
+      "--log-level-in-string",
+      "Set to log levels (trace, debug, info, ...) as words instead of numbers (10, 20, 30, ...)",
+      process.env.LOG_LEVEL_IN_STRING === "true"
+    )
+    .option(
+      "--sentry-dsn <dsn>",
+      'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"',
+      process.env.SENTRY_DSN
+    )
+    .parse(process.argv);
 
-const githubToken = program.token;
+  const githubToken = program.token;
 
-if (!program.event || !program.payloadPath) {
-  program.help();
-}
+  if (!program.event || !program.payloadPath) {
+    program.help();
+  }
 
-const privateKey = getPrivateKey();
-if (!githubToken && (!program.app || !privateKey)) {
-  console.warn(
-    "No token specified and no certificate found, which means you will not be able to do authenticated requests to GitHub"
+  const privateKey = getPrivateKey();
+  if (!githubToken && (!program.app || !privateKey)) {
+    console.warn(
+      "No token specified and no certificate found, which means you will not be able to do authenticated requests to GitHub"
+    );
+  }
+
+  const payload = require(path.resolve(program.payloadPath));
+  const log = getLog({
+    level: program.logLevel,
+    logFormat: program.logFormat,
+    logLevelInString: program.logLevelInString,
+    sentryDsn: program.sentryDsn,
+  });
+
+  const probot = new Probot({
+    appId: program.app,
+    privateKey: String(privateKey),
+    githubToken: githubToken,
+    log,
+  });
+
+  const appFn = await resolveAppFunction(
+    path.resolve(process.cwd(), program.args[0])
   );
+  probot.load(appFn);
+
+  probot.log.debug("Receiving event", program.event);
+  probot.receive({ name: program.event, payload, id: uuidv4() }).catch(() => {
+    // Process must exist non-zero to indicate that the action failed to run
+    process.exit(1);
+  });
 }
 
-const payload = require(path.resolve(program.payloadPath));
-const log = getLog({
-  level: program.logLevel,
-  logFormat: program.logFormat,
-  logLevelInString: program.logLevelInString,
-  sentryDsn: program.sentryDsn,
-});
-
-const probot = new Probot({
-  appId: program.app,
-  privateKey: String(privateKey),
-  githubToken: githubToken,
-  log,
-});
-
-const appFn = require(path.resolve(process.cwd(), program.args[0]));
-probot.load(appFn);
-
-probot.log.debug("Receiving event", program.event);
-probot.receive({ name: program.event, payload, id: uuidv4() }).catch(() => {
-  // Process must exist non-zero to indicate that the action failed to run
+main().catch((error) => {
+  console.error(error);
   process.exit(1);
 });

--- a/src/helpers/resolve-app-function.ts
+++ b/src/helpers/resolve-app-function.ts
@@ -2,25 +2,18 @@ import { sync } from "resolve";
 
 const defaultOptions: ResolveOptions = {};
 
-export const resolveAppFunction = (appFnId: string, opts?: ResolveOptions) => {
+export const resolveAppFunction = async (
+  appFnId: string,
+  opts?: ResolveOptions
+) => {
   opts = opts || defaultOptions;
   // These are mostly to ease testing
   const basedir = opts.basedir || process.cwd();
   const resolver: Resolver = opts.resolver || sync;
   const appFnPath = resolver(appFnId, { basedir });
-  const mod = require(appFnPath);
-
-  if (typeof mod === "function") {
-    return mod;
-  }
-
-  // handle ES Module export transpiled to JS
-  // https://github.com/probot/probot/issues/1447
-  if (mod.__esModule && typeof mod.default === "function") {
-    return mod.default;
-  }
-
-  throw new Error(`[probot] now app function found at ${appFnPath}`);
+  const mod = await import(appFnPath);
+  // Note: This needs "esModuleInterop" to be set to "true" in "tsconfig.json"
+  return mod.default;
 };
 
 export type Resolver = (appFnId: string, opts: { basedir: string }) => string;

--- a/src/run.ts
+++ b/src/run.ts
@@ -109,13 +109,13 @@ export async function run(
 
       if (Array.isArray(pkg.apps)) {
         for (const appPath of pkg.apps) {
-          const appFn = resolveAppFunction(appPath);
+          const appFn = await resolveAppFunction(appPath);
           server.load(appFn);
         }
       }
 
       const [appPath] = args;
-      const appFn = resolveAppFunction(appPath);
+      const appFn = await resolveAppFunction(appPath);
       server.load(appFn);
     };
 

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -7,16 +7,16 @@ const stubTranspiledAppFnPath = require.resolve(
 const basedir = process.cwd();
 
 describe("resolver", () => {
-  it("loads the module at the resolved path", () => {
+  it("loads the module at the resolved path", async () => {
     const stubResolver = jest.fn().mockReturnValue(stubAppFnPath);
-    const module = resolveAppFunction("foo", { resolver: stubResolver });
+    const module = await resolveAppFunction("foo", { resolver: stubResolver });
     expect(module).toBe(require(stubAppFnPath));
     expect(stubResolver).toHaveBeenCalledWith("foo", { basedir });
   });
 
-  it("loads module transpiled from TypeScript (https://github.com/probot/probot/issues/1447)", () => {
+  it("loads module transpiled from TypeScript (https://github.com/probot/probot/issues/1447)", async () => {
     const stubResolver = jest.fn().mockReturnValue(stubTranspiledAppFnPath);
-    const module = resolveAppFunction("foo", { resolver: stubResolver });
+    const module = await resolveAppFunction("foo", { resolver: stubResolver });
     expect(module).toBe(require(stubTranspiledAppFnPath).default);
     expect(stubResolver).toHaveBeenCalledWith("foo", { basedir });
   });


### PR DESCRIPTION
There had been a fix previously #1448, to load transpiled app functions
for `probot run`.
This commit replaces the custom check for `.default` and `.__esModule`
properties with a dynamic import, which TypeScript compiles to a
`require` call that is capable of handling both, commonJS and ESM, as
long as `esModuleInterop` is set to `true` in probot's root
`tsconfig.json`.
Since a dynamic import is async, I had to wrap the `probot receive` CLI
in an async function.

*Tipp:* Add `?w=1` to the diff view, to ignore whitespace changes:
https://github.com/probot/probot/pull/1457/files?w=1