### PR TITLE
chore: explicit filename import

### DIFF
--- a/src/helpers/get-log.ts
+++ b/src/helpers/get-log.ts
@@ -17,7 +17,7 @@
 import { pino } from "pino";
 import type { Logger, LoggerOptions } from "pino";
 import { getTransformStream, type Options, type LogLevel } from "@probot/pino";
-import { rebindLog } from "./rebind-log";
+import { rebindLog } from "./rebind-log.js";
 
 export type GetLogOptions = {
   level?: LogLevel;


### PR DESCRIPTION
while testing if we can use esm, it showed that we missed to import with an explicit filename