### PR TITLE
refactor: remove fallback to `.owner.name` when `.owner.login` is not set. `.owner.login` is always set

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   },
   "scripts": {
     "build": "rimraf lib && tsc -p tsconfig.json",
-    "lint": "prettier --check 'src/**/*.ts' 'test/**/*.ts' 'docs/*.md' *.md package.json tsconfig.json",
-    "lint:fix": "prettier --write 'src/**/*.ts' 'test/**/*.ts' 'docs/*.md' *.md package.json tsconfig.json",
+    "lint": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
+    "lint:fix": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "pretest": "tsc --noEmit -p test",
     "test": "jest",
     "posttest": "npm run lint",

--- a/src/context.ts
+++ b/src/context.ts
@@ -18,10 +18,6 @@ type RepoOwnerType<T extends WebhookEvents> =
     repository: { owner: { login: string } };
   }
     ? string
-    : never | WebhookEvent<T>["payload"] extends {
-        repository: { owner: { name: string } };
-      }
-    ? string
     : never;
 
 /** Repo name type, either string or never depending on the context */
@@ -109,7 +105,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
 
     return Object.assign(
       {
-        owner: repo.owner.login || repo.owner.name,
+        owner: repo.owner.login,
         repo: repo.name,
       },
       object

--- a/test/fixtures/webhook/push.json
+++ b/test/fixtures/webhook/push.json
@@ -57,7 +57,8 @@
     "full_name": "bkeepers-inc/test",
     "owner": {
       "name": "bkeepers-inc",
-      "email": null
+      "email": null,
+      "login": "bkeepers-inc"
     },
     "private": true,
     "html_url": "https://github.com/bkeepers-inc/test",


### PR DESCRIPTION
This also should fix the prettier config for windows user.

Please let me know if you think there are any problems. 