### PR TITLE
Allow passing probot instance to Server constructor

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -33,7 +33,7 @@ export class Server {
   constructor(options: ServerOptions = {} as ServerOptions) {
     this.expressApp = express();
     this.log = options.log || getLog().child({ name: "server" });
-    this.probotApp = new options.Probot();
+    this.probotApp = options.probotApp || new options.Probot();
 
     this.state = {
       port: options.port,


### PR DESCRIPTION
I want to use the `createProbot` helper with Server. But the helper returns the instance of Probot, while the Server constructor accept only the class.

This PR adds option `probotApp` to pass the instance to the Server constructor, and so allow to use `createProbot` with it.