### PR TITLE
replace lru-cache with toad-cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,11 +30,11 @@
         "import-meta-resolve": "^4.1.0",
         "ioredis": "^5.3.2",
         "js-yaml": "^4.1.0",
-        "lru-cache": "^10.0.3",
         "octokit-auth-probot": "^3.0.0",
         "package-config": "^5.0.0",
         "pino": "^9.0.0",
         "pino-http": "^10.0.0",
+        "toad-cache": "^3.7.0",
         "update-dotenv": "^1.1.1"
       },
       "bin": {
@@ -1318,7 +1318,7 @@
         "linux"
       ]
     },
-        "node_modules/@rollup/rollup-linux-x64-musl": {
+    "node_modules/@rollup/rollup-linux-x64-musl": {
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.24.0.tgz",
       "integrity": "sha512-w1i+L7kAXZNdYl+vFvzSZy8Y1arS7vMgIy8wusXJzRrPyof5LAb02KGr1PD2EkRcl73kHulIID0M501lN+vobQ==",
@@ -12115,6 +12115,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toad-cache": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
+      "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/toidentifier": {

--- a/package.json
+++ b/package.json
@@ -57,11 +57,11 @@
     "import-meta-resolve": "^4.1.0",
     "ioredis": "^5.3.2",
     "js-yaml": "^4.1.0",
-    "lru-cache": "^10.0.3",
     "octokit-auth-probot": "^3.0.0",
     "package-config": "^5.0.0",
     "pino": "^9.0.0",
     "pino-http": "^10.0.0",
+    "toad-cache": "^3.7.0",
     "update-dotenv": "^1.1.1"
   },
   "devDependencies": {

--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -1,4 +1,4 @@
-import type { LRUCache } from "lru-cache";
+import type { Lru } from "toad-cache";
 import { ProbotOctokit } from "./probot-octokit.js";
 import type { RedisOptions } from "ioredis";
 import { request } from "@octokit/request";
@@ -10,7 +10,7 @@ import type { RequestRequestOptions } from "@octokit/types";
 import type { OctokitOptions } from "../types.js";
 
 type Options = {
-  cache: LRUCache<number, string>;
+  cache: Lru<string>;
   Octokit: typeof ProbotOctokit;
   log: Logger;
   githubToken?: string;

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -69,7 +69,7 @@ export class Probot {
       // cache max. 15000 tokens, that will use less than 10mb memory
       15000,
       // Cache for 1 minute less than GitHub expiry
-      1000 * 60 * 59
+      1000 * 60 * 59,
     );
 
     const Octokit = getProbotOctokitWithDefaults({

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -1,4 +1,4 @@
-import { LRUCache } from "lru-cache";
+import { Lru } from "toad-cache";
 import type { Logger } from "pino";
 import type { EmitterWebhookEvent as WebhookEvent } from "@octokit/webhooks";
 
@@ -65,12 +65,12 @@ export class Probot {
       : getLog({ level, logMessageKey });
 
     // TODO: support redis backend for access token cache if `options.redisConfig`
-    const cache = new LRUCache<number, string>({
+    const cache = new Lru<string>(
       // cache max. 15000 tokens, that will use less than 10mb memory
-      max: 15000,
+      15000,
       // Cache for 1 minute less than GitHub expiry
-      ttl: 1000 * 60 * 59,
-    });
+      1000 * 60 * 59
+    );
 
     const Octokit = getProbotOctokitWithDefaults({
       githubToken: options.githubToken,

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,7 +3,6 @@ import type {
   EmitterWebhookEvent as WebhookEvent,
   Webhooks,
 } from "@octokit/webhooks";
-import type { LRUCache } from "lru-cache";
 import type { RedisOptions } from "ioredis";
 import type { Options as LoggingOptions } from "pino-http";
 
@@ -13,6 +12,7 @@ import { ProbotOctokit } from "./octokit/probot-octokit.js";
 
 import type { Logger } from "pino";
 import type { RequestRequestOptions } from "@octokit/types";
+import { Lru } from "toad-cache";
 
 export interface Options {
   privateKey?: string;
@@ -39,7 +39,7 @@ export type State = {
   log: Logger;
   Octokit: typeof ProbotOctokit;
   octokit: ProbotOctokit;
-  cache?: LRUCache<number, string>;
+  cache?: Lru<string>;
   webhooks: {
     secret?: string;
   };


### PR DESCRIPTION
This PR is corresponding to https://github.com/octokit/auth-app.js/pull/654 and replaces lru-cache with toad-cache.

toad-cache is developed by @kibertoad

We use it in fastify and have good results with it. Also it is possible to reach to kibertoad and get things merged if necessary.