### PR TITLE
fix: logging of first octokit instance is not set

### DIFF
--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -3,6 +3,7 @@ import { ProbotOctokit } from "./probot-octokit";
 import Redis from "ioredis";
 
 import { getOctokitThrottleOptions } from "./get-octokit-throttle-options";
+import { aliasLog } from "../helpers/alias-log";
 
 import type { Logger } from "pino";
 
@@ -45,6 +46,9 @@ export function getProbotOctokitWithDefaults(options: Options) {
 
   let defaultOptions: any = {
     auth: authOptions,
+    log: options.log.child
+      ? aliasLog(options.log.child({ name: "octokit" }))
+      : options.log,
   };
 
   if (options.baseUrl) {

--- a/test/create-probot.test.ts
+++ b/test/create-probot.test.ts
@@ -80,4 +80,24 @@ describe("createProbot", () => {
     });
     expect(JSON.parse(outputData).myMessage).toEqual("Ciao");
   });
+
+  test("env, octokit logger set", async () => {
+    const outputData = await captureLogOutput(async () => {
+      const probot = createProbot({
+        env: {
+          ...env,
+          LOG_LEVEL: "info",
+          LOG_FORMAT: "json",
+          LOG_MESSAGE_KEY: "myMessage",
+        },
+      });
+
+      const octokit = await probot.auth();
+      octokit.log.info("Ciao");
+    });
+    expect(JSON.parse(outputData)).toMatchObject({
+      myMessage: "Ciao",
+      name: "octokit",
+    });
+  });
 });


### PR DESCRIPTION
This should fix the logging in the default ocotkit instance from issue #1673