### PR TITLE
ci(workflow): fix `test` workflow to assure it is not skipped if dependant jobs fails

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,7 +114,7 @@ jobs:
         run: npm run test
         env:
           REDIS_HOST: 127.0.0.1
-                
+
   test:
     runs-on: ubuntu-latest
     needs:
@@ -122,6 +122,8 @@ jobs:
       - test-redis
 
     steps:
+      - run: exit 1
+        if: ${{ needs.test-unit.result != 'success' || needs.test-redis.result != 'success' }}
       - name: Check out repository
         uses: actions/checkout@v4
         with:
@@ -141,3 +143,4 @@ jobs:
         run: npx codecov
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+    if: ${{ always() }}


### PR DESCRIPTION
# Description

Assure 'test' Check Run is always executed and `fails`/`succeeds` accordingly to the results of its dependency jobs.

- Example commit with all tests passing ✅: https://github.com/octokit/auth-oauth-device.js/commit/c4a2c50e7eb30baa6b3fb54c75e3c31429c591ed
- Example commit with tests failing 🔴: octokit/auth-oauth-device.js@8d93278aa268be6706f97c973a17d3d05cbac53f

---
# Context
When using `job.needs`, [by default only runs when the dependency jobs succeed](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idneeds). If one or more of them fail, the dependent job is **skipped**