### PR TITLE
fix: added definite type so that caller does not get warnings

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -61,7 +61,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    * @param object - Params to be merged with the repo params.
    *
    */
-  public repo<T>(object?: T) {
+  public repo<T>(object?: T): { owner: string; repo: string; } & T {
     // @ts-ignore `repository` is not always present in this.payload
     const repo = this.payload.repository;
 
@@ -92,7 +92,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the issue params.
    */
-  public issue<T>(object?: T) {
+  public issue<T>(object?: T): { owner: string; repo: string; issue_number: number; } & T {
     return Object.assign(
       {
         issue_number:
@@ -116,7 +116,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the pull request params.
    */
-  public pullRequest<T>(object?: T) {
+  public pullRequest<T>(object?: T): { owner: string; repo: string; pull_number: number; } & T {
     const payload = this.payload;
     return Object.assign(
       {

--- a/src/context.ts
+++ b/src/context.ts
@@ -14,21 +14,39 @@ export type MergeOptions = merge.Options;
 
 /** Repo owner type, either string or never depending on the context */
 type RepoOwnerType<T extends WebhookEvents> =
-  WebhookEvent<T>["payload"] extends { repository: { owner: { login: string } } } ? string : never |
-  WebhookEvent<T>["payload"] extends { repository: { owner: { name: string } } } ? string : never;
+  WebhookEvent<T>["payload"] extends {
+    repository: { owner: { login: string } };
+  }
+    ? string
+    : never | WebhookEvent<T>["payload"] extends {
+        repository: { owner: { name: string } };
+      }
+    ? string
+    : never;
 
 /** Repo name type, either string or never depending on the context */
 type RepoNameType<T extends WebhookEvents> =
-  WebhookEvent<T>["payload"] extends { repository: { name: string } } ? string : never;
+  WebhookEvent<T>["payload"] extends { repository: { name: string } }
+    ? string
+    : never;
 
 /** Issue type (also pull request number), either number or never depending on the context */
 type RepoIssueNumberType<T extends WebhookEvents> =
-  WebhookEvent<T>["payload"] extends { issue: { number: number } } ? number : never |
-  WebhookEvent<T>["payload"] extends { pull_request: { number: number } } ? number : never |
-  WebhookEvent<T>["payload"] extends { number: number } ? number : never;
+  WebhookEvent<T>["payload"] extends { issue: { number: number } }
+    ? number
+    : never | WebhookEvent<T>["payload"] extends {
+        pull_request: { number: number };
+      }
+    ? number
+    : never | WebhookEvent<T>["payload"] extends { number: number }
+    ? number
+    : never;
 
 /** Context.repo return type */
-type RepoResultType<E extends WebhookEvents> = { owner: RepoOwnerType<E>; repo: RepoNameType<E>; };
+type RepoResultType<E extends WebhookEvents> = {
+  owner: RepoOwnerType<E>;
+  repo: RepoNameType<E>;
+};
 
 /**
  * The context of the event that was triggered, including the payload and
@@ -110,7 +128,9 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the issue params.
    */
-  public issue<T>(object?: T): RepoResultType<E> & { issue_number: RepoIssueNumberType<E>; } & T {
+  public issue<T>(
+    object?: T
+  ): RepoResultType<E> & { issue_number: RepoIssueNumberType<E> } & T {
     return Object.assign(
       {
         issue_number:
@@ -134,7 +154,9 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the pull request params.
    */
-  public pullRequest<T>(object?: T): RepoResultType<E> & { pull_number: RepoIssueNumberType<E>; } & T {
+  public pullRequest<T>(
+    object?: T
+  ): RepoResultType<E> & { pull_number: RepoIssueNumberType<E> } & T {
     const payload = this.payload;
     return Object.assign(
       {

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,6 +12,24 @@ import { EmitterWebhookEventName as WebhookEvents } from "@octokit/webhooks/dist
 
 export type MergeOptions = merge.Options;
 
+/** Repo owner type, either string or never depending on the context */
+type RepoOwnerType<T extends WebhookEvents> =
+  WebhookEvent<T>["payload"] extends { repository: { owner: { login: string } } } ? string : never |
+  WebhookEvent<T>["payload"] extends { repository: { owner: { name: string } } } ? string : never;
+
+/** Repo name type, either string or never depending on the context */
+type RepoNameType<T extends WebhookEvents> =
+  WebhookEvent<T>["payload"] extends { repository: { name: string } } ? string : never;
+
+/** Issue type (also pull request number), either number or never depending on the context */
+type RepoIssueNumberType<T extends WebhookEvents> =
+  WebhookEvent<T>["payload"] extends { issue: { number: number } } ? number : never |
+  WebhookEvent<T>["payload"] extends { pull_request: { number: number } } ? number : never |
+  WebhookEvent<T>["payload"] extends { number: number } ? number : never;
+
+/** Context.repo return type */
+type RepoResultType<E extends WebhookEvents> = { owner: RepoOwnerType<E>; repo: RepoNameType<E>; };
+
 /**
  * The context of the event that was triggered, including the payload and
  * helpers for extracting information can be passed to GitHub API calls.
@@ -61,7 +79,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    * @param object - Params to be merged with the repo params.
    *
    */
-  public repo<T>(object?: T): { owner: string; repo: string; } & T {
+  public repo<T>(object?: T): RepoResultType<E> & T {
     // @ts-ignore `repository` is not always present in this.payload
     const repo = this.payload.repository;
 
@@ -92,7 +110,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the issue params.
    */
-  public issue<T>(object?: T): { owner: string; repo: string; issue_number: number; } & T {
+  public issue<T>(object?: T): RepoResultType<E> & { issue_number: RepoIssueNumberType<E>; } & T {
     return Object.assign(
       {
         issue_number:
@@ -116,7 +134,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    *
    * @param object - Params to be merged with the pull request params.
    */
-  public pullRequest<T>(object?: T): { owner: string; repo: string; pull_number: number; } & T {
+  public pullRequest<T>(object?: T): RepoResultType<E> & { pull_number: RepoIssueNumberType<E>; } & T {
     const payload = this.payload;
     return Object.assign(
       {


### PR DESCRIPTION
This will give typescript the correct return type.

My ts compiler complains about the any type, this should fix it.
Only question would be if the context type does not support some of the properties the correct type would be undefined.
This would mask the error.
The first commit is the easy solution, the second uses conditional types to detect that problem.

Let me know what you think.
Should I add export to the types?