### PR TITLE
chore:  repair typedoc

### DIFF
--- a/.typedoc.json
+++ b/.typedoc.json
@@ -5,7 +5,6 @@
   "theme": "default",
   "excludePrivate": true,
   "excludeExternals": true,
-  "listInvalidSymbolLinks": true,
   "excludeInternal": true,
   "entryPointStrategy": "expand",
   "readme": "none",


### PR DESCRIPTION
Seems like listInvalidSymbolLinks is deprecated or so, removed it