### PR TITLE
Pass logger options to pino logging middleware

### DIFF
--- a/src/server/logging-middleware.ts
+++ b/src/server/logging-middleware.ts
@@ -2,7 +2,12 @@ import pinoHttp from "pino-http";
 import type { Logger } from "pino";
 import { v4 as uuidv4 } from "uuid";
 
-export function getLoggingMiddleware(logger: Logger) {
+export type LoggerOptions = pinoHttp.Options;
+
+export function getLoggingMiddleware(
+  logger: Logger,
+  options: LoggerOptions = {}
+) {
   return pinoHttp({
     logger: logger.child({ name: "http" }),
     customSuccessMessage(res) {
@@ -19,5 +24,6 @@ export function getLoggingMiddleware(logger: Logger) {
       req.headers["x-request-id"] ||
       req.headers["x-github-delivery"] ||
       uuidv4(),
+    ...options,
   });
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -42,7 +42,7 @@ export class Server {
       webhookProxy: options.webhookProxy,
     };
 
-    this.expressApp.use(getLoggingMiddleware(this.log));
+    this.expressApp.use(getLoggingMiddleware(this.log, options.loggerOptions));
     this.expressApp.use(
       "/probot/static/",
       express.static(join(__dirname, "..", "..", "static"))

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ import { Context } from "./context";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 
 import type { Logger, LogFn } from "pino";
+import { LoggerOptions } from "./server/logging-middleware";
 
 export interface Options {
   privateKey?: string;
@@ -65,6 +66,7 @@ export type ServerOptions = {
   webhookPath?: string;
   webhookProxy?: string;
   Probot: typeof Probot;
+  loggerOptions?: LoggerOptions;
 };
 
 export type MiddlewareOptions = {

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -63,6 +63,31 @@ describe("Server", () => {
     });
   });
 
+  describe("LoggerOptions", () => {
+    it("passes loggerOptions to logging middleware", async () => {
+      const testApp = new Server({
+        Probot: Probot.defaults({ appId, privateKey }),
+        port: 3003,
+        host: "127.0.0.1",
+        log: pino(streamLogsToOutput),
+        loggerOptions: {
+          autoLogging: {
+            ignorePaths: ["/ping"],
+          },
+        },
+      });
+      await testApp.start();
+
+      output = [];
+
+      await request(testApp.expressApp).get("/ping").expect(200, "PONG");
+
+      expect(output.length).toEqual(0);
+
+      await testApp.stop();
+    });
+  });
+
   describe("webhook handler (POST /)", () => {
     it("should return 200 and run event handlers in app function", async () => {
       expect.assertions(3);


### PR DESCRIPTION
This can be useful to ignore certain paths, like health checks.

Please let me know what you think of this change. AFAIR the previous major version didn't use pino and therefore something like the following was possible:
```javascript
router.get('/alive', (request, response) => {
    // disable logging on /alive route to not spam the logs
    request.log = null;
    response.type('text/plain').send('ALIVE');
  });
```
With this change it might couple the logger implementation (pino) a bit more into the server, so I'm not quite sure, if this is the right way to go.

Thanks for your feedback!