### PR TITLE
fix(types): avoid TS2590 errors in `Context`

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -58,15 +58,17 @@ type RepoResultType<E extends WebhookEvents> = {
  * @property {payload} payload - The webhook event payload
  * @property {log} log - A pino instance
  */
-export class Context<E extends WebhookEvents = WebhookEvents> {
+export class Context<Event extends WebhookEvents = WebhookEvents> {
   public name: WebhookEvents;
   public id: string;
-  public payload: WebhookEvent<E>["payload"];
+  public payload: {
+    [K in Event]: K extends WebhookEvents ? WebhookEvent<K> : never;
+  }[Event]["payload"];
 
   public octokit: ProbotOctokit;
   public log: Logger;
 
-  constructor(event: WebhookEvent<E>, octokit: ProbotOctokit, log: Logger) {
+  constructor(event: WebhookEvent<Event>, octokit: ProbotOctokit, log: Logger) {
     this.name = event.name;
     this.id = event.id;
     this.payload = event.payload;
@@ -97,7 +99,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    * @param object - Params to be merged with the repo params.
    *
    */
-  public repo<T>(object?: T): RepoResultType<E> & T {
+  public repo<T>(object?: T): RepoResultType<Event> & T {
     // @ts-expect-error `repository` is not always present in this.payload
     const repo = this.payload.repository;
 
@@ -130,7 +132,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    */
   public issue<T>(
     object?: T,
-  ): RepoResultType<E> & { issue_number: RepoIssueNumberType<E> } & T {
+  ): RepoResultType<Event> & { issue_number: RepoIssueNumberType<Event> } & T {
     return Object.assign(
       {
         issue_number:
@@ -156,7 +158,7 @@ export class Context<E extends WebhookEvents = WebhookEvents> {
    */
   public pullRequest<T>(
     object?: T,
-  ): RepoResultType<E> & { pull_number: RepoIssueNumberType<E> } & T {
+  ): RepoResultType<Event> & { pull_number: RepoIssueNumberType<Event> } & T {
     const payload = this.payload;
     return Object.assign(
       {


### PR DESCRIPTION
Fixes #1968

> error TS2590: Expression produces a union type that is too complex to represent.

The solution was taken from https://github.com/ubiquity/ubiquibot-kernel/pull/52
See https://github.com/probot/probot/issues/1680
See https://github.com/probot/probot/discussions/1966