### PR TITLE
fix(probot): passes logger to webhooks

### DIFF
--- a/src/octokit/get-webhooks.ts
+++ b/src/octokit/get-webhooks.ts
@@ -11,6 +11,7 @@ export function getWebhooks(state: State) {
   //       > The context of the event that was triggered, including the payload and
   //         helpers for extracting information can be passed to GitHub API calls
   const webhooks = new Webhooks({
+    log: state.log,
     secret: state.webhooks.secret!,
     transform: webhookTransform.bind(null, state),
   });

--- a/test/probot.test.ts
+++ b/test/probot.test.ts
@@ -625,5 +625,21 @@ describe("Probot", () => {
         expect(error.message).toMatch(/error from app/);
       }
     });
+
+    it.only("passes logger to webhooks", async () => {
+      const probot = new Probot({
+        appId,
+        privateKey,
+        log: pino(streamLogsToOutput),
+      });
+
+      // @ts-expect-error
+      probot.on("unknown-event", () => {});
+
+      expect(output.length).toEqual(1);
+      expect(output[0].msg).toEqual(
+        '"unknown-event" is not a known webhook name (https://developer.github.com/v3/activity/events/types/)'
+      );
+    });
   });
 });


### PR DESCRIPTION
Current behavior:

```js
const probot = new Probot({ log: myCustomLog });
probot.on("my_custom_event", handler);
// logs with console, not with `myCustomLog`
```

With this pull request, `myCustomLog` will be passed to webhooks and the warning will be logged using the passed logger instead of native `console`
