### PR TITLE
docs(testing): use `ProbotOctokit.defaults()` callback

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,7 +10,6 @@ We highly recommend working in the style of [test-driven development](http://agi
 For our testing examples, we use [jest](https://facebook.github.io/jest/), but there are other options that can perform similar operations. We also recommend using [nock](https://github.com/nock/nock), a tool for mocking HTTP requests, which is often crucial to testing in Probot, considering how much of Probot depends on GitHub's APIs. Here's an example of creating an app instance and using nock to test that we correctly hit the GitHub API:
 
 ```js
-import {OctokitOptions} from "probot/lib/types";
 import nock from "nock";
 // Requiring our app implementation
 import myProbotApp from "../index.js";
@@ -27,7 +26,7 @@ describe("My Probot app", () => {
     probot = new Probot({
       githubToken: "test",
       // Disable throttling & retrying requests for easier testing
-      Octokit: ProbotOctokit.defaults((instanceOptions:OctokitOptions):OctokitOptions =>{
+      Octokit: ProbotOctokit.defaults((instanceOptions: any) =>{
           return {
               ...instanceOptions,
               retry: { enabled: false },

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,7 @@ We highly recommend working in the style of [test-driven development](http://agi
 For our testing examples, we use [jest](https://facebook.github.io/jest/), but there are other options that can perform similar operations. We also recommend using [nock](https://github.com/nock/nock), a tool for mocking HTTP requests, which is often crucial to testing in Probot, considering how much of Probot depends on GitHub's APIs. Here's an example of creating an app instance and using nock to test that we correctly hit the GitHub API:
 
 ```js
+import {OctokitOptions} from "probot/lib/types";
 import nock from "nock";
 // Requiring our app implementation
 import myProbotApp from "../index.js";
@@ -26,9 +27,12 @@ describe("My Probot app", () => {
     probot = new Probot({
       githubToken: "test",
       // Disable throttling & retrying requests for easier testing
-      Octokit: ProbotOctokit.defaults({
-        retry: { enabled: false },
-        throttle: { enabled: false },
+      Octokit: ProbotOctokit.defaults((instanceOptions:OctokitOptions):OctokitOptions =>{
+          return {
+              ...instanceOptions,
+              retry: { enabled: false },
+              throttle: { enabled: false },
+          }
       }),
     });
     myProbotApp(probot);

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -26,12 +26,12 @@ describe("My Probot app", () => {
     probot = new Probot({
       githubToken: "test",
       // Disable throttling & retrying requests for easier testing
-      Octokit: ProbotOctokit.defaults((instanceOptions: any) =>{
-          return {
-              ...instanceOptions,
-              retry: { enabled: false },
-              throttle: { enabled: false },
-          }
+      Octokit: ProbotOctokit.defaults((instanceOptions: any) => {
+        return {
+          ...instanceOptions,
+          retry: { enabled: false },
+          throttle: { enabled: false },
+        };
       }),
     });
     myProbotApp(probot);


### PR DESCRIPTION
Hi there,

There is currently an issue with `Octokit: ProbotOctokit.defaults()` regarding throttling, which I've opened up an [issue](https://github.com/probot/probot/issues/2039#issue-2368070197) for, issue number #2039. It describes the problem in great detail with valid proofs and a solution.

This PR updates the documentation's 'Testing' section/tab with the solution (or rather hotfix) to prevent developers from struggling in testing environments. Personally it took me couple of hours before I found a solution to it. Hopefully it helps other people from wasting time as well, until a proper solution is conducted.

I've update the code section with strong type def which could be overkill, because it requires an additional import on line 13, we can remove the type definitions if not needed.

Thank you.