### PR TITLE
ci: split lint job from test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,19 @@ jobs:
       - name: Check Licenses
         run: npx license-checker --production --summary --onlyAllow="0BSD;Apache-2.0;Apache 2.0;Python-2.0;BSD-2-Clause;BSD-3-Clause;ISC;MIT"
 
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js lts
+        uses: actions/setup-node@v3
+        with:
+          node-version: lts/*
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+
   test_matrix:
     name: Test on Node ${{ matrix.node-version }} and ${{ matrix.os }}
     strategy:
@@ -68,7 +81,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run test
+      - run: npm run test:unit
   test:
     runs-on: ubuntu-latest
     needs: test_matrix

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npm run test:unit
+      - run: npm run test
   test:
     runs-on: ubuntu-latest
     needs: test_matrix

--- a/package.json
+++ b/package.json
@@ -13,10 +13,9 @@
     "lint": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "lint:fix": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "pretest": "npm run build && tsc --noEmit -p test",
-    "test": "vitest run && npm run lint",
+    "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:dev": "vitest --ui --coverage",
-    "test:unit": "vitest run",
     "doc": "typedoc --options .typedoc.json"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "lint": "prettier --check \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "lint:fix": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\" \"docs/*.md\" *.md package.json tsconfig.json --end-of-line auto",
     "pretest": "npm run build && tsc --noEmit -p test",
-    "test": "vitest run",
-    "test:dev": "vitest --ui --coverage",
+    "test": "vitest run && npm run lint",
     "test:coverage": "vitest run --coverage",
-    "posttest": "npm run lint",
+    "test:dev": "vitest --ui --coverage",
+    "test:unit": "vitest run",
     "doc": "typedoc --options .typedoc.json"
   },
   "files": [


### PR DESCRIPTION
Because of #1901 I think it would be nicer to split linting and testing inthe workflows. Should also slightly improve test runs on the CI, because we only need to run the linting once. 