### PR TITLE
chore: add comment to `SimplifiedObject`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,7 @@ export type State = {
 };
 
 // Omit the `payload`, `id`,`name` properties from the `Context` class as they are already present in the types of `WebhookEvent`
-// The `Webhooks` class accept a type parameter (`TTransformed`) that is used to transform the event payload in the form of
+// The `Webhooks` class accepts a type parameter (`TTransformed`) that is used to transform the event payload in the form of
 // WebhookEvent["payload"] & T
 // Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer
 // See https://github.com/probot/probot/issues/1388

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,6 +50,12 @@ export type State = {
   request?: RequestRequestOptions;
 };
 
+// Omit the `payload`, `id`,`name` properties from `Context` as they are already present in the types of `WebhookEvent`
+// The `Webhooks` class accept a type parameter (`TTransformed`) that is used to transform the event payload in the form of
+// WebhookEvent["payload"] & T
+// Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer
+// See https://github.com/probot/probot/issues/1388
+// See https://github.com/probot/probot/issues/1815 as for why this is in a seperate type, and not directly passed to `Webhooks`
 type SimplifiedObject = Omit<Context, keyof WebhookEvent>;
 export type ProbotWebhooks = Webhooks<SimplifiedObject>;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type State = {
   request?: RequestRequestOptions;
 };
 
-// Omit the `payload`, `id`,`name` properties from `the Context` class as they are already present in the types of `WebhookEvent`
+// Omit the `payload`, `id`,`name` properties from the `Context` class as they are already present in the types of `WebhookEvent`
 // The `Webhooks` class accept a type parameter (`TTransformed`) that is used to transform the event payload in the form of
 // WebhookEvent["payload"] & T
 // Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export type State = {
   request?: RequestRequestOptions;
 };
 
-// Omit the `payload`, `id`,`name` properties from `Context` as they are already present in the types of `WebhookEvent`
+// Omit the `payload`, `id`,`name` properties from `the Context` class as they are already present in the types of `WebhookEvent`
 // The `Webhooks` class accept a type parameter (`TTransformed`) that is used to transform the event payload in the form of
 // WebhookEvent["payload"] & T
 // Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer


### PR DESCRIPTION
This documents the different reasons for the `SimplifiedObject` type, starting from the `Omit`, and finishing with the type itself