### PR TITLE
docs(development): fix `ProbotOctokit` usage example

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -271,7 +271,9 @@ const { ProbotOctokit } = require("probot");
 function myProbotApp(app) {
   const octokit = new ProbotOctokit({
     // any options you'd pass to Octokit
-    auth: "token <myToken>",
+    auth: {
+      token: "yourToken"
+    },
     // and a logger
     log: app.log.child({ name: "my-octokit" }),
   });

--- a/docs/development.md
+++ b/docs/development.md
@@ -272,7 +272,7 @@ function myProbotApp(app) {
   const octokit = new ProbotOctokit({
     // any options you'd pass to Octokit
     auth: {
-      token: "yourToken"
+      token: "yourToken",
     },
     // and a logger
     log: app.log.child({ name: "my-octokit" }),


### PR DESCRIPTION
The currently documented example

```
function myProbotApp(app) {
  const octokit = new ProbotOctokit({
    // any options you'd pass to Octokit
    auth: "token <myToken>",
    // and a logger
    log: app.log.child({ name: "my-octokit" }),
  });
}
```
does not work. It will return an error because of missing auth.

This PR modifies the example to show the currently supported way for token auth

-----
[View rendered docs/development.md](https://github.com/chris-schra/probot/blob/patch-1/docs/development.md)