### PR TITLE
feat: set `x-github-delivery` header to `event.id` for all requests sent from `context.octokit` in event handlers

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -73,6 +73,16 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
 
     this.octokit = octokit;
     this.log = log;
+
+    // set `x-github-delivery` header on all requests sent in response to the current
+    // event. This allows GitHub Support to correlate the request with the event.
+    // This is not documented and not considered public API, the header may change.
+    // Once we document this as best practice on https://docs.github.com/en/rest/guides/best-practices-for-integrators
+    // we will make it official
+    /* istanbul ignore next */
+    octokit.hook.before("request", (options) => {
+      options.headers["x-github-delivery"] = event.id;
+    });
   }
 
   /**

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -33,9 +33,14 @@ describe("Context", () => {
     name: "push",
     payload: pushEventPayload,
   };
+  let octokit = {
+    hook: {
+      before: vi.fn(),
+    },
+  };
   let context: Context<"push"> = new Context<"push">(
     event,
-    {} as any,
+    octokit as any,
     {} as any,
   );
 
@@ -52,8 +57,13 @@ describe("Context", () => {
         name: "push",
         payload: pushEventPayload,
       };
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      context = new Context<"push">(event, octokit as any, {} as any);
     });
 
     it("returns attributes from repository payload", () => {
@@ -83,8 +93,13 @@ describe("Context", () => {
     // https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#push
     it("properly handles the push event", () => {
       event.payload = require("./fixtures/webhook/push") as PushEvent;
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      context = new Context<"push">(event, octokit as any, {} as any);
       expect(context.repo()).toEqual({ owner: "bkeepers-inc", repo: "test" });
     });
 
@@ -94,8 +109,13 @@ describe("Context", () => {
         name: "push",
         payload: { ...pushEventPayload, repository: undefined as any },
       };
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
 
-      context = new Context<"push">(event, {} as any, {} as any);
+      context = new Context<"push">(event, octokit as any, {} as any);
       try {
         context.repo();
       } catch (e) {
@@ -115,8 +135,13 @@ describe("Context", () => {
         name: "issues",
         payload: issuesEventPayload,
       };
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
 
-      context = new Context<"issues">(event, {} as any, {} as any);
+      context = new Context<"issues">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
       expect(context.issue()).toEqual({
@@ -154,8 +179,13 @@ describe("Context", () => {
         name: "pull_request",
         payload: pullRequestEventPayload,
       };
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
 
-      context = new Context<"pull_request">(event, {} as any, {} as any);
+      context = new Context<"pull_request">(event, octokit as any, {} as any);
     });
     it("returns attributes from repository payload", () => {
       expect(context.pullRequest()).toEqual({
@@ -288,19 +318,49 @@ describe("Context", () => {
       await context.config("test-file.yml", {}, { arrayMerge: customMerge });
       expect(customMerge).toHaveBeenCalled();
     });
+
+    it("sets x-github-delivery header to event id", async () => {
+      const fetch = fetchMock.sandbox().getOnce((_url, { headers }) => {
+        expect(
+          // @ts-expect-error
+          headers["x-github-delivery"],
+        ).toBe("0");
+        return true;
+      }, getConfigFile("basic.yml"));
+
+      const octokit = new ProbotOctokit({
+        retry: { enabled: false },
+        throttle: { enabled: false },
+        request: {
+          fetch,
+        },
+      });
+      const context = new Context(event, octokit, {} as any);
+      await context.config("test-file.yml");
+    });
   });
 
   describe("isBot", () => {
     test("returns true if sender is a bot", () => {
       event.payload.sender.type = "Bot";
-      context = new Context(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
+      context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(true);
     });
 
     test("returns false if sender is not a bot", () => {
       event.payload.sender.type = "User";
-      context = new Context(event, {} as any, {} as any);
+      let octokit = {
+        hook: {
+          before: vi.fn(),
+        },
+      };
+      context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(false);
     });


### PR DESCRIPTION
up-port #2026