### PR TITLE
docs: Correct wrong link to `Developing an App` page

### DIFF
--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -44,7 +44,7 @@ module.exports = (app) => {
 };
 ```
 
-To get started, you can use the instructions for [Developing an App](https://probot.github.io/docs/development/) or remix this 'Hello World' project on Glitch:
+To get started, you can use the instructions for [Developing an App](/docs/development/) or remix this 'Hello World' project on Glitch:
 
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/probot-hello-world)
 

--- a/docs/hello-world.md
+++ b/docs/hello-world.md
@@ -44,7 +44,7 @@ module.exports = (app) => {
 };
 ```
 
-To get started, you can use the instructions for [Developing an App](./development.md) or remix this 'Hello World' project on Glitch:
+To get started, you can use the instructions for [Developing an App](https://probot.github.io/docs/development/) or remix this 'Hello World' project on Glitch:
 
 [![Remix on Glitch](https://cdn.glitch.com/2703baf2-b643-4da7-ab91-7ee2a2d00b5b%2Fremix-button.svg)](https://glitch.com/edit/#!/remix/probot-hello-world)
 


### PR DESCRIPTION
Currently, the link to `Developing an App` on https://probot.github.io/docs/hello-world/ points to https://probot.github.io/docs/hello-world/development.md which does not exist. This PR fixes that.

-----
[View rendered docs/hello-world.md](https://github.com/tnorthcutt/probot/blob/patch-1/docs/hello-world.md)