### PR TITLE
feat(server): add logging options

### DIFF
--- a/src/server/logging-middleware.ts
+++ b/src/server/logging-middleware.ts
@@ -2,8 +2,9 @@ import pinoHttp from "pino-http";
 import type { Logger } from "pino";
 import { v4 as uuidv4 } from "uuid";
 
-export function getLoggingMiddleware(logger: Logger) {
+export function getLoggingMiddleware(logger: Logger, options?: pinoHttp.Options) {
   return pinoHttp({
+    ...options,
     logger: logger.child({ name: "http" }),
     customSuccessMessage(res) {
       const responseTime = Date.now() - res[pinoHttp.startTime];

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -45,7 +45,7 @@ export class Server {
       webhookProxy: options.webhookProxy,
     };
 
-    this.expressApp.use(getLoggingMiddleware(this.log));
+    this.expressApp.use(getLoggingMiddleware(this.log, options.loggingOptions));
     this.expressApp.use(
       "/probot/static/",
       express.static(join(__dirname, "..", "..", "static"))

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ import {
 } from "@octokit/webhooks";
 import LRUCache from "lru-cache";
 import Redis from "ioredis";
+import { Options as LoggingOptions } from "pino-http";
 
 import { Probot } from "./index";
 import { Context } from "./context";
@@ -64,6 +65,7 @@ export type ServerOptions = {
   webhookPath?: string;
   webhookProxy?: string;
   Probot: typeof Probot;
+  loggingOptions?: LoggingOptions;
 };
 
 export type MiddlewareOptions = {


### PR DESCRIPTION
## What

Enable to receive pino-http option to logging-middleware.

## Why

For example, even if normally want to handle all access logs, may need to exclude some endpoints. (e.g. health check endpoint). And, It may also be useful for developers to be able to specify other options.