### PR TITLE
Fix url to Probot repo

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -213,7 +213,7 @@ Learn more
 
 Examples
 
-- Probot's "Hello, world!" example deployed as a GitHub Action: [probot/example-github-actions](https://github.com/probot/example-github-actions/#readme)
+- Probot's "Hello, world!" example deployed as a GitHub Action: [probot/example-github-action](https://github.com/probot/example-github-action/#readme)
 
 Please add yours!
 


### PR DESCRIPTION
The given url results in a 404 because it was misspelled.

-----
[View rendered docs/deployment.md](https://github.com/zkoppert/probot/blob/patch-1/docs/deployment.md)