### PR TITLE
chore(ci): add dependency review and license check for production dependencies

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,8 +7,47 @@ name: Test
     types:
       - opened
       - synchronize
+
 jobs:
+  dependency-review:
+    name: Dependency Review
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Dependency review
+        uses: actions/dependency-review-action@v3
+
+  license-check:
+    name: Check Licenses
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check Licenses
+        run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;Python-2.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT"
+
   test_matrix:
+    needs:
+      - license-check
     strategy:
       matrix:
         node-version:
@@ -30,7 +69,8 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: npx jest
-  test:
+
+  test-codecov:
     runs-on: ubuntu-latest
     needs: test_matrix
     steps:


### PR DESCRIPTION
This is what we do in [fastify](https://github.com/fastify/workflows/blob/main/.github/workflows/plugins-ci.yml)

We use the license-checker and not the option of dependency review action, because the license-checker was more reliable in the past. 

We have to be careful, as e.g. @isaacs is moving to the BlueOak license for his packages and isaacs controles alot of dependencies e.g. `glob`. Blue Oak is not OSI approved and could result in license issues for projects dependending on probot, if we are not careful to detect them in the production dependencies. So if e.g. isaacs decides that he wants to move from MIT to BlueOak for glob, we need to detect that.