### PR TITLE
docs(deployment): Update Heroku branch name

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -108,7 +108,7 @@ Probot runs like [any other Node app](https://devcenter.heroku.com/articles/depl
 
 1.  Deploy the app to heroku with `git push`:
 
-        $ git push heroku master
+        $ git push heroku main
         ...
         -----> Node.js app detected
         ...


### PR DESCRIPTION
Heroku default deployment branch is now named "main" not "master"

-----
[View rendered docs/deployment.md](https://github.com/borgmanJeremy/probot/blob/patch-1/docs/deployment.md)