### PR TITLE
build(package): bump package and package-lock

### DIFF
--- a/.typedoc.json
+++ b/.typedoc.json
@@ -1,17 +1,13 @@
 {
-  "mode": "file",
+  "entryPoints": ["src"],
   "out": "out",
   "exclude": "test",
-  "theme": "minimal",
+  "theme": "default",
   "excludePrivate": true,
-  "excludeNotExported": true,
   "excludeExternals": true,
   "listInvalidSymbolLinks": true,
-  "target": "ES5",
-  "moduleResolution": "node",
-  "preserveConstEnums": "true",
-  "stripInternal": "true",
-  "module": "commonjs",
+  "excludeInternal": true,
+  "entryPointStrategy": "expand",
   "readme": "none",
   "gaID": "UA-102577034-2"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "dotenv": "^8.2.0",
         "eventsource": "^1.0.7",
         "express": "^4.17.1",
-        "hbs": "^4.1.1",
+        "hbs": "^4.2.0",
         "ioredis": "^4.27.8",
         "js-yaml": "^3.14.1",
         "lru-cache": "^6.0.0",
@@ -79,7 +79,7 @@
         "supertest": "^6.0.1",
         "ts-jest": "^26.4.4",
         "tsd": "^0.14.0",
-        "typedoc": "^0.19.2",
+        "typedoc": "^0.22.10",
         "typescript": "^4.1.2"
       },
       "engines": {
@@ -775,27 +775,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/@jest/core/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/core/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/environment": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-26.6.2.tgz",
@@ -1126,9 +1105,9 @@
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
     },
     "node_modules/@octokit/plugin-enterprise-compatibility": {
       "version": "1.3.0",
@@ -1140,11 +1119,11 @@
       }
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.5.tgz",
-      "integrity": "sha512-3WSAKBLa1RaR/7GG+LQR/tAZ9fp9H9waE9aPXallidyci9oZsfgsLn5M836d3LuDC6Fcym+2idRTBpssHZePVg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
       "dependencies": {
-        "@octokit/types": "^6.13.0"
+        "@octokit/types": "^6.34.0"
       },
       "peerDependencies": {
         "@octokit/core": ">=2"
@@ -1160,11 +1139,11 @@
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
       "dependencies": {
-        "@octokit/types": "^6.16.2",
+        "@octokit/types": "^6.34.0",
         "deprecation": "^2.3.1"
       },
       "peerDependencies": {
@@ -1216,23 +1195,23 @@
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.0.tgz",
-      "integrity": "sha512-MdHuXHDJM7e5sUBe3K9tt7th0cs4csKU5Bb52LRi2oHAeIMrMZ4XqaTrEv660HoUPoM1iDlnj27Ab/Nh3MtwlA==",
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
       "dev": true,
       "dependencies": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
       "dependencies": {
-        "@octokit/openapi-types": "^7.3.2"
+        "@octokit/openapi-types": "^11.2.0"
       }
     },
     "node_modules/@octokit/webhooks": {
@@ -1375,9 +1354,9 @@
       }
     },
     "node_modules/@semantic-release/github/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "bin": {
         "mime": "cli.js"
@@ -1968,9 +1947,9 @@
       }
     },
     "node_modules/@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
     "node_modules/@types/semver": {
@@ -2146,24 +2125,11 @@
       }
     },
     "node_modules/ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "dependencies": {
-        "string-width": "^3.0.0"
-      }
-    },
-    "node_modules/ansi-align/node_modules/string-width": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-      "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-      "dependencies": {
-        "emoji-regex": "^7.0.1",
-        "is-fullwidth-code-point": "^2.0.0",
-        "strip-ansi": "^5.1.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "string-width": "^4.1.0"
       }
     },
     "node_modules/ansi-escapes": {
@@ -2194,11 +2160,11 @@
       }
     },
     "node_modules/ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "engines": {
-        "node": ">=6"
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2348,15 +2314,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
       "dev": true
-    },
-    "node_modules/at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/atob": {
       "version": "2.1.2",
@@ -3089,16 +3046,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+    "node_modules/cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "dependencies": {
-        "colors": "1.0.3"
+        "string-width": "^4.2.0"
       },
       "engines": {
-        "node": ">= 0.2.0"
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "colors": "1.4.0"
       }
     },
     "node_modules/cliui": {
@@ -3110,15 +3070,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.0",
         "wrap-ansi": "^6.2.0"
-      }
-    },
-    "node_modules/cliui/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/cliui/node_modules/ansi-styles": {
@@ -3153,18 +3104,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/cliui/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/cliui/node_modules/wrap-ansi": {
       "version": "6.2.0",
@@ -3245,10 +3184,11 @@
       "dev": true
     },
     "node_modules/colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true,
+      "optional": true,
       "engines": {
         "node": ">=0.1.90"
       }
@@ -3345,9 +3285,9 @@
       }
     },
     "node_modules/conventional-changelog-angular": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
-      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dev": true,
       "dependencies": {
         "compare-func": "^2.0.0",
@@ -3413,9 +3353,9 @@
       }
     },
     "node_modules/conventional-commits-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
-      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "dependencies": {
         "is-text-path": "^1.0.1",
@@ -3423,8 +3363,7 @@
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
-        "through2": "^4.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "through2": "^4.0.0"
       },
       "bin": {
         "conventional-commits-parser": "cli.js"
@@ -3477,15 +3416,15 @@
       }
     },
     "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "node_modules/cosmiconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "dependencies": {
         "@types/parse-json": "^4.0.0",
@@ -3952,11 +3891,6 @@
         "url": "https://github.com/sindresorhus/emittery?sponsor=1"
       }
     },
-    "node_modules/emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
     "node_modules/encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -3974,63 +3908,17 @@
       }
     },
     "node_modules/env-ci": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
-      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
       "dependencies": {
-        "execa": "^4.0.0",
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
         "java-properties": "^1.0.0"
       },
       "engines": {
-        "node": ">=10.13"
-      }
-    },
-    "node_modules/env-ci/node_modules/execa": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-      "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-      "dev": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.0",
-        "get-stream": "^5.0.0",
-        "human-signals": "^1.1.1",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.0",
-        "onetime": "^5.1.0",
-        "signal-exit": "^3.0.2",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/env-ci/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/env-ci/node_modules/human-signals": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true,
-      "engines": {
-        "node": ">=8.12.0"
+        "node": ">=10.17"
       }
     },
     "node_modules/error-ex": {
@@ -4773,6 +4661,26 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
     "node_modules/fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -4958,9 +4866,9 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "dependencies": {
         "fs.realpath": "^1.0.0",
@@ -5348,25 +5256,16 @@
       }
     },
     "node_modules/hbs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.1.2.tgz",
-      "integrity": "sha512-WfBnQbozbdiTLjJu6P6Wturgvy0FN8xtRmIjmP0ebX9OGQrt+2S6UC7xX0IebHTCS1sXe20zfTzQ7yhjrEvrfQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.2.0.tgz",
+      "integrity": "sha512-dQwHnrfWlTk5PvG9+a45GYpg0VpX47ryKF8dULVd6DtwOE6TEcYQXQ5QM6nyOx/h7v3bvEQbdn19EDAcfUAgZg==",
       "dependencies": {
         "handlebars": "4.7.7",
-        "walk": "2.3.14"
+        "walk": "2.3.15"
       },
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
-      }
-    },
-    "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/hook-std": {
@@ -5595,15 +5494,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/into-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
@@ -5718,9 +5608,9 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "dependencies": {
         "has": "^1.0.3"
       },
@@ -5807,14 +5697,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/is-generator-fn": {
@@ -6898,6 +6780,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -7171,12 +7059,6 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
-    "node_modules/lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "node_modules/lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -7300,32 +7182,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.2.tgz",
-      "integrity": "sha512-ueJhIvklJJw04qxQbGIAu63EXwwOCYc7yKMBjgagTM4rjC5QtWyqSNgW7jCosV1/Km/1TUfs5qEpAqcGG0Mo5g==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
       "dev": true,
       "bin": {
         "marked": "bin/marked"
       },
       "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/marked-terminal": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
-      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
-      "dev": true,
-      "dependencies": {
-        "ansi-escapes": "^4.3.1",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table": "^0.3.1",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
-      },
-      "peerDependencies": {
-        "marked": "^1.0.0 || ^2.0.0"
+        "node": ">= 12"
       }
     },
     "node_modules/media-typer": {
@@ -7362,9 +7227,9 @@
       }
     },
     "node_modules/meow/node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -7374,13 +7239,13 @@
       }
     },
     "node_modules/meow/node_modules/normalize-package-data": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-      "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
       "dev": true,
       "dependencies": {
         "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
+        "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
@@ -7717,12 +7582,12 @@
       }
     },
     "node_modules/node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "dependencies": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node_modules/node-fetch": {
@@ -7808,25 +7673,28 @@
       }
     },
     "node_modules/npm": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.18.1.tgz",
-      "integrity": "sha512-fu7rMtc4ZaDnFlZsiLhqwWWs6KixOcBGiBLoJH+AbuaznwtT8mYQnq5nGNN14Jib+E9OjkjNRgg+X45Ia9xtKQ==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "bundleDependencies": [
+        "@isaacs/string-locale-compare",
         "@npmcli/arborist",
         "@npmcli/ci-detect",
         "@npmcli/config",
+        "@npmcli/map-workspaces",
+        "@npmcli/package-json",
         "@npmcli/run-script",
         "abbrev",
         "ansicolors",
         "ansistyles",
         "archy",
-        "byte-size",
         "cacache",
         "chalk",
         "chownr",
         "cli-columns",
         "cli-table3",
         "columnify",
+        "fastest-levenshtein",
         "glob",
         "graceful-fs",
         "hosted-git-info",
@@ -7834,7 +7702,6 @@
         "init-package-json",
         "is-cidr",
         "json-parse-even-better-errors",
-        "leven",
         "libnpmaccess",
         "libnpmdiff",
         "libnpmexec",
@@ -7855,6 +7722,7 @@
         "node-gyp",
         "nopt",
         "npm-audit-report",
+        "npm-install-checks",
         "npm-package-arg",
         "npm-pick-manifest",
         "npm-profile",
@@ -7882,73 +7750,76 @@
       ],
       "dev": true,
       "dependencies": {
-        "@npmcli/arborist": "^2.6.3",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.3",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "bin": {
         "npm": "bin/npm-cli.js",
@@ -7970,38 +7841,54 @@
         "node": ">=8"
       }
     },
+    "node_modules/npm/node_modules/@gar/promisify": {
+      "version": "1.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
+    "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
+      "version": "1.1.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "2.6.3",
+      "version": "2.9.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@isaacs/string-locale-compare": "^1.0.1",
         "@npmcli/installed-package-contents": "^1.0.7",
         "@npmcli/map-workspaces": "^1.0.2",
         "@npmcli/metavuln-calculator": "^1.1.0",
         "@npmcli/move-file": "^1.1.0",
         "@npmcli/name-from-folder": "^1.0.1",
         "@npmcli/node-gyp": "^1.0.1",
+        "@npmcli/package-json": "^1.0.1",
         "@npmcli/run-script": "^1.8.2",
         "bin-links": "^2.2.1",
         "cacache": "^15.0.3",
         "common-ancestor-path": "^1.0.1",
         "json-parse-even-better-errors": "^2.3.1",
         "json-stringify-nice": "^1.1.4",
+        "mkdirp": "^1.0.4",
         "mkdirp-infer-owner": "^2.0.0",
         "npm-install-checks": "^4.0.0",
-        "npm-package-arg": "^8.1.0",
+        "npm-package-arg": "^8.1.5",
         "npm-pick-manifest": "^6.1.0",
         "npm-registry-fetch": "^11.0.0",
-        "pacote": "^11.2.6",
+        "pacote": "^11.3.5",
         "parse-conflict-json": "^1.1.1",
         "proc-log": "^1.0.0",
         "promise-all-reject-late": "^1.0.0",
         "promise-call-limit": "^1.0.1",
         "read-package-json-fast": "^2.0.2",
         "readdir-scoped-modules": "^1.1.0",
+        "rimraf": "^3.0.2",
         "semver": "^7.3.5",
-        "tar": "^6.1.0",
+        "ssri": "^8.0.1",
         "treeverse": "^1.0.4",
         "walk-up-path": "^1.0.0"
       },
@@ -8019,7 +7906,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/config": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8046,8 +7933,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/npm/node_modules/@npmcli/fs": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.0.1",
+        "semver": "^7.3.5"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/git": {
-      "version": "2.0.9",
+      "version": "2.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8079,7 +7976,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
-      "version": "1.0.3",
+      "version": "1.0.4",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8129,6 +8026,15 @@
       "inBundle": true,
       "license": "ISC"
     },
+    "node_modules/npm/node_modules/@npmcli/package-json": {
+      "version": "1.0.1",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "json-parse-even-better-errors": "^2.3.1"
+      }
+    },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "1.3.2",
       "dev": true,
@@ -8139,14 +8045,13 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
-      "version": "1.8.5",
+      "version": "1.8.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@npmcli/node-gyp": "^1.0.2",
         "@npmcli/promise-spawn": "^1.3.2",
-        "infer-owner": "^1.0.4",
         "node-gyp": "^7.1.0",
         "read-package-json-fast": "^2.0.1"
       }
@@ -8270,13 +8175,16 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/are-we-there-yet": {
-      "version": "1.1.5",
+      "version": "1.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "delegates": "^1.0.0",
-        "readable-stream": "^2.0.6"
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/asap": {
@@ -8381,21 +8289,13 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/byte-size": {
-      "version": "7.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/npm/node_modules/cacache": {
-      "version": "15.2.0",
+      "version": "15.3.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
+        "@npmcli/fs": "^1.0.0",
         "@npmcli/move-file": "^1.0.1",
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -8425,7 +8325,7 @@
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/chalk": {
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8591,6 +8491,15 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/color-support": {
+      "version": "1.1.3",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/npm/node_modules/colors": {
       "version": "1.4.0",
       "dev": true,
@@ -8660,7 +8569,7 @@
       }
     },
     "node_modules/npm/node_modules/debug": {
-      "version": "4.3.1",
+      "version": "4.3.2",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -8811,6 +8720,12 @@
       "inBundle": true,
       "license": "MIT"
     },
+    "node_modules/npm/node_modules/fastest-levenshtein": {
+      "version": "1.0.12",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT"
+    },
     "node_modules/npm/node_modules/forever-agent": {
       "version": "0.6.1",
       "dev": true,
@@ -8845,51 +8760,23 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/gauge": {
-      "version": "2.7.4",
+      "version": "3.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "aproba": "^1.0.3",
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
         "console-control-strings": "^1.0.0",
-        "has-unicode": "^2.0.0",
-        "object-assign": "^4.1.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
         "signal-exit": "^3.0.0",
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1",
-        "wide-align": "^1.1.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/aproba": {
-      "version": "1.2.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "number-is-nan": "^1.0.0"
+        "string-width": "^1.0.1 || ^2.0.0",
+        "strip-ansi": "^3.0.1 || ^4.0.0",
+        "wide-align": "^1.1.2"
       },
       "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/npm/node_modules/gauge/node_modules/string-width": {
-      "version": "1.0.2",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "code-point-at": "^1.0.0",
-        "is-fullwidth-code-point": "^1.0.0",
-        "strip-ansi": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/getpass": {
@@ -8902,7 +8789,7 @@
       }
     },
     "node_modules/npm/node_modules/glob": {
-      "version": "7.1.7",
+      "version": "7.2.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -8922,7 +8809,7 @@
       }
     },
     "node_modules/npm/node_modules/graceful-fs": {
-      "version": "4.2.6",
+      "version": "4.2.8",
       "dev": true,
       "inBundle": true,
       "license": "ISC"
@@ -9117,16 +9004,15 @@
       }
     },
     "node_modules/npm/node_modules/init-package-json": {
-      "version": "2.0.3",
+      "version": "2.0.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "glob": "^7.1.1",
-        "npm-package-arg": "^8.1.2",
+        "npm-package-arg": "^8.1.5",
         "promzard": "^0.3.0",
         "read": "~1.0.1",
-        "read-package-json": "^3.0.1",
+        "read-package-json": "^4.1.1",
         "semver": "^7.3.5",
         "validate-npm-package-license": "^3.0.4",
         "validate-npm-package-name": "^3.0.0"
@@ -9163,7 +9049,7 @@
       }
     },
     "node_modules/npm/node_modules/is-core-module": {
-      "version": "2.4.0",
+      "version": "2.7.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9190,12 +9076,6 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
-    "node_modules/npm/node_modules/isarray": {
       "version": "1.0.0",
       "dev": true,
       "inBundle": true,
@@ -9287,15 +9167,6 @@
       "inBundle": true,
       "license": "MIT"
     },
-    "node_modules/npm/node_modules/leven": {
-      "version": "3.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "4.0.3",
       "dev": true,
@@ -9331,7 +9202,7 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9468,7 +9339,7 @@
       }
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
-      "version": "9.0.3",
+      "version": "9.1.0",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9487,7 +9358,7 @@
         "minipass-pipeline": "^1.2.4",
         "negotiator": "^0.6.2",
         "promise-retry": "^2.0.1",
-        "socks-proxy-agent": "^5.0.0",
+        "socks-proxy-agent": "^6.0.0",
         "ssri": "^8.0.0"
       },
       "engines": {
@@ -9495,7 +9366,7 @@
       }
     },
     "node_modules/npm/node_modules/mime-db": {
-      "version": "1.48.0",
+      "version": "1.49.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9504,12 +9375,12 @@
       }
     },
     "node_modules/npm/node_modules/mime-types": {
-      "version": "2.1.31",
+      "version": "2.1.32",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "mime-db": "1.48.0"
+        "mime-db": "1.49.0"
       },
       "engines": {
         "node": ">= 0.6"
@@ -9528,7 +9399,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass": {
-      "version": "3.1.3",
+      "version": "3.1.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -9552,7 +9423,7 @@
       }
     },
     "node_modules/npm/node_modules/minipass-fetch": {
-      "version": "1.3.3",
+      "version": "1.4.1",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -9698,6 +9569,66 @@
         "node": ">= 10.12.0"
       }
     },
+    "node_modules/npm/node_modules/node-gyp/node_modules/aproba": {
+      "version": "1.2.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC"
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
+      "version": "2.7.4",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "number-is-nan": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
+      "version": "4.1.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/node-gyp/node_modules/string-width": {
+      "version": "1.0.2",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "dependencies": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm/node_modules/nopt": {
       "version": "5.0.0",
       "dev": true,
@@ -9714,13 +9645,13 @@
       }
     },
     "node_modules/npm/node_modules/normalize-package-data": {
-      "version": "3.0.2",
+      "version": "3.0.3",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^4.0.1",
-        "resolve": "^1.20.0",
+        "is-core-module": "^2.5.0",
         "semver": "^7.3.4",
         "validate-npm-package-license": "^3.0.1"
       },
@@ -9847,15 +9778,28 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/npmlog": {
-      "version": "4.1.2",
+      "version": "5.0.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "are-we-there-yet": "~1.1.2",
-        "console-control-strings": "~1.1.0",
-        "gauge": "~2.7.3",
-        "set-blocking": "~2.0.0"
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/npm/node_modules/npmlog/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/npm/node_modules/number-is-nan": {
@@ -9919,12 +9863,12 @@
       }
     },
     "node_modules/npm/node_modules/pacote": {
-      "version": "11.3.4",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/git": "^2.0.1",
+        "@npmcli/git": "^2.1.0",
         "@npmcli/installed-package-contents": "^1.0.6",
         "@npmcli/promise-spawn": "^1.2.0",
         "@npmcli/run-script": "^1.8.2",
@@ -9971,12 +9915,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/npm/node_modules/path-parse": {
-      "version": "1.0.7",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
-    },
     "node_modules/npm/node_modules/performance-now": {
       "version": "2.1.0",
       "dev": true,
@@ -9988,12 +9926,6 @@
       "dev": true,
       "inBundle": true,
       "license": "ISC"
-    },
-    "node_modules/npm/node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT"
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
@@ -10092,7 +10024,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/read-package-json": {
-      "version": "3.0.1",
+      "version": "4.1.1",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10107,7 +10039,7 @@
       }
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10120,18 +10052,17 @@
       }
     },
     "node_modules/npm/node_modules/readable-stream": {
-      "version": "2.3.7",
+      "version": "3.6.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/npm/node_modules/readdir-scoped-modules": {
@@ -10204,19 +10135,6 @@
         "node": ">=0.8"
       }
     },
-    "node_modules/npm/node_modules/resolve": {
-      "version": "1.20.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-core-module": "^2.2.0",
-        "path-parse": "^1.0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
       "dev": true,
@@ -10242,8 +10160,22 @@
       }
     },
     "node_modules/npm/node_modules/safe-buffer": {
-      "version": "5.1.2",
+      "version": "5.2.1",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "inBundle": true,
       "license": "MIT"
     },
@@ -10281,7 +10213,7 @@
       "license": "ISC"
     },
     "node_modules/npm/node_modules/smart-buffer": {
-      "version": "4.1.0",
+      "version": "4.2.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -10305,17 +10237,17 @@
       }
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
-      "version": "5.0.0",
+      "version": "6.1.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "agent-base": "6",
-        "debug": "4",
-        "socks": "^2.3.3"
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.1",
+        "socks": "^2.6.1"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 10"
       }
     },
     "node_modules/npm/node_modules/spdx-correct": {
@@ -10345,7 +10277,7 @@
       }
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
-      "version": "3.0.9",
+      "version": "3.0.10",
       "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
@@ -10388,12 +10320,12 @@
       }
     },
     "node_modules/npm/node_modules/string_decoder": {
-      "version": "1.1.1",
+      "version": "1.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
-        "safe-buffer": "~5.1.0"
+        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/npm/node_modules/string-width": {
@@ -10461,7 +10393,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "6.1.0",
+      "version": "6.1.11",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -10912,13 +10844,13 @@
       }
     },
     "node_modules/p-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
-      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
       "dev": true,
       "dependencies": {
         "@types/retry": "^0.12.0",
-        "retry": "^0.12.0"
+        "retry": "^0.13.1"
       },
       "engines": {
         "node": ">=8"
@@ -11301,15 +11233,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/pretty-format/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -11348,15 +11271,6 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
-    },
-    "node_modules/progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.4.0"
-      }
     },
     "node_modules/prompts": {
       "version": "2.4.1",
@@ -11656,18 +11570,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "dependencies": {
-        "resolve": "^1.1.6"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -11857,9 +11759,9 @@
       }
     },
     "node_modules/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true,
       "engines": {
         "node": ">= 4"
@@ -12246,9 +12148,9 @@
       }
     },
     "node_modules/semantic-release": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-      "integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+      "version": "17.4.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+      "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "dev": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -12284,7 +12186,7 @@
         "semantic-release": "bin/semantic-release.js"
       },
       "engines": {
-        "node": ">=10.18"
+        "node": ">=10.19"
       }
     },
     "node_modules/semantic-release-plugin-update-version-in-files": {
@@ -12295,15 +12197,6 @@
       "dependencies": {
         "debug": "^4.1.1",
         "glob": "^7.1.3"
-      }
-    },
-    "node_modules/semantic-release/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/semantic-release/node_modules/cliui": {
@@ -12330,9 +12223,9 @@
       }
     },
     "node_modules/semantic-release/node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -12341,16 +12234,33 @@
         "node": ">=10"
       }
     },
-    "node_modules/semantic-release/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+    "node_modules/semantic-release/node_modules/marked": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
       "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
+      "bin": {
+        "marked": "bin/marked"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">= 10"
+      }
+    },
+    "node_modules/semantic-release/node_modules/marked-terminal": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
+      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
+      "dev": true,
+      "dependencies": {
+        "ansi-escapes": "^4.3.1",
+        "cardinal": "^2.1.1",
+        "chalk": "^4.1.0",
+        "cli-table3": "^0.6.0",
+        "node-emoji": "^1.10.0",
+        "supports-hyperlinks": "^2.1.0"
+      },
+      "peerDependencies": {
+        "marked": "^1.0.0 || ^2.0.0"
       }
     },
     "node_modules/semantic-release/node_modules/y18n": {
@@ -12560,29 +12470,23 @@
         "node": ">=8"
       }
     },
-    "node_modules/shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      },
-      "bin": {
-        "shjs": "bin/shjs"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "dependencies": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.0.4",
@@ -13171,27 +13075,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/string-length/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-length/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string-width": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
@@ -13201,14 +13084,6 @@
         "is-fullwidth-code-point": "^3.0.0",
         "strip-ansi": "^6.0.0"
       },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/string-width/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
       "engines": {
         "node": ">=8"
       }
@@ -13226,26 +13101,15 @@
         "node": ">=8"
       }
     },
-    "node_modules/string-width/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "dependencies": {
-        "ansi-regex": "^5.0.0"
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-      "dependencies": {
-        "ansi-regex": "^4.1.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/strip-bom": {
@@ -13301,6 +13165,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/superagent/-/superagent-5.3.1.tgz",
       "integrity": "sha512-wjJ/MoTid2/RuGCOFtlacyGNxN9QLMgcpYLDQlWFIhhdJ93kNscFonGvrpAHSCVjRVj++DGCglocF7Aej1KHvQ==",
+      "deprecated": "Please upgrade to v7.0.2+ of superagent.  We have fixed numerous issues with streams, form-data, attach(), filesystem errors not bubbling up (ENOENT on attach()), and all tests are now passing.  See the releases tab for more information at <https://github.com/visionmedia/superagent/releases>. Thanks to @shadowgate15, @spence-s, and @niftylettuce. Superagent is sponsored by Forward Email at <https://forwardemail.net>.",
       "dev": true,
       "dependencies": {
         "component-emitter": "^1.3.0",
@@ -13320,9 +13185,9 @@
       }
     },
     "node_modules/superagent/node_modules/mime": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-      "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
       "dev": true,
       "bin": {
         "mime": "cli.js"
@@ -13332,9 +13197,9 @@
       }
     },
     "node_modules/superagent/node_modules/qs": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-      "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+      "version": "6.10.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+      "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
       "dev": true,
       "dependencies": {
         "side-channel": "^1.0.4"
@@ -13711,15 +13576,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/ts-jest": {
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
@@ -14018,76 +13874,25 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
       "dev": true,
       "dependencies": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
+        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
       },
       "bin": {
         "typedoc": "bin/typedoc"
       },
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 12.10.0"
       },
       "peerDependencies": {
-        "typescript": "3.9.x || 4.0.x"
-      }
-    },
-    "node_modules/typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/typedoc/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/typedoc/node_modules/marked": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-      "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
-      "dev": true,
-      "bin": {
-        "marked": "bin/marked"
-      },
-      "engines": {
-        "node": ">= 8.16.2"
-      }
-    },
-    "node_modules/typedoc/node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 10.0.0"
+        "typescript": "4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x"
       }
     },
     "node_modules/typescript": {
@@ -14411,6 +14216,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
+    },
     "node_modules/w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -14433,9 +14250,9 @@
       }
     },
     "node_modules/walk": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
-      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
+      "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
       "dependencies": {
         "foreachasync": "^3.0.0"
       }
@@ -14549,14 +14366,6 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
-    "node_modules/wrap-ansi/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -14586,17 +14395,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/wrap-ansi/node_modules/strip-ansi": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "dependencies": {
-        "ansi-regex": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -15295,23 +15093,6 @@
         "rimraf": "^3.0.0",
         "slash": "^3.0.0",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
       }
     },
     "@jest/environment": {
@@ -15606,9 +15387,9 @@
       }
     },
     "@octokit/openapi-types": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-7.3.2.tgz",
-      "integrity": "sha512-oJhK/yhl9Gt430OrZOzAl2wJqR0No9445vmZ9Ey8GjUZUpwuu/vmEFP0TDhDXdpGDoxD6/EIFHJEcY8nHXpDTA=="
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-11.2.0.tgz",
+      "integrity": "sha512-PBsVO+15KSlGmiI8QAzaqvsNlZlrDlyAJYcrXBCvVUxCp7VnXjkwPoFHgjEJXx3WF9BAwkA6nfCUA7i9sODzKA=="
     },
     "@octokit/plugin-enterprise-compatibility": {
       "version": "1.3.0",
@@ -15620,11 +15401,11 @@
       }
     },
     "@octokit/plugin-paginate-rest": {
-      "version": "2.13.5",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.13.5.tgz",
-      "integrity": "sha512-3WSAKBLa1RaR/7GG+LQR/tAZ9fp9H9waE9aPXallidyci9oZsfgsLn5M836d3LuDC6Fcym+2idRTBpssHZePVg==",
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-2.17.0.tgz",
+      "integrity": "sha512-tzMbrbnam2Mt4AhuyCHvpRkS0oZ5MvwwcQPYGtMv4tUa5kkzG58SVB0fcsLulOZQeRnOgdkZWkRUiyBlh0Bkyw==",
       "requires": {
-        "@octokit/types": "^6.13.0"
+        "@octokit/types": "^6.34.0"
       }
     },
     "@octokit/plugin-request-log": {
@@ -15635,11 +15416,11 @@
       "requires": {}
     },
     "@octokit/plugin-rest-endpoint-methods": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.3.1.tgz",
-      "integrity": "sha512-3B2iguGmkh6bQQaVOtCsS0gixrz8Lg0v4JuXPqBcFqLKuJtxAUf3K88RxMEf/naDOI73spD+goJ/o7Ie7Cvdjg==",
+      "version": "5.13.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-5.13.0.tgz",
+      "integrity": "sha512-uJjMTkN1KaOIgNtUPMtIXDOjx6dGYysdIFhgA52x4xSadQCz3b/zJexvITDVpANnfKPW/+E0xkOvLntqMYpviA==",
       "requires": {
-        "@octokit/types": "^6.16.2",
+        "@octokit/types": "^6.34.0",
         "deprecation": "^2.3.1"
       }
     },
@@ -15685,23 +15466,23 @@
       }
     },
     "@octokit/rest": {
-      "version": "18.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.6.0.tgz",
-      "integrity": "sha512-MdHuXHDJM7e5sUBe3K9tt7th0cs4csKU5Bb52LRi2oHAeIMrMZ4XqaTrEv660HoUPoM1iDlnj27Ab/Nh3MtwlA==",
+      "version": "18.12.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-18.12.0.tgz",
+      "integrity": "sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==",
       "dev": true,
       "requires": {
-        "@octokit/core": "^3.5.0",
-        "@octokit/plugin-paginate-rest": "^2.6.2",
-        "@octokit/plugin-request-log": "^1.0.2",
-        "@octokit/plugin-rest-endpoint-methods": "5.3.1"
+        "@octokit/core": "^3.5.1",
+        "@octokit/plugin-paginate-rest": "^2.16.8",
+        "@octokit/plugin-request-log": "^1.0.4",
+        "@octokit/plugin-rest-endpoint-methods": "^5.12.0"
       }
     },
     "@octokit/types": {
-      "version": "6.16.4",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.16.4.tgz",
-      "integrity": "sha512-UxhWCdSzloULfUyamfOg4dJxV9B+XjgrIZscI0VCbp4eNrjmorGEw+4qdwcpTsu6DIrm9tQsFQS2pK5QkqQ04A==",
+      "version": "6.34.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-6.34.0.tgz",
+      "integrity": "sha512-s1zLBjWhdEI2zwaoSgyOFoKSl109CUcVBCc7biPJ3aAf6LGLU6szDvi31JPU7bxfla2lqfhjbbg/5DdFNxOwHw==",
       "requires": {
-        "@octokit/openapi-types": "^7.3.2"
+        "@octokit/openapi-types": "^11.2.0"
       }
     },
     "@octokit/webhooks": {
@@ -15825,9 +15606,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
           "dev": true
         }
       }
@@ -16376,9 +16157,9 @@
       }
     },
     "@types/retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
     "@types/semver": {
@@ -16536,23 +16317,11 @@
       }
     },
     "ansi-align": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.0.tgz",
-      "integrity": "sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
       "requires": {
-        "string-width": "^3.0.0"
-      },
-      "dependencies": {
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-          "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
-          }
-        }
+        "string-width": "^4.1.0"
       }
     },
     "ansi-escapes": {
@@ -16573,9 +16342,9 @@
       }
     },
     "ansi-regex": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -16692,12 +16461,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
-    },
-    "at-least-node": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
       "dev": true
     },
     "atob": {
@@ -17262,13 +17025,14 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
       "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw=="
     },
-    "cli-table": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cli-table/-/cli-table-0.3.6.tgz",
-      "integrity": "sha512-ZkNZbnZjKERTY5NwC2SeMeLeifSPq/pubeRoTpdr3WchLlnZg6hEgvHkK5zL7KNFdd9PmHN8lxrENUwI3cE8vQ==",
+    "cli-table3": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.1.tgz",
+      "integrity": "sha512-w0q/enDHhPLq44ovMGdQeeDLvwxwavsJX7oQGYt/LrBlYsyaxyDnp6z3QzFut/6kLLKnlcUVJLrpB7KBfgG/RA==",
       "dev": true,
       "requires": {
-        "colors": "1.0.3"
+        "colors": "1.4.0",
+        "string-width": "^4.2.0"
       }
     },
     "cliui": {
@@ -17282,12 +17046,6 @@
         "wrap-ansi": "^6.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -17311,15 +17069,6 @@
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -17389,10 +17138,11 @@
       "dev": true
     },
     "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=",
-      "dev": true
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "dev": true,
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -17470,9 +17220,9 @@
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "conventional-changelog-angular": {
-      "version": "5.0.12",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.12.tgz",
-      "integrity": "sha512-5GLsbnkR/7A89RyHLvvoExbiGbd9xKdKqDTrArnPbOqBqG/2wIosu0fHwpeIRI8Tl94MhVNBXcLJZl92ZQ5USw==",
+      "version": "5.0.13",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.13.tgz",
+      "integrity": "sha512-i/gipMxs7s8L/QeuavPF2hLnJgH6pEZAttySB6aiQLWcX3puWDL3ACVmvBhJGxnAy52Qc15ua26BufY6KpmrVA==",
       "dev": true,
       "requires": {
         "compare-func": "^2.0.0",
@@ -17522,9 +17272,9 @@
       }
     },
     "conventional-commits-parser": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.1.tgz",
-      "integrity": "sha512-OG9kQtmMZBJD/32NEw5IhN5+HnBqVjy03eC+I71I0oQRFA5rOgA4OtPOYG7mz1GkCfCNxn3gKIX8EiHJYuf1cA==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/conventional-commits-parser/-/conventional-commits-parser-3.2.4.tgz",
+      "integrity": "sha512-nK7sAtfi+QXbxHCYfhpZsfRtaitZLIA6889kFIouLvz6repszQDgxBu7wf2WbU+Dco7sAnNCJYERCwt54WPC2Q==",
       "dev": true,
       "requires": {
         "is-text-path": "^1.0.1",
@@ -17532,8 +17282,7 @@
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
         "split2": "^3.0.0",
-        "through2": "^4.0.0",
-        "trim-off-newlines": "^1.0.0"
+        "through2": "^4.0.0"
       }
     },
     "convert-source-map": {
@@ -17576,15 +17325,15 @@
       "dev": true
     },
     "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
     "cosmiconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
-      "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
       "dev": true,
       "requires": {
         "@types/parse-json": "^4.0.0",
@@ -17952,11 +17701,6 @@
       "integrity": "sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==",
       "dev": true
     },
-    "emoji-regex": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
-    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -17971,47 +17715,14 @@
       }
     },
     "env-ci": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.0.2.tgz",
-      "integrity": "sha512-Xc41mKvjouTXD3Oy9AqySz1IeyvJvHZ20Twf5ZLYbNpPPIuCnL/qHCmNlD01LoNy0JTunw9HPYVptD19Ac7Mbw==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/env-ci/-/env-ci-5.5.0.tgz",
+      "integrity": "sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==",
       "dev": true,
       "requires": {
-        "execa": "^4.0.0",
+        "execa": "^5.0.0",
+        "fromentries": "^1.3.2",
         "java-properties": "^1.0.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
-          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
-          "dev": true,
-          "requires": {
-            "cross-spawn": "^7.0.0",
-            "get-stream": "^5.0.0",
-            "human-signals": "^1.1.1",
-            "is-stream": "^2.0.0",
-            "merge-stream": "^2.0.0",
-            "npm-run-path": "^4.0.0",
-            "onetime": "^5.1.0",
-            "signal-exit": "^3.0.2",
-            "strip-final-newline": "^2.0.0"
-          }
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "human-signals": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-          "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-          "dev": true
-        }
       }
     },
     "error-ex": {
@@ -18612,6 +18323,12 @@
         }
       }
     },
+    "fromentries": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fromentries/-/fromentries-1.3.2.tgz",
+      "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
+      "dev": true
+    },
     "fs-extra": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.0.tgz",
@@ -18764,9 +18481,9 @@
       }
     },
     "glob": {
-      "version": "7.1.7",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.7.tgz",
-      "integrity": "sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -19044,19 +18761,13 @@
       "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw=="
     },
     "hbs": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.1.2.tgz",
-      "integrity": "sha512-WfBnQbozbdiTLjJu6P6Wturgvy0FN8xtRmIjmP0ebX9OGQrt+2S6UC7xX0IebHTCS1sXe20zfTzQ7yhjrEvrfQ==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/hbs/-/hbs-4.2.0.tgz",
+      "integrity": "sha512-dQwHnrfWlTk5PvG9+a45GYpg0VpX47ryKF8dULVd6DtwOE6TEcYQXQ5QM6nyOx/h7v3bvEQbdn19EDAcfUAgZg==",
       "requires": {
         "handlebars": "4.7.7",
-        "walk": "2.3.14"
+        "walk": "2.3.15"
       }
-    },
-    "highlight.js": {
-      "version": "10.7.3",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-10.7.3.tgz",
-      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
-      "dev": true
     },
     "hook-std": {
       "version": "2.0.0",
@@ -19231,12 +18942,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
       "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA=="
     },
-    "interpret": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz",
-      "integrity": "sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==",
-      "dev": true
-    },
     "into-stream": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-6.0.0.tgz",
@@ -19321,9 +19026,9 @@
       }
     },
     "is-core-module": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
-      "integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.1.tgz",
+      "integrity": "sha512-SdNCUs284hr40hFTFP6l0IfZ/RSrMXF3qgoRHd3/79unUTvrFO/JoXwkGm+5J/Oe3E/b5GsnG330uUNgRpu1PA==",
       "requires": {
         "has": "^1.0.3"
       }
@@ -19385,11 +19090,6 @@
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
       "dev": true
-    },
-    "is-fullwidth-code-point": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-generator-fn": {
       "version": "2.1.0",
@@ -20226,6 +19926,12 @@
         "minimist": "^1.2.5"
       }
     },
+    "jsonc-parser": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.0.0.tgz",
+      "integrity": "sha512-fQzRfAbIBnR0IQvftw9FJveWiHp72Fg20giDrHz6TdfB12UH/uue0D3hm57UB5KgAVuniLMCaS8P1IMj9NR7cA==",
+      "dev": true
+    },
     "jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -20460,12 +20166,6 @@
       "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=",
       "dev": true
     },
-    "lodash.toarray": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
-      "integrity": "sha1-JMS/zWsvuji/0FlNsRedjptlZWE=",
-      "dev": true
-    },
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
@@ -20558,24 +20258,10 @@
       }
     },
     "marked": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.2.tgz",
-      "integrity": "sha512-ueJhIvklJJw04qxQbGIAu63EXwwOCYc7yKMBjgagTM4rjC5QtWyqSNgW7jCosV1/Km/1TUfs5qEpAqcGG0Mo5g==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-3.0.8.tgz",
+      "integrity": "sha512-0gVrAjo5m0VZSJb4rpL59K1unJAMb/hm8HRXqasD8VeC8m91ytDPMritgFSlKonfdt+rRYYpP/JfLxgIX8yoSw==",
       "dev": true
-    },
-    "marked-terminal": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.1.1.tgz",
-      "integrity": "sha512-t7Mdf6T3PvOEyN01c3tYxDzhyKZ8xnkp8Rs6Fohno63L/0pFTJ5Qtwto2AQVuDtbQiWzD+4E5AAu1Z2iLc8miQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "^4.3.1",
-        "cardinal": "^2.1.1",
-        "chalk": "^4.1.0",
-        "cli-table": "^0.3.1",
-        "node-emoji": "^1.10.0",
-        "supports-hyperlinks": "^2.1.0"
-      }
     },
     "media-typer": {
       "version": "0.3.0",
@@ -20602,22 +20288,22 @@
       },
       "dependencies": {
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.2.tgz",
-          "integrity": "sha512-6CdZocmfGaKnIHPVFhJJZ3GuR8SsLKvDANFp47Jmy51aKIr8akjAWTSxtpI+MBgBFdSMRyo4hMpDlT6dTffgZg==",
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+          "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -20876,12 +20562,12 @@
       }
     },
     "node-emoji": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.10.0.tgz",
-      "integrity": "sha512-Yt3384If5H6BYGVHiHwTL+99OzJKHhgp82S8/dktEK73T26BazdgZ4JZh92xSVtGNJvz9UbXdNAc5hcrXV42vw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.11.0.tgz",
+      "integrity": "sha512-wo2DpQkQp7Sjm2A0cq+sN7EHKO6Sl0ctXeBdFZrL9T9+UywORbufTcTZxom8YqpLQt/FqNMUkOpkZrJVYSKD3A==",
       "dev": true,
       "requires": {
-        "lodash.toarray": "^4.4.0"
+        "lodash": "^4.17.21"
       }
     },
     "node-fetch": {
@@ -20954,111 +20640,128 @@
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
     },
     "npm": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-7.18.1.tgz",
-      "integrity": "sha512-fu7rMtc4ZaDnFlZsiLhqwWWs6KixOcBGiBLoJH+AbuaznwtT8mYQnq5nGNN14Jib+E9OjkjNRgg+X45Ia9xtKQ==",
+      "version": "7.24.2",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-7.24.2.tgz",
+      "integrity": "sha512-120p116CE8VMMZ+hk8IAb1inCPk4Dj3VZw29/n2g6UI77urJKVYb7FZUDW8hY+EBnfsjI/2yrobBgFyzo7YpVQ==",
       "dev": true,
       "requires": {
-        "@npmcli/arborist": "^2.6.3",
-        "@npmcli/ci-detect": "^1.2.0",
-        "@npmcli/config": "^2.2.0",
-        "@npmcli/run-script": "^1.8.5",
-        "abbrev": "~1.1.1",
-        "ansicolors": "~0.3.2",
-        "ansistyles": "~0.1.3",
-        "archy": "~1.0.0",
-        "byte-size": "^7.0.1",
-        "cacache": "^15.2.0",
-        "chalk": "^4.1.0",
-        "chownr": "^2.0.0",
-        "cli-columns": "^3.1.2",
-        "cli-table3": "^0.6.0",
-        "columnify": "~1.5.4",
-        "glob": "^7.1.7",
-        "graceful-fs": "^4.2.6",
-        "hosted-git-info": "^4.0.2",
-        "ini": "^2.0.0",
-        "init-package-json": "^2.0.3",
-        "is-cidr": "^4.0.2",
-        "json-parse-even-better-errors": "^2.3.1",
-        "leven": "^3.1.0",
-        "libnpmaccess": "^4.0.2",
-        "libnpmdiff": "^2.0.4",
-        "libnpmexec": "^2.0.0",
-        "libnpmfund": "^1.1.0",
-        "libnpmhook": "^6.0.2",
-        "libnpmorg": "^2.0.2",
-        "libnpmpack": "^2.0.1",
-        "libnpmpublish": "^4.0.1",
-        "libnpmsearch": "^3.1.1",
-        "libnpmteam": "^2.0.3",
-        "libnpmversion": "^1.2.1",
-        "make-fetch-happen": "^9.0.3",
-        "minipass": "^3.1.3",
-        "minipass-pipeline": "^1.2.4",
-        "mkdirp": "^1.0.4",
-        "mkdirp-infer-owner": "^2.0.0",
-        "ms": "^2.1.2",
-        "node-gyp": "^7.1.2",
-        "nopt": "^5.0.0",
-        "npm-audit-report": "^2.1.5",
-        "npm-package-arg": "^8.1.5",
-        "npm-pick-manifest": "^6.1.1",
-        "npm-profile": "^5.0.3",
-        "npm-registry-fetch": "^11.0.0",
-        "npm-user-validate": "^1.0.1",
-        "npmlog": "~4.1.2",
-        "opener": "^1.5.2",
-        "pacote": "^11.3.3",
-        "parse-conflict-json": "^1.1.1",
-        "qrcode-terminal": "^0.12.0",
-        "read": "~1.0.7",
-        "read-package-json": "^3.0.1",
-        "read-package-json-fast": "^2.0.2",
-        "readdir-scoped-modules": "^1.1.0",
-        "rimraf": "^3.0.2",
-        "semver": "^7.3.5",
-        "ssri": "^8.0.1",
-        "tar": "^6.1.0",
-        "text-table": "~0.2.0",
-        "tiny-relative-date": "^1.3.0",
-        "treeverse": "^1.0.4",
-        "validate-npm-package-name": "~3.0.0",
-        "which": "^2.0.2",
-        "write-file-atomic": "^3.0.3"
+        "@isaacs/string-locale-compare": "*",
+        "@npmcli/arborist": "*",
+        "@npmcli/ci-detect": "*",
+        "@npmcli/config": "*",
+        "@npmcli/map-workspaces": "*",
+        "@npmcli/package-json": "*",
+        "@npmcli/run-script": "*",
+        "abbrev": "*",
+        "ansicolors": "*",
+        "ansistyles": "*",
+        "archy": "*",
+        "cacache": "*",
+        "chalk": "*",
+        "chownr": "*",
+        "cli-columns": "*",
+        "cli-table3": "*",
+        "columnify": "*",
+        "fastest-levenshtein": "*",
+        "glob": "*",
+        "graceful-fs": "*",
+        "hosted-git-info": "*",
+        "ini": "*",
+        "init-package-json": "*",
+        "is-cidr": "*",
+        "json-parse-even-better-errors": "*",
+        "libnpmaccess": "*",
+        "libnpmdiff": "*",
+        "libnpmexec": "*",
+        "libnpmfund": "*",
+        "libnpmhook": "*",
+        "libnpmorg": "*",
+        "libnpmpack": "*",
+        "libnpmpublish": "*",
+        "libnpmsearch": "*",
+        "libnpmteam": "*",
+        "libnpmversion": "*",
+        "make-fetch-happen": "*",
+        "minipass": "*",
+        "minipass-pipeline": "*",
+        "mkdirp": "*",
+        "mkdirp-infer-owner": "*",
+        "ms": "*",
+        "node-gyp": "*",
+        "nopt": "*",
+        "npm-audit-report": "*",
+        "npm-install-checks": "*",
+        "npm-package-arg": "*",
+        "npm-pick-manifest": "*",
+        "npm-profile": "*",
+        "npm-registry-fetch": "*",
+        "npm-user-validate": "*",
+        "npmlog": "*",
+        "opener": "*",
+        "pacote": "*",
+        "parse-conflict-json": "*",
+        "qrcode-terminal": "*",
+        "read": "*",
+        "read-package-json": "*",
+        "read-package-json-fast": "*",
+        "readdir-scoped-modules": "*",
+        "rimraf": "*",
+        "semver": "*",
+        "ssri": "*",
+        "tar": "*",
+        "text-table": "*",
+        "tiny-relative-date": "*",
+        "treeverse": "*",
+        "validate-npm-package-name": "*",
+        "which": "*",
+        "write-file-atomic": "*"
       },
       "dependencies": {
+        "@gar/promisify": {
+          "version": "1.1.2",
+          "bundled": true,
+          "dev": true
+        },
+        "@isaacs/string-locale-compare": {
+          "version": "1.1.0",
+          "bundled": true,
+          "dev": true
+        },
         "@npmcli/arborist": {
-          "version": "2.6.3",
+          "version": "2.9.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@isaacs/string-locale-compare": "^1.0.1",
             "@npmcli/installed-package-contents": "^1.0.7",
             "@npmcli/map-workspaces": "^1.0.2",
             "@npmcli/metavuln-calculator": "^1.1.0",
             "@npmcli/move-file": "^1.1.0",
             "@npmcli/name-from-folder": "^1.0.1",
             "@npmcli/node-gyp": "^1.0.1",
+            "@npmcli/package-json": "^1.0.1",
             "@npmcli/run-script": "^1.8.2",
             "bin-links": "^2.2.1",
             "cacache": "^15.0.3",
             "common-ancestor-path": "^1.0.1",
             "json-parse-even-better-errors": "^2.3.1",
             "json-stringify-nice": "^1.1.4",
+            "mkdirp": "^1.0.4",
             "mkdirp-infer-owner": "^2.0.0",
             "npm-install-checks": "^4.0.0",
-            "npm-package-arg": "^8.1.0",
+            "npm-package-arg": "^8.1.5",
             "npm-pick-manifest": "^6.1.0",
             "npm-registry-fetch": "^11.0.0",
-            "pacote": "^11.2.6",
+            "pacote": "^11.3.5",
             "parse-conflict-json": "^1.1.1",
             "proc-log": "^1.0.0",
             "promise-all-reject-late": "^1.0.0",
             "promise-call-limit": "^1.0.1",
             "read-package-json-fast": "^2.0.2",
             "readdir-scoped-modules": "^1.1.0",
+            "rimraf": "^3.0.2",
             "semver": "^7.3.5",
-            "tar": "^6.1.0",
+            "ssri": "^8.0.1",
             "treeverse": "^1.0.4",
             "walk-up-path": "^1.0.0"
           }
@@ -21069,7 +20772,7 @@
           "dev": true
         },
         "@npmcli/config": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21088,8 +20791,17 @@
             "ansi-styles": "^4.3.0"
           }
         },
+        "@npmcli/fs": {
+          "version": "1.0.0",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "@gar/promisify": "^1.0.1",
+            "semver": "^7.3.5"
+          }
+        },
         "@npmcli/git": {
-          "version": "2.0.9",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21113,7 +20825,7 @@
           }
         },
         "@npmcli/map-workspaces": {
-          "version": "1.0.3",
+          "version": "1.0.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21152,6 +20864,14 @@
           "bundled": true,
           "dev": true
         },
+        "@npmcli/package-json": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "json-parse-even-better-errors": "^2.3.1"
+          }
+        },
         "@npmcli/promise-spawn": {
           "version": "1.3.2",
           "bundled": true,
@@ -21161,13 +20881,12 @@
           }
         },
         "@npmcli/run-script": {
-          "version": "1.8.5",
+          "version": "1.8.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "@npmcli/node-gyp": "^1.0.2",
             "@npmcli/promise-spawn": "^1.3.2",
-            "infer-owner": "^1.0.4",
             "node-gyp": "^7.1.0",
             "read-package-json-fast": "^2.0.1"
           }
@@ -21254,12 +20973,12 @@
           "dev": true
         },
         "are-we-there-yet": {
-          "version": "1.1.5",
+          "version": "1.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
             "delegates": "^1.0.0",
-            "readable-stream": "^2.0.6"
+            "readable-stream": "^3.6.0"
           }
         },
         "asap": {
@@ -21340,16 +21059,12 @@
           "bundled": true,
           "dev": true
         },
-        "byte-size": {
-          "version": "7.0.1",
-          "bundled": true,
-          "dev": true
-        },
         "cacache": {
-          "version": "15.2.0",
+          "version": "15.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
+            "@npmcli/fs": "^1.0.0",
             "@npmcli/move-file": "^1.0.1",
             "chownr": "^2.0.0",
             "fs-minipass": "^2.0.0",
@@ -21375,7 +21090,7 @@
           "dev": true
         },
         "chalk": {
-          "version": "4.1.1",
+          "version": "4.1.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21481,6 +21196,11 @@
           "bundled": true,
           "dev": true
         },
+        "color-support": {
+          "version": "1.1.3",
+          "bundled": true,
+          "dev": true
+        },
         "colors": {
           "version": "1.4.0",
           "bundled": true,
@@ -21533,7 +21253,7 @@
           }
         },
         "debug": {
-          "version": "4.3.1",
+          "version": "4.3.2",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21642,6 +21362,11 @@
           "bundled": true,
           "dev": true
         },
+        "fastest-levenshtein": {
+          "version": "1.0.12",
+          "bundled": true,
+          "dev": true
+        },
         "forever-agent": {
           "version": "0.6.1",
           "bundled": true,
@@ -21666,43 +21391,19 @@
           "dev": true
         },
         "gauge": {
-          "version": "2.7.4",
+          "version": "3.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "aproba": "^1.0.3",
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
             "console-control-strings": "^1.0.0",
-            "has-unicode": "^2.0.0",
-            "object-assign": "^4.1.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
             "signal-exit": "^3.0.0",
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wide-align": "^1.1.0"
-          },
-          "dependencies": {
-            "aproba": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "1.0.0",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "number-is-nan": "^1.0.0"
-              }
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
+            "string-width": "^1.0.1 || ^2.0.0",
+            "strip-ansi": "^3.0.1 || ^4.0.0",
+            "wide-align": "^1.1.2"
           }
         },
         "getpass": {
@@ -21714,7 +21415,7 @@
           }
         },
         "glob": {
-          "version": "7.1.7",
+          "version": "7.2.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21727,7 +21428,7 @@
           }
         },
         "graceful-fs": {
-          "version": "4.2.6",
+          "version": "4.2.8",
           "bundled": true,
           "dev": true
         },
@@ -21865,15 +21566,14 @@
           "dev": true
         },
         "init-package-json": {
-          "version": "2.0.3",
+          "version": "2.0.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "glob": "^7.1.1",
-            "npm-package-arg": "^8.1.2",
+            "npm-package-arg": "^8.1.5",
             "promzard": "^0.3.0",
             "read": "~1.0.1",
-            "read-package-json": "^3.0.1",
+            "read-package-json": "^4.1.1",
             "semver": "^7.3.5",
             "validate-npm-package-license": "^3.0.4",
             "validate-npm-package-name": "^3.0.0"
@@ -21898,7 +21598,7 @@
           }
         },
         "is-core-module": {
-          "version": "2.4.0",
+          "version": "2.7.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -21916,11 +21616,6 @@
           "dev": true
         },
         "is-typedarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "isarray": {
           "version": "1.0.0",
           "bundled": true,
           "dev": true
@@ -21991,11 +21686,6 @@
           "bundled": true,
           "dev": true
         },
-        "leven": {
-          "version": "3.1.0",
-          "bundled": true,
-          "dev": true
-        },
         "libnpmaccess": {
           "version": "4.0.3",
           "bundled": true,
@@ -22023,7 +21713,7 @@
           }
         },
         "libnpmexec": {
-          "version": "2.0.0",
+          "version": "2.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22126,7 +21816,7 @@
           }
         },
         "make-fetch-happen": {
-          "version": "9.0.3",
+          "version": "9.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22144,21 +21834,21 @@
             "minipass-pipeline": "^1.2.4",
             "negotiator": "^0.6.2",
             "promise-retry": "^2.0.1",
-            "socks-proxy-agent": "^5.0.0",
+            "socks-proxy-agent": "^6.0.0",
             "ssri": "^8.0.0"
           }
         },
         "mime-db": {
-          "version": "1.48.0",
+          "version": "1.49.0",
           "bundled": true,
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.31",
+          "version": "2.1.32",
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.48.0"
+            "mime-db": "1.49.0"
           }
         },
         "minimatch": {
@@ -22170,7 +21860,7 @@
           }
         },
         "minipass": {
-          "version": "3.1.3",
+          "version": "3.1.5",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22186,7 +21876,7 @@
           }
         },
         "minipass-fetch": {
-          "version": "1.3.3",
+          "version": "1.4.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22283,6 +21973,57 @@
             "semver": "^7.3.2",
             "tar": "^6.0.2",
             "which": "^2.0.2"
+          },
+          "dependencies": {
+            "aproba": {
+              "version": "1.2.0",
+              "bundled": true,
+              "dev": true
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+              }
+            },
+            "is-fullwidth-code-point": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "number-is-nan": "^1.0.0"
+              }
+            },
+            "npmlog": {
+              "version": "4.1.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+              }
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
           }
         },
         "nopt": {
@@ -22294,12 +22035,12 @@
           }
         },
         "normalize-package-data": {
-          "version": "3.0.2",
+          "version": "3.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
             "hosted-git-info": "^4.0.1",
-            "resolve": "^1.20.0",
+            "is-core-module": "^2.5.0",
             "semver": "^7.3.4",
             "validate-npm-package-license": "^3.0.1"
           }
@@ -22392,14 +22133,25 @@
           "dev": true
         },
         "npmlog": {
-          "version": "4.1.2",
+          "version": "5.0.1",
           "bundled": true,
           "dev": true,
           "requires": {
-            "are-we-there-yet": "~1.1.2",
-            "console-control-strings": "~1.1.0",
-            "gauge": "~2.7.3",
-            "set-blocking": "~2.0.0"
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          },
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "2.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^3.6.0"
+              }
+            }
           }
         },
         "number-is-nan": {
@@ -22439,11 +22191,11 @@
           }
         },
         "pacote": {
-          "version": "11.3.4",
+          "version": "11.3.5",
           "bundled": true,
           "dev": true,
           "requires": {
-            "@npmcli/git": "^2.0.1",
+            "@npmcli/git": "^2.1.0",
             "@npmcli/installed-package-contents": "^1.0.6",
             "@npmcli/promise-spawn": "^1.2.0",
             "@npmcli/run-script": "^1.8.2",
@@ -22479,11 +22231,6 @@
           "bundled": true,
           "dev": true
         },
-        "path-parse": {
-          "version": "1.0.7",
-          "bundled": true,
-          "dev": true
-        },
         "performance-now": {
           "version": "2.1.0",
           "bundled": true,
@@ -22491,11 +22238,6 @@
         },
         "proc-log": {
           "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.1",
           "bundled": true,
           "dev": true
         },
@@ -22565,7 +22307,7 @@
           "dev": true
         },
         "read-package-json": {
-          "version": "3.0.1",
+          "version": "4.1.1",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22576,7 +22318,7 @@
           }
         },
         "read-package-json-fast": {
-          "version": "2.0.2",
+          "version": "2.0.3",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -22585,17 +22327,13 @@
           }
         },
         "readable-stream": {
-          "version": "2.3.7",
+          "version": "3.6.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         },
         "readdir-scoped-modules": {
@@ -22657,15 +22395,6 @@
             }
           }
         },
-        "resolve": {
-          "version": "1.20.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.2.0",
-            "path-parse": "^1.0.6"
-          }
-        },
         "retry": {
           "version": "0.12.0",
           "bundled": true,
@@ -22680,7 +22409,7 @@
           }
         },
         "safe-buffer": {
-          "version": "5.1.2",
+          "version": "5.2.1",
           "bundled": true,
           "dev": true
         },
@@ -22708,7 +22437,7 @@
           "dev": true
         },
         "smart-buffer": {
-          "version": "4.1.0",
+          "version": "4.2.0",
           "bundled": true,
           "dev": true
         },
@@ -22722,13 +22451,13 @@
           }
         },
         "socks-proxy-agent": {
-          "version": "5.0.0",
+          "version": "6.1.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "agent-base": "6",
-            "debug": "4",
-            "socks": "^2.3.3"
+            "agent-base": "^6.0.2",
+            "debug": "^4.3.1",
+            "socks": "^2.6.1"
           }
         },
         "spdx-correct": {
@@ -22755,7 +22484,7 @@
           }
         },
         "spdx-license-ids": {
-          "version": "3.0.9",
+          "version": "3.0.10",
           "bundled": true,
           "dev": true
         },
@@ -22784,11 +22513,11 @@
           }
         },
         "string_decoder": {
-          "version": "1.1.1",
+          "version": "1.3.0",
           "bundled": true,
           "dev": true,
           "requires": {
-            "safe-buffer": "~5.1.0"
+            "safe-buffer": "~5.2.0"
           }
         },
         "string-width": {
@@ -22837,7 +22566,7 @@
           }
         },
         "tar": {
-          "version": "6.1.0",
+          "version": "6.1.11",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -23192,13 +22921,13 @@
       "dev": true
     },
     "p-retry": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.5.0.tgz",
-      "integrity": "sha512-5Hwh4aVQSu6BEP+w2zKlVXtFAaYQe1qWuVADSgoeVlLjwe/Q/AMSoRR4MDeaAfu8llT+YNbEijWu/YF3m6avkg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
+      "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
       "dev": true,
       "requires": {
         "@types/retry": "^0.12.0",
-        "retry": "^0.12.0"
+        "retry": "^0.13.1"
       }
     },
     "p-try": {
@@ -23490,12 +23219,6 @@
         "react-is": "^17.0.1"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -23526,12 +23249,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
-    },
-    "progress": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
     },
     "prompts": {
@@ -23754,15 +23471,6 @@
         "util-deprecate": "^1.0.1"
       }
     },
-    "rechoir": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
-      "dev": true,
-      "requires": {
-        "resolve": "^1.1.6"
-      }
-    },
     "redent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
@@ -23912,9 +23620,9 @@
       "dev": true
     },
     "retry": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-      "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true
     },
     "reusify": {
@@ -24201,9 +23909,9 @@
       }
     },
     "semantic-release": {
-      "version": "17.4.4",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.4.tgz",
-      "integrity": "sha512-fQIA0lw2Sy/9+TcoM/BxyzKCSwdUd8EPRwGoOuBLgxKigPCY6kaKs8TOsgUVy6QrlTYwni2yzbMb5Q2107P9eA==",
+      "version": "17.4.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+      "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "dev": true,
       "requires": {
         "@semantic-release/commit-analyzer": "^8.0.0",
@@ -24236,12 +23944,6 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
         "cliui": {
           "version": "7.0.4",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -24260,21 +23962,32 @@
           "dev": true
         },
         "hosted-git-info": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-          "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+          "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
         },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+        "marked": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+          "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==",
+          "dev": true
+        },
+        "marked-terminal": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
+          "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
           "dev": true,
           "requires": {
-            "ansi-regex": "^5.0.0"
+            "ansi-escapes": "^4.3.1",
+            "cardinal": "^2.1.1",
+            "chalk": "^4.1.0",
+            "cli-table3": "^0.6.0",
+            "node-emoji": "^1.10.0",
+            "supports-hyperlinks": "^2.1.0"
           }
         },
         "y18n": {
@@ -24456,23 +24169,23 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "shelljs": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.4.tgz",
-      "integrity": "sha512-7gk3UZ9kOfPLIAbslLzyWeGiEqx9e3rxwZM0KE6EL8GlGwjym9Mrlx5/p33bWTu9YG6vcS4MBxYZDHYr5lr8BQ==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.0.0",
-        "interpret": "^1.0.0",
-        "rechoir": "^0.6.2"
-      }
-    },
     "shellwords": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
+    },
+    "shiki": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-0.9.15.tgz",
+      "integrity": "sha512-/Y0z9IzhJ8nD9nbceORCqu6NgT9X6I8Fk8c3SICHI5NbZRLdZYFaB233gwct9sU0vvSypyaL/qaKvzyQGJBZSw==",
+      "dev": true,
+      "requires": {
+        "jsonc-parser": "^3.0.0",
+        "vscode-oniguruma": "^1.6.1",
+        "vscode-textmate": "5.2.0"
+      }
     },
     "side-channel": {
       "version": "1.0.4",
@@ -24973,23 +24686,6 @@
       "requires": {
         "char-regex": "^1.0.2",
         "strip-ansi": "^6.0.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
-        }
       }
     },
     "string-width": {
@@ -25002,11 +24698,6 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
         "emoji-regex": {
           "version": "8.0.0",
           "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -25016,23 +24707,15 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         }
       }
     },
     "strip-ansi": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "requires": {
-        "ansi-regex": "^4.1.0"
+        "ansi-regex": "^5.0.1"
       }
     },
     "strip-bom": {
@@ -25086,15 +24769,15 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.5.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.5.2.tgz",
-          "integrity": "sha512-tqkh47FzKeCPD2PUiPB6pkbMzsCasjxAfC62/Wap5qrUWcb+sFasXUC5I3gYM5iBM8v/Qpn4UK0x+j0iHyFPDg==",
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+          "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
           "dev": true
         },
         "qs": {
-          "version": "6.10.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.1.tgz",
-          "integrity": "sha512-M528Hph6wsSVOBiYUnGf+K/7w0hNshs/duGsNXPUCLH5XAqjEtiPGwNONLV0tBH8NoGb0mvD5JubnUTrujKDTg==",
+          "version": "6.10.3",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
+          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -25380,12 +25063,6 @@
       "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
       "dev": true
     },
-    "trim-off-newlines": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-off-newlines/-/trim-off-newlines-1.0.1.tgz",
-      "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
-      "dev": true
-    },
     "ts-jest": {
       "version": "26.5.6",
       "resolved": "https://registry.npmjs.org/ts-jest/-/ts-jest-26.5.6.tgz",
@@ -25603,55 +25280,17 @@
       }
     },
     "typedoc": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.19.2.tgz",
-      "integrity": "sha512-oDEg1BLEzi1qvgdQXc658EYgJ5qJLVSeZ0hQ57Eq4JXy6Vj2VX4RVo18qYxRWz75ifAaYuYNBUCnbhjd37TfOg==",
+      "version": "0.22.10",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.22.10.tgz",
+      "integrity": "sha512-hQYZ4WtoMZ61wDC6w10kxA42+jclWngdmztNZsDvIz7BMJg7F2xnT+uYsUa7OluyKossdFj9E9Ye4QOZKTy8SA==",
       "dev": true,
       "requires": {
-        "fs-extra": "^9.0.1",
-        "handlebars": "^4.7.6",
-        "highlight.js": "^10.2.0",
-        "lodash": "^4.17.20",
+        "glob": "^7.2.0",
         "lunr": "^2.3.9",
-        "marked": "^1.1.1",
-        "minimatch": "^3.0.0",
-        "progress": "^2.0.3",
-        "semver": "^7.3.2",
-        "shelljs": "^0.8.4",
-        "typedoc-default-themes": "^0.11.4"
-      },
-      "dependencies": {
-        "fs-extra": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-          "dev": true,
-          "requires": {
-            "at-least-node": "^1.0.0",
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
-        "marked": {
-          "version": "1.2.9",
-          "resolved": "https://registry.npmjs.org/marked/-/marked-1.2.9.tgz",
-          "integrity": "sha512-H8lIX2SvyitGX+TRdtS06m1jHMijKN/XjfH6Ooii9fvxMlh8QdqBfBDkGUpMWH2kQNrtixjzYUa3SH8ROTgRRw==",
-          "dev": true
-        },
-        "universalify": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-          "dev": true
-        }
+        "marked": "^3.0.8",
+        "minimatch": "^3.0.4",
+        "shiki": "^0.9.12"
       }
-    },
-    "typedoc-default-themes": {
-      "version": "0.11.4",
-      "resolved": "https://registry.npmjs.org/typedoc-default-themes/-/typedoc-default-themes-0.11.4.tgz",
-      "integrity": "sha512-Y4Lf+qIb9NTydrexlazAM46SSLrmrQRqWiD52593g53SsmUFioAsMWt8m834J6qsp+7wHRjxCXSZeiiW5cMUdw==",
-      "dev": true
     },
     "typescript": {
       "version": "4.3.4",
@@ -25894,6 +25533,18 @@
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.2.0.tgz",
+      "integrity": "sha512-Uw5ooOQxRASHgu6C7GVvUxisKXfSgW4oFlO+aa+PAkgmH89O3CXxEEzNRNtHSqtXFTl0nAC1uYj0GMSH27uwtQ==",
+      "dev": true
+    },
     "w3c-hr-time": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/w3c-hr-time/-/w3c-hr-time-1.0.2.tgz",
@@ -25913,9 +25564,9 @@
       }
     },
     "walk": {
-      "version": "2.3.14",
-      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
-      "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.15.tgz",
+      "integrity": "sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==",
       "requires": {
         "foreachasync": "^3.0.0"
       }
@@ -26005,11 +25656,6 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
-        "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
-        },
         "ansi-styles": {
           "version": "4.3.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -26030,14 +25676,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-        },
-        "strip-ansi": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-          "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dotenv": "^8.2.0",
     "eventsource": "^1.0.7",
     "express": "^4.17.1",
-    "hbs": "^4.1.1",
+    "hbs": "^4.2.0",
     "ioredis": "^4.27.8",
     "js-yaml": "^3.14.1",
     "lru-cache": "^6.0.0",
@@ -102,7 +102,7 @@
     "supertest": "^6.0.1",
     "ts-jest": "^26.4.4",
     "tsd": "^0.14.0",
-    "typedoc": "^0.19.2",
+    "typedoc": "^0.22.10",
     "typescript": "^4.1.2"
   },
   "engines": {


### PR DESCRIPTION
`hbs` depends on `handlebars` which had a vulnerability of critical severity

bumped `typedocs` as it was not compatible with the typescript version defined in dev dependencies.

package-lock had a version reference to ansi-regex v4.0.1 which had a vulnerability of moderate severity.