### PR TITLE
docs: update documentation for correct middleware usage

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -192,7 +192,13 @@ Please add yours!
 import { createNodeMiddleware, createProbot } from "probot";
 import app from "./app.js";
 
-exports.probotApp = createNodeMiddleware(app, { probot: createProbot() });
+const middleware = createNodeMiddleware(app, { probot: createProbot() });
+exports.probotApp = (req, res) => {
+  middleware(req, res, () => {
+    res.writeHead(404);
+    res.end();
+  });
+};
 ```
 
 Examples

--- a/docs/development.md
+++ b/docs/development.md
@@ -226,7 +226,14 @@ const probot = new Probot({
   secret: "webhooksecret123",
 });
 
-export default createNodeMiddleware(app, { probot });
+const middleware = createNodeMiddleware(app, { probot });
+
+export default (req, res) => {
+  middleware(req, res, () => {
+    res.writeHead(404);
+    res.end();
+  });
+};
 ```
 
 If you want to read probot's configuration from the same environment variables as [`run`](#run), use the [`createProbot`](https://probot.github.io/api/latest/index.html#createprobot) export

--- a/example/node-middleware.cjs
+++ b/example/node-middleware.cjs
@@ -62,7 +62,12 @@ const appFn = (app) => {
 
 const middleware = createNodeMiddleware(appFn, { probot: createProbot() });
 
-const server = createServer(middleware);
+const server = createServer((req, res) => {
+  middleware(req, res, () => {
+    res.writeHead(404);
+    res.end();
+  });
+});
 
 server.listen(3000, async () => {
   console.log("Probot started http://localhost:3000/")

--- a/src/create-node-middleware.ts
+++ b/src/create-node-middleware.ts
@@ -1,14 +1,44 @@
-import type { RequestListener } from "http";
+import type { IncomingMessage, ServerResponse } from "node:http";
 import { createNodeMiddleware as createWebhooksMiddleware } from "@octokit/webhooks";
 
 import type { ApplicationFunction, MiddlewareOptions } from "./types.js";
 import { defaultWebhooksPath } from "./server/server.js";
 import { createProbot } from "./create-probot.js";
 
+/**
+ * Create a Node/Express middleware.
+ *
+ * ```javascript
+ * import { createServer } from "node:http"
+ * import { createProbot, createNodeMiddleware } from "probot"
+ *
+ * const appFn = (app) => {
+ *   app.on("issues.opened", async (context) => {
+ *     const issueComment = context.issue({
+ *       body: "Thanks for opening this issue!",
+ *     });
+ *     return context.octokit.issues.createComment(issueComment);
+ *   });
+ * };
+ *
+ * const middleware = createNodeMiddleware(appFn, { probot: createProbot() });
+ *
+ * const server = createServer((req, res) => {
+ *   middleware(req, res, () => {
+ *     res.writeHead(404);
+ *     res.end();
+ *   });
+ * });
+ * ```
+ */
 export function createNodeMiddleware(
   appFn: ApplicationFunction,
   { probot = createProbot(), webhooksPath } = {} as MiddlewareOptions,
-): RequestListener {
+): (
+  request: IncomingMessage,
+  response: ServerResponse,
+  next?: () => void,
+) => Promise<boolean> {
   probot.load(appFn);
 
   return createWebhooksMiddleware(probot.webhooks, {


### PR DESCRIPTION
I came accross the following two issues with `createNodeMiddleware`: First, it was unclear that the returned function is a middleware and can be composed with other middlewares. Second, when used as suggested in the examples, unhandled requests would stall instead of returning a 404.