### PR TITLE
fix(deps): -semver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
         "pino-http": "^5.3.0",
         "pkg-conf": "^3.1.0",
         "resolve": "^1.19.0",
-        "semver": "^7.3.4",
         "update-dotenv": "^1.1.1"
       },
       "bin": {
@@ -54,7 +53,6 @@
         "@types/js-yaml": "^3.12.5",
         "@types/node": "^18.18.1",
         "@types/resolve": "^1.17.1",
-        "@types/semver": "^7.3.4",
         "@types/supertest": "^2.0.10",
         "body-parser": "^1.19.0",
         "bottleneck": "^2.19.5",
@@ -2992,12 +2990,6 @@
       "version": "1.20.2",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.2.tgz",
       "integrity": "sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==",
-      "dev": true
-    },
-    "node_modules/@types/semver": {
-      "version": "7.3.13",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.13.tgz",
-      "integrity": "sha512-21cFJr9z3g5dW8B0CVI9g2O9beqaThGQ6ZFBqHfwhzLDKUxaqTIy3vnfah/UPkfOiF2pLq+tGz+W8RyCskuslw==",
       "dev": true
     },
     "node_modules/@types/serve-static": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "pino-http": "^5.3.0",
     "pkg-conf": "^3.1.0",
     "resolve": "^1.19.0",
-    "semver": "^7.3.4",
     "update-dotenv": "^1.1.1"
   },
   "devDependencies": {
@@ -77,7 +76,6 @@
     "@types/js-yaml": "^3.12.5",
     "@types/node": "^18.18.1",
     "@types/resolve": "^1.17.1",
-    "@types/semver": "^7.3.4",
     "@types/supertest": "^2.0.10",
     "body-parser": "^1.19.0",
     "bottleneck": "^2.19.5",

--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -1,11 +1,11 @@
-import semver from "semver";
 import program from "commander";
+import { isSupportedNodeVersion } from "../helpers/is-supported-node-version";
 
 require("dotenv").config();
 
 const pkg = require("../../package");
 
-if (!semver.satisfies(process.version, pkg.engines.node)) {
+if (!isSupportedNodeVersion()) {
   console.log(
     `Node.js version ${pkg.engines.node} is required. You have ${process.version}.`,
   );

--- a/src/helpers/is-supported-node-version.ts
+++ b/src/helpers/is-supported-node-version.ts
@@ -1,0 +1,3 @@
+export function isSupportedNodeVersion(nodeVersion = process.versions.node) {
+  return Number(nodeVersion.split(".", 10)[0]) >= 18;
+}

--- a/test/bin/is-supported-node-version.test.ts
+++ b/test/bin/is-supported-node-version.test.ts
@@ -1,0 +1,21 @@
+import { isSupportedNodeVersion } from "../../src/helpers/is-supported-node-version";
+import { engines } from "../../package.json";
+
+describe("isSupportedNodeVersion", () => {
+  it(`engines value is set to ">=18"`, () => {
+    expect(engines.node).toBe(">=18");
+  });
+
+  it("returns true if node is bigger or equal v18", () => {
+    expect(isSupportedNodeVersion("18.0.0")).toBe(true);
+    expect(isSupportedNodeVersion("19.0.0")).toBe(true);
+    expect(isSupportedNodeVersion("20.0.0")).toBe(true);
+    expect(isSupportedNodeVersion("21.0.0")).toBe(true);
+  });
+
+  it("returns false if node is smaller than v18", () => {
+    expect(isSupportedNodeVersion("17.0.0")).toBe(false);
+    expect(isSupportedNodeVersion("17.9.0")).toBe(false);
+    expect(isSupportedNodeVersion("17.9.9")).toBe(false);
+  });
+});


### PR DESCRIPTION
We dont need semver. We maybe change the engines field every 6 month. For that we can manually write a function, which checks if the node version is correct. A unit test ensures that the tests fail if the engines field is changed but the validate function is not updated.