### PR TITLE
feat: set `x-github-delivery` header to `event.id` for all requests sent from `context.octokit` in event handlers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -79,6 +79,16 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
 
     this.octokit = octokit;
     this.log = aliasLog(log);
+
+    // set `x-github-delivery` header on all requests sent in response to the current
+    // event. This allows GitHub Support to correlate the request with the event.
+    // This is not documented and not considered public API, the header may change.
+    // Once we document this as best practice on https://docs.github.com/en/rest/guides/best-practices-for-integrators
+    // we will make it official
+    /* istanbul ignore next */
+    octokit.hook.before("request", (options) => {
+      options.headers["x-github-delivery"] = event.id;
+    });
   }
 
   /**

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -31,9 +31,14 @@ describe("Context", () => {
     name: "push",
     payload: pushEventPayload,
   };
+  let octokit = {
+    hook: {
+      before: jest.fn()
+    }
+  }
   let context: Context<"push"> = new Context<"push">(
     event,
-    {} as any,
+    octokit as any,
     {} as any
   );
 
@@ -51,7 +56,12 @@ describe("Context", () => {
         payload: pushEventPayload,
       };
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context<"push">(event, octokit as any, {} as any);
     });
 
     it("returns attributes from repository payload", () => {
@@ -82,7 +92,12 @@ describe("Context", () => {
     it("properly handles the push event", () => {
       event.payload = require("./fixtures/webhook/push") as PushEvent;
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context<"push">(event, octokit as any, {} as any);
       expect(context.repo()).toEqual({ owner: "bkeepers-inc", repo: "test" });
     });
 
@@ -93,7 +108,12 @@ describe("Context", () => {
         payload: { ...pushEventPayload, repository: undefined as any },
       };
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context<"push">(event, octokit as any, {} as any);
       try {
         context.repo();
       } catch (e: any) {
@@ -114,7 +134,12 @@ describe("Context", () => {
         payload: issuesEventPayload,
       };
 
-      context = new Context<"issues">(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context<"issues">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
       expect(context.issue()).toEqual({
@@ -153,7 +178,12 @@ describe("Context", () => {
         payload: pullRequestEventPayload,
       };
 
-      context = new Context<"pull_request">(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context<"pull_request">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
       expect(context.pullRequest()).toEqual({
@@ -246,19 +276,42 @@ describe("Context", () => {
       expect(customMerge).toHaveBeenCalled();
       expect(mock.activeMocks()).toStrictEqual([]);
     });
+
+    it("sets x-github-delivery header to event id", async () => {
+      const mock = nock("https://api.github.com", {
+        reqheaders: {
+          "x-github-delivery": event.id,
+        },
+      })
+        .get("/repos/Codertocat/Hello-World/contents/.github%2Ftest-file.yml")
+        .reply(200, nockConfigResponseDataFile("basic.yml"));
+
+      await context.config("test-file.yml");
+      expect(mock.activeMocks()).toStrictEqual([]);
+    })
   });
 
   describe("isBot", () => {
     test("returns true if sender is a bot", () => {
       event.payload.sender.type = "Bot";
-      context = new Context(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(true);
     });
 
     test("returns false if sender is not a bot", () => {
       event.payload.sender.type = "User";
-      context = new Context(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: jest.fn()
+        }
+      }
+      context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(false);
     });

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -33,9 +33,9 @@ describe("Context", () => {
   };
   let octokit = {
     hook: {
-      before: jest.fn()
-    }
-  }
+      before: jest.fn(),
+    },
+  };
   let context: Context<"push"> = new Context<"push">(
     event,
     octokit as any,
@@ -58,9 +58,9 @@ describe("Context", () => {
 
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context<"push">(event, octokit as any, {} as any);
     });
 
@@ -94,9 +94,9 @@ describe("Context", () => {
 
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context<"push">(event, octokit as any, {} as any);
       expect(context.repo()).toEqual({ owner: "bkeepers-inc", repo: "test" });
     });
@@ -110,9 +110,9 @@ describe("Context", () => {
 
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context<"push">(event, octokit as any, {} as any);
       try {
         context.repo();
@@ -136,9 +136,9 @@ describe("Context", () => {
 
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context<"issues">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
@@ -180,9 +180,9 @@ describe("Context", () => {
 
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context<"pull_request">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
@@ -288,7 +288,7 @@ describe("Context", () => {
 
       await context.config("test-file.yml");
       expect(mock.activeMocks()).toStrictEqual([]);
-    })
+    });
   });
 
   describe("isBot", () => {
@@ -296,9 +296,9 @@ describe("Context", () => {
       event.payload.sender.type = "Bot";
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(true);
@@ -308,9 +308,9 @@ describe("Context", () => {
       event.payload.sender.type = "User";
       let octokit = {
         hook: {
-          before: jest.fn()
-        }
-      }
+          before: jest.fn(),
+        },
+      };
       context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(false);


### PR DESCRIPTION
Implements this useful feature from `@octokit/app` 
https://github.com/octokit/app.js/blob/7b65f978368f714fb85b7df4a2dd696de203c6a2/src/webhooks.ts#L52-L60