### PR TITLE
fix: support setting `baseUrl` on Octokit constructor instead of Probot constructor

### DIFF
--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -43,10 +43,13 @@ export function getProbotOctokitWithDefaults(options: Options) {
     redisConfig: options.redisConfig,
   });
 
-  const defaultOptions: any = {
-    baseUrl: options.baseUrl,
+  let defaultOptions: any = {
     auth: authOptions,
   };
+
+  if (options.baseUrl) {
+    defaultOptions.baseUrl = options.baseUrl;
+  }
 
   if (octokitThrottleOptions) {
     defaultOptions.throttle = octokitThrottleOptions;

--- a/test/probot.test.ts
+++ b/test/probot.test.ts
@@ -216,6 +216,23 @@ describe("Probot", () => {
         baseUrl: "https://notreallygithub.com/api/v3",
       }).load(appFn);
     });
+
+    it("requests from the correct API URL when setting `baseUrl` on Octokit constructor", async () => {
+      const appFn = async (app: Probot) => {
+        const octokit = await app.auth();
+        expect(octokit.request.endpoint.DEFAULTS.baseUrl).toEqual(
+          "https://notreallygithub.com/api/v3"
+        );
+      };
+
+      new Probot({
+        appId,
+        privateKey,
+        Octokit: ProbotOctokit.defaults({
+          baseUrl: "https://notreallygithub.com/api/v3",
+        }),
+      }).load(appFn);
+    });
   });
 
   describe("ghe support with http", () => {


### PR DESCRIPTION
fixes #1522
