### PR TITLE
fix: use `readFileSync` and `JSON.parse` instead of `require` in probot-receive

### DIFF
--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -4,6 +4,7 @@ import express, { Router } from "express";
 
 require("dotenv").config();
 
+import fs from "fs";
 import path from "path";
 import { randomUUID as uuidv4 } from "crypto";
 import program from "commander";
@@ -86,7 +87,9 @@ async function main() {
     );
   }
 
-  const payload = require(path.resolve(program.payloadPath));
+  const payload = JSON.parse(
+    fs.readFileSync(path.resolve(program.payloadPath), "utf8"),
+  );
   const log = getLog({
     level: program.logLevel,
     logFormat: program.logFormat,


### PR DESCRIPTION
I guess you could actually load arbitrary code into probot receive cli command. 