### PR TITLE
docs: fix localhost link protocol

### DIFF
--- a/docs/http.md
+++ b/docs/http.md
@@ -24,7 +24,7 @@ module.exports = (app, { getRouter }) => {
 };
 ```
 
-Visit https://localhost:3000/my-app/hello-world to access the endpoint.
+Visit http://localhost:3000/my-app/hello-world to access the endpoint.
 
 It is strongly encouraged to use the name of your package as the prefix so none of your routes or middleware conflict with other apps. For example, if [`probot/owners`](https://github.com/probot/owners) exposed an endpoint, the app would call `getRouter('/owners')` to prefix all endpoints with `/owners`.
 


### PR DESCRIPTION
Fixes bad link to `https://` protocol on `localhost`.

-----
[View rendered docs/http.md](https://github.com/nickofthyme/probot/blob/patch-1/docs/http.md)