### PR TITLE
fix(docs): Re-enable Google Analytics

### DIFF
--- a/.typedoc/typedoc_ga.mjs
+++ b/.typedoc/typedoc_ga.mjs
@@ -1,0 +1,31 @@
+// Apache License 2.0 - https://github.com/TypeStrong/typedoc/blob/master/LICENSE
+import td from "typedoc";
+
+/** @param {td.Application} app */
+export function load(app) {
+    app.options.addDeclaration({
+        name: "gaID",
+        help: "Set the Google Analytics tracking ID and activate tracking code",
+        type: td.ParameterType.String,
+    });
+
+    app.renderer.hooks.on("body.end", () => {
+        const gaID = app.options.getValue("gaID");
+        if (gaID) {
+            const script = `
+window.dataLayer = window.dataLayer || [];
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '${gaID}');
+`.trim();
+            return td.JSX.createElement(td.JSX.Fragment, null, [
+                td.JSX.createElement("script", {
+                    async: true,
+                    src: "https://www.googletagmanager.com/gtag/js?id=" + gaID,
+                }),
+                td.JSX.createElement("script", null, td.JSX.createElement(td.JSX.Raw, { html: script })),
+            ]);
+        }
+        return td.JSX.createElement(td.JSX.Fragment, null);
+    });
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test": "vitest run",
     "test:coverage": "vitest run --coverage",
     "test:dev": "vitest --ui --coverage",
-    "doc": "typedoc --options .typedoc.json"
+    "doc": "typedoc --options .typedoc.json --plugin .typedoc/typedoc_ga.mjs"
   },
   "files": [
     "lib",


### PR DESCRIPTION
Typedoc recently removed the corresponding option. This makes builds work again by "recovering" that code as a plugin.