### PR TITLE
feat: Support ESM apps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+      fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
       - run: npm run build
-      - run: npx jest
+      - run: NODE_OPTIONS='--experimental-vm-modules' npx jest
       - name: codecov
         run: npx codecov
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,9 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: NODE_OPTIONS='--experimental-vm-modules' npx jest
+      - run: npx jest
+        env:
+          NODE_OPTIONS: --experimental-vm-modules
   test:
     runs-on: ubuntu-latest
     needs: test_matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx jest
+      - run: NODE_OPTIONS='--experimental-vm-modules' npx jest
   test:
     runs-on: ubuntu-latest
     needs: test_matrix

--- a/package-lock.json
+++ b/package-lock.json
@@ -5074,20 +5074,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
-    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "lint:fix": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "pretest": "tsc --noEmit -p test",
-    "test": "jest",
+    "test": "NODE_OPTIONS='--experimental-vm-modules' jest",
     "posttest": "npm run lint",
     "doc": "typedoc --options .typedoc.json"
   },

--- a/src/helpers/resolve-app-function.ts
+++ b/src/helpers/resolve-app-function.ts
@@ -2,6 +2,7 @@ import { sync } from "resolve";
 
 const defaultOptions: ResolveOptions = {};
 
+// This is a workaround to prevent TypeScript from converting a dynamic import to require()
 const _importDynamic = new Function("modulePath", "return import(modulePath)");
 
 export const resolveAppFunction = async (
@@ -14,6 +15,7 @@ export const resolveAppFunction = async (
   const resolver: Resolver = opts.resolver || sync;
   const appFnPath = resolver(appFnId, { basedir });
   const mod = await _importDynamic(appFnPath);
+  // mod.default.default gets exported by transpiled TypeScript code
   return mod.default?.default ? mod.default.default : mod.default;
 };
 

--- a/src/helpers/resolve-app-function.ts
+++ b/src/helpers/resolve-app-function.ts
@@ -2,6 +2,8 @@ import { sync } from "resolve";
 
 const defaultOptions: ResolveOptions = {};
 
+const _importDynamic = new Function('modulePath', 'return import(modulePath)')
+
 export const resolveAppFunction = async (
   appFnId: string,
   opts?: ResolveOptions
@@ -11,9 +13,8 @@ export const resolveAppFunction = async (
   const basedir = opts.basedir || process.cwd();
   const resolver: Resolver = opts.resolver || sync;
   const appFnPath = resolver(appFnId, { basedir });
-  const mod = await import(appFnPath);
-  // Note: This needs "esModuleInterop" to be set to "true" in "tsconfig.json"
-  return mod.default;
+  const mod = await _importDynamic(appFnPath);
+  return mod.default?.default ? mod.default.default : mod.default;
 };
 
 export type Resolver = (appFnId: string, opts: { basedir: string }) => string;

--- a/src/helpers/resolve-app-function.ts
+++ b/src/helpers/resolve-app-function.ts
@@ -2,7 +2,7 @@ import { sync } from "resolve";
 
 const defaultOptions: ResolveOptions = {};
 
-const _importDynamic = new Function('modulePath', 'return import(modulePath)')
+const _importDynamic = new Function("modulePath", "return import(modulePath)");
 
 export const resolveAppFunction = async (
   appFnId: string,


### PR DESCRIPTION
Fixes #1684.

This would require Node 14, which is a breaking change, but Node 14 is the oldest still supported LTS version, so I think it's not a problem