### PR TITLE
feat: allow to run receive with github enterprise

### DIFF
--- a/docs/simulating-webhooks.md
+++ b/docs/simulating-webhooks.md
@@ -22,3 +22,8 @@ Note that `event-name` here is just the name of the event (like pull_request or 
 For example, to simulate receiving the `pull_request.labeled` event, run:
 
     $ node_modules/.bin/probot receive -e pull_request -p test/fixtures/pull_request.labeled.json ./index.js
+
+## GitHub Enterprise
+
+To use this feature for testing with GitHub Enterprise you can call
+the CLI with `--host <your-ghe-host>` (e.g. `https://your.company.com/github/api/v3`).

--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -60,9 +60,15 @@ async function main() {
       'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"',
       process.env.SENTRY_DSN
     )
+    .option(
+      "--host <host>",
+      'Set to your gihtub host (to support github enterprise), e.g. "https://your.github.com/api/v3"',
+      process.env.GHE_HOST || "https://api.github.com"
+    )
     .parse(process.argv);
 
   const githubToken = program.token;
+  const githubHost = program.host;
 
   if (!program.event || !program.payloadPath) {
     program.help();
@@ -88,6 +94,7 @@ async function main() {
     appId: program.app,
     privateKey: String(privateKey),
     githubToken: githubToken,
+    baseUrl: githubHost,
     log,
   });
 


### PR DESCRIPTION
This will add the option `--host` to the probot-receive script.
It allows to execute it against github enterprise instances.