### PR TITLE
docs: added an example of an aws deployment without the serverless fr…

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -158,6 +158,7 @@ Examples
 
 - Probot's "Hello, world!" example deployed to AWS Lambda: [probot/example-aws-lambda-serverless](https://github.com/probot/example-aws-lambda-serverless/#readme)
 - Issue labeler bot deployed to AWS Lambda: [riyadhalnur/issuelabeler](https://github.com/riyadhalnur/issuelabeler#issuelabeler)
+- Auto-Me-Bot is deployed to AWS Lambda without using the _serverless_ framework and adapter: [TomerFi/auto-me-bot](https://github.com/TomerFi/auto-me-bot)
 
 Please add yours!
 


### PR DESCRIPTION
Added an example _Probot_ app deployed to _AWS Lambda_ without using the _Serverless Framework_ and _Probot Adapter_.

-----
[View rendered docs/deployment.md](https://github.com/TomerFi/probot/blob/add-aws-example/docs/deployment.md)