### PR TITLE
fix: remove eventsource dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "@octokit/webhooks-examples": "^7.3.1",
         "@octokit/webhooks-methods": "^4.0.0",
         "@octokit/webhooks-types": "^7.3.1",
-        "@types/eventsource": "^1.1.15",
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^20.0.0",
         "@types/resolve": "^1.20.5",
@@ -2562,13 +2561,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/eventsource": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@types/eventsource/-/eventsource-1.1.15.tgz",
-      "integrity": "sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==",
       "dev": true,
       "license": "MIT"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "commander": "^12.0.0",
         "deepmerge": "^4.3.1",
         "dotenv": "^16.3.1",
-        "eventsource": "^2.0.2",
         "express": "^4.18.2",
         "ioredis": "^5.3.2",
         "js-yaml": "^4.1.0",
@@ -4961,6 +4960,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
       "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "@octokit/webhooks-examples": "^7.3.1",
     "@octokit/webhooks-methods": "^4.0.0",
     "@octokit/webhooks-types": "^7.3.1",
-    "@types/eventsource": "^1.1.15",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^20.0.0",
     "@types/resolve": "^1.20.5",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "commander": "^12.0.0",
     "deepmerge": "^4.3.1",
     "dotenv": "^16.3.1",
-    "eventsource": "^2.0.2",
     "express": "^4.18.2",
     "ioredis": "^5.3.2",
     "js-yaml": "^4.1.0",

--- a/src/helpers/webhook-proxy.ts
+++ b/src/helpers/webhook-proxy.ts
@@ -1,5 +1,3 @@
-import EventSource from "eventsource";
-
 import type { Logger } from "pino";
 
 export const createWebhookProxy = async (
@@ -13,7 +11,7 @@ export const createWebhookProxy = async (
       target: `http://localhost:${opts.port}${opts.path}`,
       fetch: opts.fetch,
     });
-    return smee.start();
+    return smee.start() as EventSource;
   } catch (error) {
     opts.logger.warn(
       "Run `npm install --save-dev smee-client` to proxy webhooks to localhost.",

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -10,7 +10,6 @@ import { createWebhookProxy } from "../helpers/webhook-proxy.js";
 import { VERSION } from "../version.js";
 import type { ApplicationFunction, ServerOptions } from "../types.js";
 import type { Probot } from "../index.js";
-import type EventSource from "eventsource";
 import { rebindLog } from "../helpers/rebind-log.js";
 
 // the default path as defined in @octokit/webhooks

--- a/test/webhook-proxy.test.ts
+++ b/test/webhook-proxy.test.ts
@@ -9,7 +9,6 @@ const sse: (
   next: express.NextFunction,
 ) => void = require("connect-sse")();
 import fetchMock from "fetch-mock";
-import EventSource from "eventsource";
 import { describe, expect, afterEach, test, vi } from "vitest";
 import { getLog } from "../src/helpers/get-log.js";
 import { createWebhookProxy } from "../src/helpers/webhook-proxy.js";


### PR DESCRIPTION
We dont need the dependency, as we only need it for the types of EventSource. smee-client is returning an EventSource instance. Also we have already EventSource definitions provided by typescript ;). 