### PR TITLE
refactor: remove `log` argument from auth.ts to improve test coverage

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,5 +1,3 @@
-import type { Logger } from "pino";
-
 import { getAuthenticatedOctokit } from "./octokit/get-authenticated-octokit";
 import { ProbotOctokit } from "./octokit/probot-octokit";
 import type { State } from "./types";
@@ -20,6 +18,7 @@ import type { State } from "./types";
  *    });
  *  };
  * ```
+ * @param state - Probot application instance state, which is used to persist
  *
  * @param id - ID of the installation, which can be extracted from
  * `context.payload.installation.id`. If called without this parameter, the
@@ -32,10 +31,6 @@ import type { State } from "./types";
 export async function auth(
   state: State,
   installationId?: number,
-  log?: Logger,
 ): Promise<InstanceType<typeof ProbotOctokit>> {
-  return getAuthenticatedOctokit(
-    Object.assign({}, state, log ? { log } : null),
-    installationId,
-  );
+  return getAuthenticatedOctokit(Object.assign({}, state), installationId);
 }


### PR DESCRIPTION
I am currently trying to improve the test coverage. It seems that we dont use the log parameter so it is a dead branch.