### PR TITLE
fix: Make `probot receive` support complex Probot apps

### DIFF
--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -1,6 +1,6 @@
 // Usage: probot receive -e push -p path/to/payload app.js
 
-import express, {Router} from "express";
+import express, { Router } from "express";
 
 require("dotenv").config();
 
@@ -10,7 +10,7 @@ import program from "commander";
 import { getPrivateKey } from "@probot/get-private-key";
 import { getLog } from "../helpers/get-log";
 
-import {ApplicationFunctionOptions, Probot} from "../";
+import { ApplicationFunctionOptions, Probot } from "../";
 import { resolveAppFunction } from "../helpers/resolve-app-function";
 
 async function main() {
@@ -97,10 +97,10 @@ async function main() {
   const options: ApplicationFunctionOptions = {
     getRouter: (path: string = "/") => {
       const newRouter = Router();
-      expressApp.use(path, newRouter)
-      return newRouter
-    }
-  }
+      expressApp.use(path, newRouter);
+      return newRouter;
+    },
+  };
 
   const appFn = await resolveAppFunction(
     path.resolve(process.cwd(), program.args[0])

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -10,7 +10,8 @@ import { getWebhooks } from "./octokit/get-webhooks";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 import { VERSION } from "./version";
 import {
-  ApplicationFunction, ApplicationFunctionOptions,
+  ApplicationFunction,
+  ApplicationFunctionOptions,
   DeprecatedLogger,
   Options,
   ProbotWebhooks,
@@ -104,7 +105,10 @@ export class Probot {
     return this.webhooks.receive(event);
   }
 
-  public async load(appFn: ApplicationFunction | ApplicationFunction[], options: ApplicationFunctionOptions = {}) {
+  public async load(
+    appFn: ApplicationFunction | ApplicationFunction[],
+    options: ApplicationFunctionOptions = {}
+  ) {
     if (Array.isArray(appFn)) {
       for (const fn of appFn) {
         await this.load(fn);

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -10,7 +10,7 @@ import { getWebhooks } from "./octokit/get-webhooks";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 import { VERSION } from "./version";
 import {
-  ApplicationFunction,
+  ApplicationFunction, ApplicationFunctionOptions,
   DeprecatedLogger,
   Options,
   ProbotWebhooks,
@@ -104,7 +104,7 @@ export class Probot {
     return this.webhooks.receive(event);
   }
 
-  public async load(appFn: ApplicationFunction | ApplicationFunction[]) {
+  public async load(appFn: ApplicationFunction | ApplicationFunction[], options: ApplicationFunctionOptions = {}) {
     if (Array.isArray(appFn)) {
       for (const fn of appFn) {
         await this.load(fn);
@@ -112,6 +112,6 @@ export class Probot {
       return;
     }
 
-    return appFn(this, {});
+    return appFn(this, options);
   }
 }


### PR DESCRIPTION
The command `probot receive` fails to work when:

1. The Probot appFn is asynchronous
2. The Probot appFn requires `getRouter`

The command `probot run` works fine though with the same Probot appFn.

This attempts to add support for these sorts of Probot apps when calling `probot receive`.