### PR TITLE
docs: add `webhooksPath` option for `createNodeMiddleware`

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -283,13 +283,11 @@ Please add yours!
 const { createNodeMiddleware, createProbot } = require("probot");
 
 const app = require("../../../app");
-const probot = createProbot({
-  defaults: {
-    webhookPath: "/api/github/webhooks",
-  },
-});
 
-module.exports = createNodeMiddleware(app, { probot });
+module.exports = createNodeMiddleware(app, {
+  probot: createProbot(),
+  webhooksPath: "/api/github/webhooks",
+});
 ```
 
 Examples
@@ -297,6 +295,7 @@ Examples
 - [probot/example-vercel](https://github.com/probot/example-vercel#readme)
 - [wip/app](https://github.com/wip/app#readme)
 - [all-contributors/app](https://github.com/all-contributors/app#readme)
+- [probot-nextjs-starter](https://github.com/maximousblk/probot-nextjs-starter#readme)
 
 Please add yours!
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -212,7 +212,7 @@ const probot = new Probot({
   secret: "webhooksecret123",
 });
 
-module.exports = createNodeMiddleware(app, { probot, webhooksPath: '/path/to/webhook/endpoint' });
+module.exports = createNodeMiddleware(app, { probot });
 ```
 
 If you want to read probot's configuration from the same environment variables as [`run`](#run), use the [`createProbot`](https://probot.github.io/api/latest/index.html#createprobot) export
@@ -221,6 +221,12 @@ If you want to read probot's configuration from the same environment variables a
 const { createNodeMiddleware, createProbot } = require("probot");
 const app = require("./index.js");
 
+module.exports = createNodeMiddleware(app, { probot: createProbot() });
+```
+
+By default, `createNodeMiddleware()` uses `/` as the webhook endpoint. To customize this behaviour, you can use the `webhooksPath` option.
+
+```js
 module.exports = createNodeMiddleware(app, { probot: createProbot(), webhooksPath: '/path/to/webhook/endpoint' });
 ```
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -227,7 +227,10 @@ module.exports = createNodeMiddleware(app, { probot: createProbot() });
 By default, `createNodeMiddleware()` uses `/` as the webhook endpoint. To customize this behaviour, you can use the `webhooksPath` option.
 
 ```js
-module.exports = createNodeMiddleware(app, { probot: createProbot(), webhooksPath: '/path/to/webhook/endpoint' });
+module.exports = createNodeMiddleware(app, {
+  probot: createProbot(),
+  webhooksPath: "/path/to/webhook/endpoint",
+});
 ```
 
 ### Use probot

--- a/docs/development.md
+++ b/docs/development.md
@@ -200,7 +200,7 @@ The `server` instance gives you access to the express app instance (`server.expr
 
 ### Use createNodeMiddleware
 
-If you have your own server or deploy to a serverless environment like that supports loading [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) or Node's http middleware (`(request, response) => { ... }`), you can use `createNodeMiddleware`.
+If you have your own server or deploy to a serverless environment that supports loading [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) or Node's http middleware (`(request, response) => { ... }`), you can use `createNodeMiddleware`.
 
 ```js
 const { createNodeMiddleware, Probot } = require("probot");

--- a/docs/development.md
+++ b/docs/development.md
@@ -200,7 +200,7 @@ The `server` instance gives you access to the express app instance (`server.expr
 
 ### Use createNodeMiddleware
 
-If you have your own server or deploy to a serverless environment that supports loading [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) or Node's http middleware (`(request, response) => { ... }`), you can use `createNodeMiddleware`.
+If you have your own server or deploy to a serverless environment like that supports loading [Express-style middleware](https://expressjs.com/en/guide/using-middleware.html) or Node's http middleware (`(request, response) => { ... }`), you can use `createNodeMiddleware`.
 
 ```js
 const { createNodeMiddleware, Probot } = require("probot");
@@ -212,7 +212,7 @@ const probot = new Probot({
   secret: "webhooksecret123",
 });
 
-module.exports = createNodeMiddleware(app, { probot });
+module.exports = createNodeMiddleware(app, { probot, webhooksPath: '/path/to/webhook/endpoint' });
 ```
 
 If you want to read probot's configuration from the same environment variables as [`run`](#run), use the [`createProbot`](https://probot.github.io/api/latest/index.html#createprobot) export
@@ -221,7 +221,7 @@ If you want to read probot's configuration from the same environment variables a
 const { createNodeMiddleware, createProbot } = require("probot");
 const app = require("./index.js");
 
-module.exports = createNodeMiddleware(app, { probot: createProbot() });
+module.exports = createNodeMiddleware(app, { probot: createProbot(), webhooksPath: '/path/to/webhook/endpoint' });
 ```
 
 ### Use probot


### PR DESCRIPTION
This PR adds the missing `webhooksPath` option to the docs for `createNodeMiddleware`

fixes: #1587 

-----
[View rendered docs/development.md](https://github.com/maximousblk/probot/blob/patch-1/docs/development.md)