### PR TITLE
fix(deps): `@octokit/webhooks` 
security update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/plugin-retry": "^3.0.6",
         "@octokit/plugin-throttling": "^3.3.4",
         "@octokit/types": "^8.0.0",
-        "@octokit/webhooks": "^9.26.1",
+        "@octokit/webhooks": "^9.26.3",
         "@probot/get-private-key": "^1.1.0",
         "@probot/octokit-plugin-config": "^1.0.0",
         "@probot/pino": "^2.2.0",
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "9.26.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.1.tgz",
-      "integrity": "sha512-Tkht0rGz0f18V3yxCGFk8EL4TAWRtW4y5yLUMTOBeMsBHBsHEW+fUfYXum7F0hfNiMr6y1U3sztWuwxBl9cshA==",
+      "version": "9.26.3",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.3.tgz",
+      "integrity": "sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==",
       "dependencies": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
@@ -16153,9 +16153,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "9.26.1",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.1.tgz",
-      "integrity": "sha512-Tkht0rGz0f18V3yxCGFk8EL4TAWRtW4y5yLUMTOBeMsBHBsHEW+fUfYXum7F0hfNiMr6y1U3sztWuwxBl9cshA==",
+      "version": "9.26.3",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.3.tgz",
+      "integrity": "sha512-DLGk+gzeVq5oK89Bo601txYmyrelMQ7Fi5EnjHE0Xs8CWicy2xkmnJMKptKJrBJpstqbd/9oeDFi/Zj2pudBDQ==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@octokit/plugin-retry": "^3.0.6",
         "@octokit/plugin-throttling": "^3.3.4",
         "@octokit/types": "^8.0.0",
-        "@octokit/webhooks": "^9.8.4",
+        "@octokit/webhooks": "^9.26.1",
         "@probot/get-private-key": "^1.1.0",
         "@probot/octokit-plugin-config": "^1.0.0",
         "@probot/pino": "^2.2.0",
@@ -1854,9 +1854,9 @@
       }
     },
     "node_modules/@octokit/webhooks": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.0.tgz",
-      "integrity": "sha512-foZlsgrTDwAmD5j2Czn6ji10lbWjGDVsUxTIydjG9KTkAWKJrFapXJgO5SbGxRwfPd3OJdhK3nA2YPqVhxLXqA==",
+      "version": "9.26.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.1.tgz",
+      "integrity": "sha512-Tkht0rGz0f18V3yxCGFk8EL4TAWRtW4y5yLUMTOBeMsBHBsHEW+fUfYXum7F0hfNiMr6y1U3sztWuwxBl9cshA==",
       "dependencies": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",
@@ -16153,9 +16153,9 @@
       }
     },
     "@octokit/webhooks": {
-      "version": "9.26.0",
-      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.0.tgz",
-      "integrity": "sha512-foZlsgrTDwAmD5j2Czn6ji10lbWjGDVsUxTIydjG9KTkAWKJrFapXJgO5SbGxRwfPd3OJdhK3nA2YPqVhxLXqA==",
+      "version": "9.26.1",
+      "resolved": "https://registry.npmjs.org/@octokit/webhooks/-/webhooks-9.26.1.tgz",
+      "integrity": "sha512-Tkht0rGz0f18V3yxCGFk8EL4TAWRtW4y5yLUMTOBeMsBHBsHEW+fUfYXum7F0hfNiMr6y1U3sztWuwxBl9cshA==",
       "requires": {
         "@octokit/request-error": "^2.0.2",
         "@octokit/webhooks-methods": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@octokit/plugin-retry": "^3.0.6",
     "@octokit/plugin-throttling": "^3.3.4",
     "@octokit/types": "^8.0.0",
-    "@octokit/webhooks": "^9.8.4",
+    "@octokit/webhooks": "^9.26.1",
     "@probot/get-private-key": "^1.1.0",
     "@probot/octokit-plugin-config": "^1.0.0",
     "@probot/pino": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@octokit/plugin-retry": "^3.0.6",
     "@octokit/plugin-throttling": "^3.3.4",
     "@octokit/types": "^8.0.0",
-    "@octokit/webhooks": "^9.26.1",
+    "@octokit/webhooks": "^9.26.3",
     "@probot/get-private-key": "^1.1.0",
     "@probot/octokit-plugin-config": "^1.0.0",
     "@probot/pino": "^2.2.0",


### PR DESCRIPTION
This is a security update, we need to make a release for the current version. `beta` needs to be updated to its respective latest @octokit/webhooks version as well