### PR TITLE
fix(receive): `--base-url` option and `GHE_HOST`

### DIFF
--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -59,7 +59,11 @@ async function main() {
       "--sentry-dsn <dsn>",
       'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"',
       process.env.SENTRY_DSN
-    )
+    ).option(
+      "--base-url <url>",
+      'GitHub API base URL. If you use GitHub Enterprise Server, and your hostname is "https://github.acme-inc.com", then the root URL is "https://github.acme-inc.com/api/v3"',
+      process.env.GHE_HOST ? `${process.env.GHE_PROTOCOL || "https"}://${process.env.GHE_HOST}/api/v3`
+      : "https://api.github.com")
     .parse(process.argv);
 
   const githubToken = program.token;
@@ -89,6 +93,7 @@ async function main() {
     privateKey: String(privateKey),
     githubToken: githubToken,
     log,
+    baseUrl: program.baseUrl
   });
 
   const appFn = await resolveAppFunction(

--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -65,8 +65,8 @@ async function main() {
       'GitHub API base URL. If you use GitHub Enterprise Server, and your hostname is "https://github.acme-inc.com", then the root URL is "https://github.acme-inc.com/api/v3"',
       process.env.GHE_HOST
         ? `${process.env.GHE_PROTOCOL || "https"}://${
-          process.env.GHE_HOST
-        }/api/v3`
+            process.env.GHE_HOST
+          }/api/v3`
         : "https://api.github.com"
     )
     .parse(process.argv);
@@ -98,7 +98,7 @@ async function main() {
     privateKey: String(privateKey),
     githubToken: githubToken,
     log,
-    baseUrl: program.baseUrl
+    baseUrl: program.baseUrl,
   });
 
   const appFn = await resolveAppFunction(

--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -59,11 +59,16 @@ async function main() {
       "--sentry-dsn <dsn>",
       'Set to your Sentry DSN, e.g. "https://1234abcd@sentry.io/12345"',
       process.env.SENTRY_DSN
-    ).option(
+    )
+    .option(
       "--base-url <url>",
       'GitHub API base URL. If you use GitHub Enterprise Server, and your hostname is "https://github.acme-inc.com", then the root URL is "https://github.acme-inc.com/api/v3"',
-      process.env.GHE_HOST ? `${process.env.GHE_PROTOCOL || "https"}://${process.env.GHE_HOST}/api/v3`
-      : "https://api.github.com")
+      process.env.GHE_HOST
+        ? `${process.env.GHE_PROTOCOL || "https"}://${
+          process.env.GHE_HOST
+        }/api/v3`
+        : "https://api.github.com"
+    )
     .parse(process.argv);
 
   const githubToken = program.token;


### PR DESCRIPTION
When testing probots on a self-hosted enterprise github instance, the command `probot receive -e push -p test/test-push.json ./index.js` does not recognize the GHE_HOST present in the .env file and does not allow the baseUrl to be modified in the receive arguments.

This change allows the GHE_HOST value in the .env file to be recognized and also allows the host to be modified in the arguments of the command.  Basically a copy and paste from read-cli-options.ts.
 
fixes #1556
fixes #1333