### PR TITLE
test: 100% probot octokit

### DIFF
--- a/src/octokit/probot-octokit.ts
+++ b/src/octokit/probot-octokit.ts
@@ -49,11 +49,13 @@ export const ProbotOctokit = Octokit.plugin(
   config,
 ).defaults((instanceOptions: any) => {
   // merge throttle options deeply
-  const options = Object.assign({}, defaultOptions, instanceOptions, {
-    throttle: instanceOptions.throttle
-      ? Object.assign({}, defaultOptions.throttle, instanceOptions.throttle)
-      : defaultOptions.throttle,
-  });
+  const options = {
+    ...defaultOptions,
+    ...instanceOptions,
+    ...{
+      throttle: { ...defaultOptions.throttle, ...instanceOptions?.throttle },
+    },
+  };
 
   return options;
 });


### PR DESCRIPTION
This PR reveals, that we have some typings issue with the throttling plugin. We are setting some default values, e.g. `onRateLimit`, so theoretically they are not mandatory. But because we dont reflect this in the ProbotOctokit constructor, they are still mandatory. 