### PR TITLE
fix(deps): use fork of lru-cache to fix type issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "express": "^4.21.0",
         "ioredis": "^5.3.2",
         "js-yaml": "^4.1.0",
-        "lru-cache": "^10.0.3",
+        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
         "octokit-auth-probot": "^2.0.0",
         "pino": "^9.0.0",
         "pino-http": "^10.0.0",
@@ -751,6 +751,12 @@
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
       }
+    },
+    "node_modules/@octokit/auth-app/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@octokit/auth-oauth-app": {
       "version": "7.1.0",
@@ -5422,6 +5428,13 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6353,10 +6366,14 @@
       "license": "MIT"
     },
     "node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
+      "name": "@wolfy1339/lru-cache",
+      "version": "11.0.2-patch.1",
+      "resolved": "https://registry.npmjs.org/@wolfy1339/lru-cache/-/lru-cache-11.0.2-patch.1.tgz",
+      "integrity": "sha512-BgYZfL2ADCXKOw2wJtkM3slhHotawWkgIRRxq4wEybnZQPjvAp71SPX35xepMykTw8gXlzWcWPTY31hlbnRsDA==",
+      "license": "ISC",
+      "engines": {
+        "node": "18 >=18.20 || 20 || >=22"
+      }
     },
     "node_modules/lunr": {
       "version": "2.3.9",
@@ -6915,6 +6932,13 @@
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
       }
+    },
+    "node_modules/normalize-package-data/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/normalize-url": {
       "version": "8.0.1",
@@ -12598,6 +12622,13 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/test-exclude/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/test-exclude/node_modules/minimatch": {
       "version": "9.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "ioredis": "^5.3.2",
         "js-yaml": "^4.1.0",
         "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
-        "octokit-auth-probot": "^2.0.0",
+        "octokit-auth-probot": "^2.0.1",
         "pino": "^9.0.0",
         "pino-http": "^10.0.0",
         "pkg-conf": "^3.1.0",
@@ -718,9 +718,9 @@
       }
     },
     "node_modules/@octokit/auth-app": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.2.tgz",
-      "integrity": "sha512-fWjIOpxnL8/YFY3kqquciFQ4o99aCqHw5kMFoGPYbz/h5HNZ11dJlV9zag5wS2nt0X1wJ5cs9BUo+CsAPfW4jQ==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-app/-/auth-app-6.1.3.tgz",
+      "integrity": "sha512-dcaiteA6Y/beAlDLZOPNReN3FGHu+pARD6OHfh3T9f3EO09++ec+5wt3KtGGSSs2Mp5tI8fQwdMOEnrzBLfgUA==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-oauth-app": "^7.1.0",
@@ -729,7 +729,7 @@
         "@octokit/request-error": "^5.1.0",
         "@octokit/types": "^13.1.0",
         "deprecation": "^2.3.1",
-        "lru-cache": "^10.0.0",
+        "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
         "universal-github-app-jwt": "^1.1.2",
         "universal-user-agent": "^6.0.0"
       },
@@ -751,12 +751,6 @@
       "dependencies": {
         "@octokit/openapi-types": "^22.2.0"
       }
-    },
-    "node_modules/@octokit/auth-app/node_modules/lru-cache": {
-      "version": "10.4.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
-      "license": "ISC"
     },
     "node_modules/@octokit/auth-oauth-app": {
       "version": "7.1.0",
@@ -10124,12 +10118,12 @@
       }
     },
     "node_modules/octokit-auth-probot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/octokit-auth-probot/-/octokit-auth-probot-2.0.0.tgz",
-      "integrity": "sha512-bxidVIyxYJ+hWkG24pchPrN6mJdQrklZ2Acu+oGmZlh9aRONsIrw0KNW5W7QC2VlkxsFQwb9lnV+vH0BcEhnLQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/octokit-auth-probot/-/octokit-auth-probot-2.0.1.tgz",
+      "integrity": "sha512-HzOJ4EPC5OJN6oZEoKTMYtqUQ2ZSKHmDWbLHfFB7JYpho9Zb+aJmDfRShd5a/eGvmIzbZ0NRIWjmnvspDp8JAQ==",
       "license": "ISC",
       "dependencies": {
-        "@octokit/auth-app": "^6.0.1",
+        "@octokit/auth-app": "^6.1.3",
         "@octokit/auth-token": "^4.0.0",
         "@octokit/auth-unauthenticated": "^5.0.1",
         "@octokit/types": "^12.0.0"

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ioredis": "^5.3.2",
     "js-yaml": "^4.1.0",
     "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
-    "octokit-auth-probot": "^2.0.0",
+    "octokit-auth-probot": "^2.0.1",
     "pino": "^9.0.0",
     "pino-http": "^10.0.0",
     "pkg-conf": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "express": "^4.21.0",
     "ioredis": "^5.3.2",
     "js-yaml": "^4.1.0",
-    "lru-cache": "^10.0.3",
+    "lru-cache": "npm:@wolfy1339/lru-cache@^11.0.2-patch.1",
     "octokit-auth-probot": "^2.0.0",
     "pino": "^9.0.0",
     "pino-http": "^10.0.0",


### PR DESCRIPTION
See https://github.com/isaacs/node-lru-cache/issues/355

The package author is unwilling to backport the proper fix to the previous version.
Blocked by https://github.com/octokit/auth-app.js/pull/651