### PR TITLE
feat: deprecate usage of the "*" event name

### DIFF
--- a/src/probot.ts
+++ b/src/probot.ts
@@ -95,6 +95,7 @@ export class Probot {
 
     this.on = (eventNameOrNames, callback) => {
       if (eventNameOrNames === "*") {
+        this.log.warn(`Using the "*" event with the regular Probot.on() function is deprecated. Please use the Probot.onAny() method instead`)
         // @ts-ignore this.webhooks.on("*") is deprecated
         return this.webhooks.onAny(callback);
       }

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -95,7 +95,9 @@ export class Probot {
 
     this.on = (eventNameOrNames, callback) => {
       if (eventNameOrNames === "*") {
-        this.log.warn(`Using the "*" event with the regular Probot.on() function is deprecated. Please use the Probot.onAny() method instead`)
+        this.log.warn(
+          `Using the "*" event with the regular Probot.on() function is deprecated. Please use the Probot.onAny() method instead`
+        );
         // @ts-ignore this.webhooks.on("*") is deprecated
         return this.webhooks.onAny(callback);
       }

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -96,7 +96,7 @@ export class Probot {
     this.on = (eventNameOrNames, callback) => {
       if (eventNameOrNames === "*") {
         this.log.warn(
-          `Using the "*" event with the regular Probot.on() function is deprecated. Please use the Probot.onAny() method instead`
+          `[probot] Using the "*" event with the regular app.on() function is deprecated. Please use the app.webhooks.onAny() method instead`
         );
         // @ts-ignore this.webhooks.on("*") is deprecated
         return this.webhooks.onAny(callback);


### PR DESCRIPTION
As discussed in https://github.com/probot/probot/pull/1481#discussion_r622396089 it isn't possible to use this event any longer with further versions of `@octokit/webhooks`.
This logs a deprecation warning if users end up using it