### PR TITLE
fix: add node prefix for builtin modules

### DIFF
--- a/src/apps/default.ts
+++ b/src/apps/default.ts
@@ -1,7 +1,7 @@
+import { resolve } from "node:path";
+
 import type { ApplicationFunctionOptions, Probot } from "../index.js";
 import { loadPackageJson } from "../helpers/load-package-json.js";
-import { resolve } from "path";
-
 import { probotView } from "../views/probot.js";
 
 export function defaultApp(

--- a/src/apps/setup.ts
+++ b/src/apps/setup.ts
@@ -1,6 +1,6 @@
-import express from "express";
-import { exec } from "child_process";
-import type { Request, Response } from "express";
+import { exec } from "node:child_process";
+
+import express, { type Request, type Response } from "express";
 import updateDotenv from "update-dotenv";
 
 import { Probot } from "../probot.js";

--- a/src/bin/probot-receive.ts
+++ b/src/bin/probot-receive.ts
@@ -1,12 +1,12 @@
 // Usage: probot receive -e push -p path/to/payload app.js
+import fs from "node:fs";
+import path from "node:path";
+import { randomUUID as uuidv4 } from "node:crypto";
 
 import express, { Router } from "express";
 import { config as dotenvConfig } from "dotenv";
 dotenvConfig();
 
-import fs from "fs";
-import path from "path";
-import { randomUUID as uuidv4 } from "crypto";
 import { program } from "commander";
 import { getPrivateKey } from "@probot/get-private-key";
 import { getLog } from "../helpers/get-log.js";

--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -1,8 +1,10 @@
+import { resolve } from "node:path";
+
 import { program } from "commander";
+import { config as dotenvConfig } from "dotenv";
 import { isSupportedNodeVersion } from "../helpers/is-supported-node-version.js";
 import { loadPackageJson } from "../helpers/load-package-json.js";
-import { config as dotenvConfig } from "dotenv";
-import { resolve } from "path";
+
 /*import { dirname } from 'path';
 import { fileURLToPath } from 'url';*/
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 import merge from "deepmerge";
 
 import type { EmitterWebhookEvent as WebhookEvent } from "@octokit/webhooks";

--- a/src/helpers/load-package-json.ts
+++ b/src/helpers/load-package-json.ts
@@ -1,5 +1,6 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
+
 import type { PackageJson } from "../types.js";
 
 export function loadPackageJson(

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -1,11 +1,13 @@
-import fs from "fs";
+import fs from "node:fs";
+import path from "node:path";
+
 import yaml from "js-yaml";
-import path from "path";
 import updateDotenv from "update-dotenv";
+import type { RequestParameters } from "@octokit/types";
+
 import { ProbotOctokit } from "./octokit/probot-octokit.js";
 import { loadPackageJson } from "./helpers/load-package-json.js";
 import type { Env, Manifest, OctokitOptions, PackageJson } from "./types.js";
-import type { RequestParameters } from "@octokit/types";
 
 export class ManifestCreation {
   get pkg() {

--- a/src/server/logging-middleware.ts
+++ b/src/server/logging-middleware.ts
@@ -1,6 +1,7 @@
+import { randomUUID as uuidv4 } from "node:crypto";
+
 import { pinoHttp, startTime, type Options, type HttpLogger } from "pino-http";
 import type { Logger } from "pino";
-import { randomUUID as uuidv4 } from "crypto";
 
 export function getLoggingMiddleware(
   logger: Logger,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,7 +1,7 @@
-import { Server as HttpServer } from "http";
+import type { Server as HttpServer } from "node:http";
+import { join } from "node:path";
 
 import express, { Router, type Application } from "express";
-import { join } from "path";
 import type { Logger } from "pino";
 import { createNodeMiddleware as createWebhooksMiddleware } from "@octokit/webhooks";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -97,6 +97,9 @@ export type PackageJson = {
   description?: string;
   homepage?: string;
   repository?: string;
+  engines?: {
+    [key: string]: string;
+  };
 };
 
 export type Env = Record<Uppercase<string>, string>;

--- a/test/apps/default.test.ts
+++ b/test/apps/default.test.ts
@@ -1,4 +1,4 @@
-import Stream from "stream";
+import Stream from "node:stream";
 
 import { pino } from "pino";
 import request from "supertest";

--- a/test/apps/setup.test.ts
+++ b/test/apps/setup.test.ts
@@ -1,9 +1,9 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { Stream } from "node:stream";
 
 import fetchMock from "fetch-mock";
-import { Stream } from "stream";
-import request from "supertest";
 import { pino } from "pino";
+import request from "supertest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
 import { Probot, Server } from "../../src/index.js";
 import { setupAppFactory } from "../../src/apps/setup.js";

--- a/test/bin/is-supported-node-version.test.ts
+++ b/test/bin/is-supported-node-version.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect } from "vitest";
 
 import { isSupportedNodeVersion } from "../../src/helpers/is-supported-node-version.js";
-import { engines } from "../../package.json";
+import { loadPackageJson } from "../../src/helpers/load-package-json.js";
 
 describe("isSupportedNodeVersion", () => {
+  const { engines } = loadPackageJson();
   it(`engines value is set to ">=18"`, () => {
-    expect(engines.node).toBe(">=18");
+    expect(engines!.node).toBe(">=18");
   });
 
   it("returns true if node is bigger or equal v18", () => {

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -1,5 +1,5 @@
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 
 import type { EmitterWebhookEvent as WebhookEvent } from "@octokit/webhooks";
 import WebhookExamples from "@octokit/webhooks-examples";

--- a/test/create-node-middleware.test.ts
+++ b/test/create-node-middleware.test.ts
@@ -1,5 +1,5 @@
-import { createServer, IncomingMessage, ServerResponse } from "http";
-import Stream from "stream";
+import { createServer, IncomingMessage, ServerResponse } from "node:http";
+import Stream from "node:stream";
 
 import { pino } from "pino";
 import getPort from "get-port";

--- a/test/helpers/load-package-json.test.ts
+++ b/test/helpers/load-package-json.test.ts
@@ -1,5 +1,5 @@
 import { loadPackageJson } from "../../src/helpers/load-package-json.js";
-import { resolve } from "path";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 describe("loadPackageJson", () => {

--- a/test/integration/integration-smee.test.ts
+++ b/test/integration/integration-smee.test.ts
@@ -1,4 +1,4 @@
-import { Writable } from "stream";
+import { Writable } from "node:stream";
 import { ManifestCreation } from "../../src/manifest-creation.js";
 import { describe, test, expect, afterEach } from "vitest";
 import getPort from "get-port";

--- a/test/manifest-creation.test.ts
+++ b/test/manifest-creation.test.ts
@@ -1,13 +1,21 @@
-import fs from "fs";
-import pkg from "../package.json";
-import { ManifestCreation } from "../src/manifest-creation.js";
-import response from "./fixtures/setup/response.json";
+import fs from "node:fs";
+import path from "node:path";
 import fetchMock from "fetch-mock";
 import { describe, expect, test, beforeEach, afterEach, vi } from "vitest";
+
+import { ManifestCreation } from "../src/manifest-creation.js";
+import { loadPackageJson } from "../src/helpers/load-package-json.js";
 
 describe("ManifestCreation", () => {
   let setup: ManifestCreation;
 
+  const pkg = loadPackageJson();
+  const response = JSON.parse(
+    fs.readFileSync(
+      path.resolve(process.cwd(), "./test/fixtures/setup/response.json"),
+      "utf8",
+    ),
+  );
   beforeEach(() => {
     setup = new ManifestCreation();
   });

--- a/test/probot.test.ts
+++ b/test/probot.test.ts
@@ -1,4 +1,4 @@
-import Stream from "stream";
+import Stream from "node:stream";
 
 import type {
   EmitterWebhookEvent,

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -1,4 +1,4 @@
-import path from "path";
+import path from "node:path";
 
 import request from "supertest";
 import { sign } from "@octokit/webhooks-methods";

--- a/test/server.test.ts
+++ b/test/server.test.ts
@@ -1,4 +1,4 @@
-import Stream from "stream";
+import Stream from "node:stream";
 
 import type { NextFunction, Request, Response } from "express";
 import request from "supertest";

--- a/test/server/logging-middleware.test.ts
+++ b/test/server/logging-middleware.test.ts
@@ -1,4 +1,4 @@
-import Stream from "stream";
+import Stream from "node:stream";
 
 import express from "express";
 import request from "supertest";

--- a/test/webhook-proxy.test.ts
+++ b/test/webhook-proxy.test.ts
@@ -1,4 +1,7 @@
-import { randomInt } from "crypto";
+import { randomInt } from "node:crypto";
+import http from "node:http";
+import net from "node:net";
+
 import express, { type Response } from "express";
 const sse: (
   req: express.Request,
@@ -7,8 +10,6 @@ const sse: (
 ) => void = require("connect-sse")();
 import fetchMock from "fetch-mock";
 import EventSource from "eventsource";
-import http from "http";
-import net from "net";
 import { describe, expect, afterEach, test, vi } from "vitest";
 import { getLog } from "../src/helpers/get-log.js";
 import { createWebhookProxy } from "../src/helpers/webhook-proxy.js";


### PR DESCRIPTION
I was playing around with deno. It does not like if built ins are not loaded with node prefix and json files need to be imported with assert json.

Lets see if the ci passes.