### PR TITLE
fix: ensure that the logger is always bound 

### DIFF
--- a/src/helpers/rebind-log.ts
+++ b/src/helpers/rebind-log.ts
@@ -1,17 +1,11 @@
 import type { Logger } from "pino";
 
-const kIsBound = Symbol("is-bound");
-
 export function rebindLog(log: Logger): Logger {
-  // @ts-ignore
-  if (log[kIsBound]) return log;
   for (const key in log) {
-    // @ts-ignore
+    // @ts-expect-error
     if (typeof log[key] !== "function") continue;
-    // @ts-ignore
+    // @ts-expect-error
     log[key] = log[key].bind(log);
   }
-  // @ts-ignore
-  log[kIsBound] = true;
   return log;
 }

--- a/src/octokit/get-authenticated-octokit.ts
+++ b/src/octokit/get-authenticated-octokit.ts
@@ -2,6 +2,7 @@ import type { State } from "../types.js";
 import type { ProbotOctokit } from "./probot-octokit.js";
 import type { OctokitOptions } from "../types.js";
 import type { LogFn, Level, Logger } from "pino";
+import { rebindLog } from "../helpers/rebind-log.js";
 
 type FactoryOptions = {
   octokit: ProbotOctokit;
@@ -28,14 +29,7 @@ export async function getAuthenticatedOctokit(
         log: Record<Level, LogFn>;
       } = {
         ...octokitOptions,
-        log: {
-          fatal: pinoLog.fatal.bind(pinoLog),
-          error: pinoLog.error.bind(pinoLog),
-          warn: pinoLog.warn.bind(pinoLog),
-          info: pinoLog.info.bind(pinoLog),
-          debug: pinoLog.debug.bind(pinoLog),
-          trace: pinoLog.trace.bind(pinoLog),
-        },
+        log: rebindLog(pinoLog),
         throttle: octokitOptions.throttle?.enabled
           ? {
               ...octokitOptions.throttle,

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -78,12 +78,7 @@ export class Probot {
     const octokitLogger = rebindLog(this.log.child({ name: "octokit" }));
     const octokit = new Octokit({
       request: options.request,
-      log: {
-        debug: octokitLogger.debug.bind(octokitLogger),
-        info: octokitLogger.info.bind(octokitLogger),
-        warn: octokitLogger.warn.bind(octokitLogger),
-        error: octokitLogger.error.bind(octokitLogger),
-      },
+      log: octokitLogger,
     });
 
     this.state = {


### PR DESCRIPTION
Sometimes the logger would be unbound, and would result in error messages.

Fixes #2116