### PR TITLE
feat: allow custom logger for Octokit instances

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,3 +1,4 @@
+import type { Logger } from "pino";
 import { getAuthenticatedOctokit } from "./octokit/get-authenticated-octokit.js";
 import { ProbotOctokit } from "./octokit/probot-octokit.js";
 import type { State } from "./types.js";
@@ -31,6 +32,7 @@ import type { State } from "./types.js";
 export async function auth(
   state: State,
   installationId?: number,
+  log?: Logger,
 ): Promise<InstanceType<typeof ProbotOctokit>> {
-  return getAuthenticatedOctokit(Object.assign({}, state), installationId);
+  return getAuthenticatedOctokit(Object.assign({}, state), installationId, log);
 }

--- a/src/octokit/get-authenticated-octokit.ts
+++ b/src/octokit/get-authenticated-octokit.ts
@@ -1,7 +1,7 @@
 import type { State } from "../types.js";
 import type { ProbotOctokit } from "./probot-octokit.js";
 import type { OctokitOptions } from "../types.js";
-import type { LogFn, Level } from "pino";
+import type { LogFn, Level, Logger } from "pino";
 
 type FactoryOptions = {
   octokit: ProbotOctokit;
@@ -12,8 +12,9 @@ type FactoryOptions = {
 export async function getAuthenticatedOctokit(
   state: State,
   installationId?: number,
+  log?: Logger,
 ) {
-  const { log, octokit } = state;
+  const { octokit } = state;
 
   if (!installationId) return octokit;
 
@@ -21,7 +22,7 @@ export async function getAuthenticatedOctokit(
     type: "installation",
     installationId,
     factory: ({ octokit, octokitOptions, ...otherOptions }: FactoryOptions) => {
-      const pinoLog = log.child({ name: "github" });
+      const pinoLog = log || state.log.child({ name: "github" });
 
       const options: ConstructorParameters<typeof ProbotOctokit>[0] & {
         log: Record<Level, LogFn>;


### PR DESCRIPTION
The Probot interface already provides a second parameter to [`Probot.auth`](https://github.com/probot/probot/blob/master/src/probot.ts#L45) function, however unused by the implementation. 

This PR implements this interface fully, so provided `log` (if provided) will be used by created Octokit instance instead of default logger. 

This can be useful in case when we need to add more fields to the logger to have better separation of logs, eg. based on event ID or PR number.