### PR TITLE
fix: use `import()` instead of `require` to import `smee-client`

### DIFF
--- a/src/helpers/webhook-proxy.ts
+++ b/src/helpers/webhook-proxy.ts
@@ -2,11 +2,11 @@ import EventSource from "eventsource";
 
 import type { Logger } from "pino";
 
-export const createWebhookProxy = (
+export const createWebhookProxy = async (
   opts: WebhookProxyOptions,
-): EventSource | undefined => {
+): Promise<EventSource | undefined> => {
   try {
-    const SmeeClient = require("smee-client");
+    const SmeeClient = (await import("smee-client")).default;
     const smee = new SmeeClient({
       logger: opts.logger,
       source: opts.url,
@@ -22,7 +22,7 @@ export const createWebhookProxy = (
 };
 
 export interface WebhookProxyOptions {
-  url?: string;
+  url: string;
   port?: number;
   path?: string;
   logger: Logger;

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -18,8 +18,7 @@ export class ManifestCreation {
 
   public async createWebhookChannel() {
     try {
-      // tslint:disable:no-var-requires
-      const SmeeClient = require("smee-client");
+      const SmeeClient = (await import("smee-client")).default;
 
       await this.updateEnv({
         WEBHOOK_PROXY_URL: await SmeeClient.createChannel(),

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -90,14 +90,14 @@ export class Server {
       const server = this.expressApp.listen(
         port,
         ...((host ? [host] : []) as any),
-        () => {
+        async () => {
           if (webhookProxy) {
-            this.state.eventSource = createWebhookProxy({
+            this.state.eventSource = (await createWebhookProxy({
               logger: this.log,
               path: webhookPath,
               port: port,
               url: webhookProxy,
-            }) as EventSource;
+            })) as EventSource;
           }
           this.log.info(`Listening on http://${printableHost}:${port}`);
           resolve(server);

--- a/test/webhook-proxy.test.ts
+++ b/test/webhook-proxy.test.ts
@@ -39,15 +39,15 @@ describe("webhook-proxy", () => {
         emit = res.json;
       });
 
-      server = app.listen(0, () => {
+      server = app.listen(0, async () => {
         targetPort = (server.address() as net.AddressInfo).port;
         const url = `http://127.0.0.1:${targetPort}/events`;
-        proxy = createWebhookProxy({
+        proxy = (await createWebhookProxy({
           url,
           port: targetPort,
           path: "/test",
           logger: getLog({ level: "fatal" }),
-        })!;
+        })) as EventSource;
 
         // Wait for proxy to be ready
         proxy.addEventListener("ready", () => done());
@@ -77,12 +77,12 @@ describe("webhook-proxy", () => {
     const log = getLog({ level: "fatal" }).child({});
     log.error = jest.fn();
 
-    proxy = createWebhookProxy({ url, logger: log })!;
-
-    proxy.addEventListener("error", (error: any) => {
-      expect(error.status).toBe(404);
-      expect(log.error).toHaveBeenCalledWith(error);
-      done();
+    createWebhookProxy({ url, logger: log })!.then((proxy) => {
+      (proxy as EventSource).addEventListener("error", (error: any) => {
+        expect(error.status).toBe(404);
+        expect(log.error).toHaveBeenCalledWith(error);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
I assume that using require in an esm environment could break. 