### PR TITLE
fix(run): pass additional options from run to appFn

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -13,6 +13,7 @@ import { isProduction } from "./helpers/is-production";
 
 type AdditionalOptions = {
   env: Record<string, string | undefined>;
+  [key: string]: unknown;
 };
 
 /**
@@ -114,7 +115,7 @@ export async function run(
         privateKey: "dummy value for setup, see #1512",
       }),
     });
-    await server.load(setupAppFactory(host, port));
+    await server.load(setupAppFactory(host, port), additionalOptions);
     await server.start();
     return server;
   }
@@ -123,28 +124,28 @@ export async function run(
     const pkg = await pkgConf("probot");
 
     const combinedApps: ApplicationFunction = async (app) => {
-      await server.load(defaultApp);
+      await server.load(defaultApp, additionalOptions);
 
       if (Array.isArray(pkg.apps)) {
         for (const appPath of pkg.apps) {
           const appFn = await resolveAppFunction(appPath);
-          await server.load(appFn);
+          await server.load(appFn, additionalOptions);
         }
       }
 
       const [appPath] = args;
       const appFn = await resolveAppFunction(appPath);
-      await server.load(appFn);
+      await server.load(appFn, additionalOptions);
     };
 
     server = new Server(serverOptions);
-    await server.load(combinedApps);
+    await server.load(combinedApps, additionalOptions);
     await server.start();
     return server;
   }
 
   server = new Server(serverOptions);
-  await server.load(appFnOrArgv);
+  await server.load(appFnOrArgv, additionalOptions);
   await server.start();
 
   return server;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -67,9 +67,13 @@ export class Server {
     this.expressApp.get("/ping", (req, res) => res.end("PONG"));
   }
 
-  public async load(appFn: ApplicationFunction) {
+  public async load(
+    appFn: ApplicationFunction,
+    additionalOptions?: Record<string, unknown>
+  ) {
     await appFn(this.probotApp, {
       getRouter: (path) => this.router(path),
+      ...additionalOptions,
     });
   }
 

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -3,7 +3,7 @@ import path = require("path");
 import request from "supertest";
 import { sign } from "@octokit/webhooks-methods";
 
-import { Probot, run, Server } from "../src";
+import { Probot, run, Server, ApplicationFunctionOptions } from "../src";
 
 import { captureLogOutput } from "./helpers/capture-log-output";
 
@@ -84,6 +84,23 @@ describe("run", () => {
       });
 
       expect(outputData).toMatch(/"msg":"test"/);
+    });
+
+    it("passes additional options to the loaded apps", async () => {
+      let receivedOptions: ApplicationFunctionOptions | undefined;
+
+      return new Promise(async (resolve) => {
+        server = await run(
+          (_app: Probot, options) => {
+            receivedOptions = options;
+          },
+          { env, foo: "bar" }
+        );
+        await server.stop();
+        expect(receivedOptions?.foo).toEqual("bar");
+
+        resolve(null);
+      });
     });
   });
 

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -55,6 +55,29 @@ describe("Server", () => {
     expect(Server.version).toEqual("0.0.0-development");
   });
 
+  describe("Server.load", () => {
+    it("should pass additionalOptions to the appFn", async () => {
+      server = new Server({
+        Probot: Probot.defaults({
+          appId,
+          privateKey,
+          secret: "secret",
+        }),
+        log: pino(streamLogsToOutput),
+        port: await getPort(),
+      });
+
+      await server.load(
+        (app, options) => {
+          expect(options?.extraOption).toBe(42);
+        },
+        {
+          extraOption: 42,
+        }
+      );
+    });
+  });
+
   describe("GET /ping", () => {
     it("returns a 200 response", async () => {
       await request(server.expressApp).get("/ping").expect(200, "PONG");


### PR DESCRIPTION
Allow programmatic way to pass options to the handler function through run.

Currently the `ApplicationFunctionOptions ` has following signature

```ts
export type ApplicationFunctionOptions = {
  getRouter?: (path?: string) => express.Router;
  [key: string]: unknown;
};
```

without any way to actually pass any extra keys. 