### PR TITLE
refactor: avoid require for `dotenv.config()`

### DIFF
--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -1,8 +1,8 @@
 // Usage: probot receive -e push -p path/to/payload app.js
 
 import express, { Router } from "express";
-
-require("dotenv").config();
+import { config as dotenvConfig } from "dotenv";
+dotenvConfig();
 
 import path from "path";
 import { randomUUID as uuidv4 } from "crypto";

--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -1,7 +1,8 @@
 import program from "commander";
 import { isSupportedNodeVersion } from "../helpers/is-supported-node-version";
+import { config as dotenvConfig } from "dotenv";
 
-require("dotenv").config();
+dotenvConfig();
 
 const pkg = require("../../package");
 

--- a/src/run.ts
+++ b/src/run.ts
@@ -10,6 +10,7 @@ import { Server } from "./server/server";
 import { defaultApp } from "./apps/default";
 import { resolveAppFunction } from "./helpers/resolve-app-function";
 import { isProduction } from "./helpers/is-production";
+import { config as dotenvConfig } from "dotenv";
 
 type AdditionalOptions = {
   env: Record<string, string | undefined>;
@@ -23,7 +24,7 @@ export async function run(
   appFnOrArgv: ApplicationFunction | string[],
   additionalOptions?: AdditionalOptions,
 ) {
-  require("dotenv").config();
+  dotenvConfig();
 
   const envOptions = readEnvOptions(additionalOptions?.env);
   const cliOptions = Array.isArray(appFnOrArgv)


### PR DESCRIPTION
This and #1890 and #1891 will remove all require calls. 