### PR TITLE
ci(docs): do not update docs when tags are created

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,9 +3,6 @@ on:
   push:
     branches:
       - master
-    tags:
-      # TODO: only update docs for tags that match npm's @latest version
-      - v10.*
 
 jobs:
   docs:


### PR DESCRIPTION
close #1327

For a long time now tags are created using a GItHub Action using `secrets.GITHUB_TOKEN`, so other actions don't act on it anyway