### PR TITLE
Enhance error message on wrong pem error

### DIFF
--- a/src/helpers/get-error-handler.ts
+++ b/src/helpers/get-error-handler.ts
@@ -23,7 +23,7 @@ export function getErrorHandler(log: Logger) {
       if (errMessage.includes("pem") || errMessage.includes("json web token")) {
         log.error(
           error,
-          "Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you're deploying to Now, visit https://probot.github.io/docs/deployment/#now."
+          "Your private key (a .pem file or PRIVATE_KEY environment variable) or APP_ID is incorrect. Go to https://github.com/settings/apps/YOUR_APP, verify that APP_ID is set correctly, and generate a new PEM file if necessary."
         );
         continue;
       }

--- a/test/__snapshots__/probot.test.ts.snap
+++ b/test/__snapshots__/probot.test.ts.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Probot webhooks responds with the correct error if the PEM file is missing 1`] = `"Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you're deploying to Now, visit https://probot.github.io/docs/deployment/#now."`;
+exports[`Probot webhooks responds with the correct error if the PEM file is missing 1`] = `"Your private key (a .pem file or PRIVATE_KEY environment variable) or APP_ID is incorrect. Go to https://github.com/settings/apps/YOUR_APP, verify that APP_ID is set correctly, and generate a new PEM file if necessary."`;
 
-exports[`Probot webhooks responds with the correct error if the jwt could not be decoded 1`] = `"Your private key (usually a .pem file) is not correct. Go to https://github.com/settings/apps/YOUR_APP and generate a new PEM file. If you're deploying to Now, visit https://probot.github.io/docs/deployment/#now."`;
+exports[`Probot webhooks responds with the correct error if the jwt could not be decoded 1`] = `"Your private key (a .pem file or PRIVATE_KEY environment variable) or APP_ID is incorrect. Go to https://github.com/settings/apps/YOUR_APP, verify that APP_ID is set correctly, and generate a new PEM file if necessary."`;
 
 exports[`Probot webhooks responds with the correct error if webhook secret does not match 1`] = `"Go to https://github.com/settings/apps/YOUR_APP and verify that the Webhook secret matches the value of the WEBHOOK_SECRET environment variable."`;
 


### PR DESCRIPTION
The invalid pem message can appear, when the pem is corrent but only the app_id is wrong. This could come from an reinstalltion of the app or migrating from local to prod.