### PR TITLE
fix: derive `Server` log from `Probot` log

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -5,7 +5,6 @@ import { join } from "path";
 import type { Logger } from "pino";
 import { createNodeMiddleware as createWebhooksMiddleware } from "@octokit/webhooks";
 
-import { getLog } from "../helpers/get-log";
 import { getLoggingMiddleware } from "./logging-middleware";
 import { createWebhookProxy } from "../helpers/webhook-proxy";
 import { VERSION } from "../version";
@@ -38,10 +37,10 @@ export class Server {
 
   constructor(options: ServerOptions = {} as ServerOptions) {
     this.expressApp = express();
-    this.log = options.log || getLog().child({ name: "server" });
     this.probotApp = new options.Probot({
       request: options.request,
     });
+    this.log = options.log || this.probotApp.log.child({ name: "server" });
 
     this.state = {
       cwd: options.cwd || process.cwd(),


### PR DESCRIPTION
Fixes #1490