### PR TITLE
fix: skipp smee setup without side effects of host variable

### DIFF
--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -21,7 +21,7 @@ export const setupAppFactory = (
     // If not on Glitch or Production, create a smee URL
     if (
       process.env.NODE_ENV !== "production" &&
-      !(process.env.PROJECT_DOMAIN || process.env.WEBHOOK_PROXY_URL || host)
+      !(process.env.PROJECT_DOMAIN || process.env.WEBHOOK_PROXY_URL || process.env.NO_SMEE_SETUP === 'true')
     ) {
       await setup.createWebhookChannel();
     }


### PR DESCRIPTION
Using the host variable did create side effect for some docker container. This should solve that.
Is there a good way to test a lib in typescript without publishing them?