### PR TITLE
poc: server 

### DIFF
--- a/example/server.cjs
+++ b/example/server.cjs
@@ -1,0 +1,69 @@
+'use strict';
+
+const { sign } = require("@octokit/webhooks-methods");
+const { Server, createProbot } = require("../lib");
+const WebhookExamples = require("@octokit/webhooks-examples");
+
+process.env.APP_ID = "123";
+process.env.PRIVATE_KEY = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEA1c7+9z5Pad7OejecsQ0bu3aozN3tihPmljnnudb9G3HECdnH
+lWu2/a1gB9JW5TBQ+AVpum9Okx7KfqkfBKL9mcHgSL0yWMdjMfNOqNtrQqKlN4kE
+p6RD++7sGbzbfZ9arwrlD/HSDAWGdGGJTSOBM6pHehyLmSC3DJoR/CTu0vTGTWXQ
+rO64Z8tyXQPtVPb/YXrcUhbBp8i72b9Xky0fD6PkEebOy0Ip58XVAn2UPNlNOSPS
+ye+Qjtius0Md4Nie4+X8kwVI2Qjk3dSm0sw/720KJkdVDmrayeljtKBx6AtNQsSX
+gzQbeMmiqFFkwrG1+zx6E7H7jqIQ9B6bvWKXGwIDAQABAoIBAD8kBBPL6PPhAqUB
+K1r1/gycfDkUCQRP4DbZHt+458JlFHm8QL6VstKzkrp8mYDRhffY0WJnYJL98tr4
+4tohsDbqFGwmw2mIaHjl24LuWXyyP4xpAGDpl9IcusjXBxLQLp2m4AKXbWpzb0OL
+Ulrfc1ZooPck2uz7xlMIZOtLlOPjLz2DuejVe24JcwwHzrQWKOfA11R/9e50DVse
+hnSH/w46Q763y4I0E3BIoUMsolEKzh2ydAAyzkgabGQBUuamZotNfvJoDXeCi1LD
+8yNCWyTlYpJZJDDXooBU5EAsCvhN1sSRoaXWrlMSDB7r/E+aQyKua4KONqvmoJuC
+21vSKeECgYEA7yW6wBkVoNhgXnk8XSZv3W+Q0xtdVpidJeNGBWnczlZrummt4xw3
+xs6zV+rGUDy59yDkKwBKjMMa42Mni7T9Fx8+EKUuhVK3PVQyajoyQqFwT1GORJNz
+c/eYQ6VYOCSC8OyZmsBM2p+0D4FF2/abwSPMmy0NgyFLCUFVc3OECpkCgYEA5OAm
+I3wt5s+clg18qS7BKR2DuOFWrzNVcHYXhjx8vOSWV033Oy3yvdUBAhu9A1LUqpwy
+Ma+unIgxmvmUMQEdyHQMcgBsVs10dR/g2xGjMLcwj6kn+xr3JVIZnbRT50YuPhf+
+ns1ScdhP6upo9I0/sRsIuN96Gb65JJx94gQ4k9MCgYBO5V6gA2aMQvZAFLUicgzT
+u/vGea+oYv7tQfaW0J8E/6PYwwaX93Y7Q3QNXCoCzJX5fsNnoFf36mIThGHGiHY6
+y5bZPPWFDI3hUMa1Hu/35XS85kYOP6sGJjf4kTLyirEcNKJUWH7CXY+00cwvTkOC
+S4Iz64Aas8AilIhRZ1m3eQKBgQCUW1s9azQRxgeZGFrzC3R340LL530aCeta/6FW
+CQVOJ9nv84DLYohTVqvVowdNDTb+9Epw/JDxtDJ7Y0YU0cVtdxPOHcocJgdUGHrX
+ZcJjRIt8w8g/s4X6MhKasBYm9s3owALzCuJjGzUKcDHiO2DKu1xXAb0SzRcTzUCn
+7daCswKBgQDOYPZ2JGmhibqKjjLFm0qzpcQ6RPvPK1/7g0NInmjPMebP0K6eSPx0
+9/49J6WTD++EajN7FhktUSYxukdWaCocAQJTDNYP0K88G4rtC2IYy5JFn9SWz5oh
+x//0u+zd/R/QRUzLOw4N72/Hu+UG6MNt5iDZFCtapRaKt6OvSBwy8w==
+-----END RSA PRIVATE KEY-----`;
+process.env.WEBHOOK_SECRET = "secret";
+process.env.WEBHOOK_PATH = "/";
+process.env.LOG_LEVEL = "silent";
+
+const pushEvent = JSON.stringify((
+  WebhookExamples.filter(
+    (event) => event.name === "push",
+  )[0]
+).examples[0]);
+
+const appFn = (app) => {
+  app.on("issues.opened", async (context) => {
+    const issueComment = context.issue({
+      body: "Thanks for opening this issue!",
+    });
+    return context.octokit.issues.createComment(issueComment);
+  });
+
+  app.onAny(async (context) => {
+    context.log.info({ event: context.name, action: context.payload.action });
+  });
+
+  app.onError(async (error) => {
+    app.log.error(error);
+  });
+};
+
+const server = new Server({
+});
+server.load(appFn);
+
+server.start().then(async () => {
+    console.log("Probot started http://localhost:3000/")
+    console.log(`autocannon -m POST -b '${pushEvent}' -H content-type=application/json -H x-github-event=push -H x-github-delivery=1 -H x-hub-signature-256=${await sign("secret", pushEvent)} http://127.0.0.1:3000/`)
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,6 +76,9 @@ export type ServerOptions = {
   host?: string;
   webhookPath?: string;
   webhookProxy?: string;
+  appId?: string;
+  privateKey?: string;
+  secret?: string;
   Probot: typeof Probot;
   loggingOptions?: LoggingOptions;
   request?: RequestRequestOptions;


### PR DESCRIPTION
This is a poc for https://github.com/octokit/webhooks.js/pull/932

I think I will also take some parts of this PR to the beta. E.g. loglevel is not passed through every layer, resulting in logging everything, which can slow down significantly. 

I used npm link on the @octokit/webhooks.js branch I proposed to test it here. So the ci wont work.

Anyway here some naive benchmarks.

before:
```

┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 1 ms │ 2 ms │ 6 ms  │ 7 ms │ 2.28 ms │ 1.45 ms │ 40 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬────────┬────────┬────────┬────────┬─────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%    │ 97.5%  │ Avg     │ Stdev  │ Min    │
├───────────┼────────┼────────┼────────┼────────┼─────────┼────────┼────────┤
│ Req/Sec   │ 2167   │ 2167   │ 3813   │ 4009   │ 3607.91 │ 546.98 │ 2166   │
├───────────┼────────┼────────┼────────┼────────┼─────────┼────────┼────────┤
│ Bytes/Sec │ 321 kB │ 321 kB │ 565 kB │ 593 kB │ 534 kB  │ 81 kB  │ 321 kB │
└───────────┴────────┴────────┴────────┴────────┴─────────┴────────┴────────┘

Req/Bytes counts sampled once per second.
# of samples: 11

40k requests in 11.01s, 5.87 MB read
```

Because logging is not passed through the original performance is about 30 k/ 10 secs.

after:

```
Running 10s test @ http://127.0.0.1:3000/
10 connections


┌─────────┬──────┬──────┬───────┬──────┬─────────┬─────────┬───────┐
│ Stat    │ 2.5% │ 50%  │ 97.5% │ 99%  │ Avg     │ Stdev   │ Max   │
├─────────┼──────┼──────┼───────┼──────┼─────────┼─────────┼───────┤
│ Latency │ 0 ms │ 0 ms │ 4 ms  │ 4 ms │ 0.57 ms │ 1.04 ms │ 31 ms │
└─────────┴──────┴──────┴───────┴──────┴─────────┴─────────┴───────┘
┌───────────┬────────┬────────┬─────────┬─────────┬────────┬────────┬────────┐
│ Stat      │ 1%     │ 2.5%   │ 50%     │ 97.5%   │ Avg    │ Stdev  │ Min    │
├───────────┼────────┼────────┼─────────┼─────────┼────────┼────────┼────────┤
│ Req/Sec   │ 4727   │ 4727   │ 8047    │ 8187    │ 7675.2 │ 994.42 │ 4726   │
├───────────┼────────┼────────┼─────────┼─────────┼────────┼────────┼────────┤
│ Bytes/Sec │ 591 kB │ 591 kB │ 1.01 MB │ 1.02 MB │ 959 kB │ 124 kB │ 591 kB │
└───────────┴────────┴────────┴─────────┴─────────┴────────┴────────┴────────┘

Req/Bytes counts sampled once per second.
# of samples: 10

77k requests in 10.02s, 9.59 MB read
```
