### PR TITLE
fix(setup): do not enter setup mode if `HOST` environment variable is set

### DIFF
--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -21,7 +21,7 @@ export const setupAppFactory = (
     // If not on Glitch or Production, create a smee URL
     if (
       process.env.NODE_ENV !== "production" &&
-      !(process.env.PROJECT_DOMAIN || process.env.WEBHOOK_PROXY_URL)
+      !(process.env.PROJECT_DOMAIN || process.env.WEBHOOK_PROXY_URL || host)
     ) {
       await setup.createWebhookChannel();
     }

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -82,11 +82,13 @@ export class ManifestCreation {
       options
     );
 
-    const { id, webhook_secret, pem } = response.data;
+    const { id, client_id, client_secret, webhook_secret, pem } = response.data;
     await this.updateEnv({
       APP_ID: id.toString(),
       PRIVATE_KEY: `"${pem}"`,
       WEBHOOK_SECRET: webhook_secret,
+      GITHUB_CLIENT_ID: client_id,
+      GITHUB_CLIENT_SECRET: client_secret,
     });
 
     return response.data.html_url;

--- a/test/apps/__snapshots__/setup.test.ts.snap
+++ b/test/apps/__snapshots__/setup.test.ts.snap
@@ -10,6 +10,8 @@ Array [
   Array [
     Object {
       "APP_ID": "id",
+      "GITHUB_CLIENT_ID": "Iv1.8a61f9b3a7aba766",
+      "GITHUB_CLIENT_SECRET": "1726be1638095a19edd134c77bde3aa2ece1e5d8",
       "PRIVATE_KEY": "\\"pem\\"",
       "WEBHOOK_SECRET": "webhook_secret",
     },

--- a/test/apps/setup.test.ts
+++ b/test/apps/setup.test.ts
@@ -98,6 +98,8 @@ describe("Setup app", () => {
           id: "id",
           pem: "pem",
           webhook_secret: "webhook_secret",
+          client_id: "Iv1.8a61f9b3a7aba766",
+          client_secret: "1726be1638095a19edd134c77bde3aa2ece1e5d8",
         });
 
       await request(server.expressApp)


### PR DESCRIPTION
This adds the missing env settings:
- GITHUB_CLIENT_ID
- GITHUB_CLIENT_SECRET

This also skips creating the WEBHOOK_PROXY_URL when the host is defined and smee is not needed. This way the setup process through the web page '/probot/setup' will work without using smee.