### PR TITLE
feat: Add dark mode to builtin pages

### DIFF
--- a/views/import.hbs
+++ b/views/import.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="height-full">
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
 
 <head>
     <meta charset="UTF-8">

--- a/views/probot.hbs
+++ b/views/probot.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="height-full">
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/views/setup.hbs
+++ b/views/setup.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="height-full">
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/views/success.hbs
+++ b/views/success.hbs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" class="height-full">
+<html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
   <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
This adds a dark mode to all builtin pages.
Dark mode gets automatically enabled depending on the color scheme set in the browser/operating system-
This is a follow-up for #1508, which updated primer.css to a version that supports dark mode.

Here's how it looks on the setup page:
![grafik](https://user-images.githubusercontent.com/67546953/115401294-89b9b380-a1ea-11eb-94c4-b793a7627f58.png)
