### PR TITLE
docs: wrong log call in `onError` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ module.exports = (app) => {
   });
 
   app.onError(async (error) => {
-    context.log.error(error);
+    app.log.error(error);
   });
 };
 ```


### PR DESCRIPTION
`context.log.error(error)` wouldn't work here since context is not exposed

-----
[View rendered README.md](https://github.com/atymchuk/probot/blob/patch-1/README.md)