### PR TITLE
docs: update sentence to include the word "use"

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -224,7 +224,7 @@ module.exports = createNodeMiddleware(app, { probot: createProbot() });
 
 ### Use `probot`
 
-If you don't Probot's http handling in order to receive and verify events from GitHub via webhook requests, you can use the [`Probot`](https://probot.github.io/api/latest/classes/probot.html) class directly.
+If you don't use Probot's http handling in order to receive and verify events from GitHub via webhook requests, you can use the [`Probot`](https://probot.github.io/api/latest/classes/probot.html) class directly.
 
 ```js
 const { Probot } = require("probot");


### PR DESCRIPTION
### What does this PR do?

Under the section, ["Use Probot"](https://probot.github.io/docs/development/#use-codeprobotcode), the first sentence is missing the word, `use`. This PR adds the word to the sentence.

-----
[View rendered docs/development.md](https://github.com/jaylenw/probot/blob/master/docs/development.md)