### PR TITLE
Add await to probot and server load

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -125,13 +125,13 @@ export async function run(
       if (Array.isArray(pkg.apps)) {
         for (const appPath of pkg.apps) {
           const appFn = await resolveAppFunction(appPath);
-          server.load(appFn);
+          await server.load(appFn);
         }
       }
 
       const [appPath] = args;
       const appFn = await resolveAppFunction(appPath);
-      server.load(appFn);
+      await server.load(appFn);
     };
 
     server = new Server(serverOptions);


### PR DESCRIPTION
Some part already have an await some not. This should make it behave the same if the app has an async entry point.
Please let me know what you think.

One test fails for me (end-to-end-tests › hello-world app) but it does that even without my change.
