### PR TITLE
docs: fix broken image link in development doc

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -113,7 +113,7 @@ To automatically configure your GitHub App, follow these steps:
 
 1. Run the app locally by running `npm start` in your terminal.
 1. Next follow instructions to visit [http://localhost:3000](http://localhost:3000) (or your custom Glitch URL).
-1. You should see something like this: ![Screenshot of Probot's setup wizzard](/docs/assets/probot-setup-wizzard.png)
+1. You should see something like this: ![Screenshot of Probot's setup wizard](/assets/img/probot-setup-wizard.png)
 1. Go ahead and click the **Register a GitHub App** button.
 1. Next, you'll get to decide on an app name that isn't already taken. Note: if you see a message "Name is already in use" although no such app exists, it means that a GitHub organization with that name exists and cannot be used as an app name.
 1. After registering your GitHub App, you'll be redirected to install the app on any repositories. At the same time, you can check your local `.env` and notice it will be populated with values GitHub sends us in the course of that redirect.


### PR DESCRIPTION
There is a broken image link for "Screenshot of Probot's setup wizzard" in `docs/development.md` (also wizard is misspelled). This corrects the link and the misspelling.

-----
[View rendered docs/development.md](https://github.com/lisadean/probot/blob/fix-broken-image-link/docs/development.md)