### PR TITLE
ci: Speed up CI by skipping build

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,6 @@ jobs:
           node-version: ${{ matrix.node-version }}
           cache: npm
       - run: npm ci
-      - run: npm run build
       - run: npm run test
 
   test-redis:
@@ -102,7 +101,6 @@ jobs:
           node-version: lts/*
           cache: npm
       - run: npm ci
-      - run: npm run build
       - run: npm run test
         env:
           REDIS_HOST: 127.0.0.1
@@ -120,7 +118,6 @@ jobs:
           cache: npm
           node-version: lts/*
       - run: npm ci
-      - run: npm run build
       - run: npm run test:coverage
       - name: codecov
         run: npx codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,6 +118,7 @@ jobs:
           cache: npm
           node-version: lts/*
       - run: npm ci
+      - run: npm run build
       - run: npm run test:coverage
       - name: codecov
         run: npx codecov


### PR DESCRIPTION
Because build is run by pretest automatically, we're currently building twice.