### PR TITLE
fix(deps): pin version of @octokit/webhooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1193,9 +1193,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.18.1.tgz",
-      "integrity": "sha512-x16nd6IRFFwi+f7LmfNiuCT+QsKcFxxelTUm+tPYWZIIuUHh89/VIeAStozGSJ1+oOlTs3VF0F66iqub+cKcvg==",
+      "version": "7.21.0",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-7.21.0.tgz",
+      "integrity": "sha512-Mj7Pa6JZgSjfzQfYF3Bf5KpyhzEBv4kHbj2EjCB/vMQiZCiiW30j5rS6t/d0ZN0FBrlSOuJIT+YU8IJt30VyWA==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "aggregate-error": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@octokit/plugin-retry": "^3.0.6",
     "@octokit/plugin-throttling": "^3.3.4",
     "@octokit/types": "^6.1.1",
-    "@octokit/webhooks": "^7.18.1",
+    "@octokit/webhooks": "7.21.0",
     "@probot/get-private-key": "^1.1.0",
     "@probot/octokit-plugin-config": "^1.0.0",
     "@probot/pino": "^2.2.0",


### PR DESCRIPTION
The new types introduced in `@octokit/webhooks@7.22.0`, are incompatible with the current codebase. This will prevent users from getting anything newer than the pinned version in order to avoid type errors for end-users