### PR TITLE
feat: drop Node 18 and Node 21 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vitest": "^3.0.0"
   },
   "engines": {
-    "node": "^20.10 || >= 21"
+    "node": "^20.17 || >= 22"
   },
   "release": {
     "plugins": [

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "vitest": "^3.0.0"
   },
   "engines": {
-    "node": ">=18"
+    "node": "^20.10 || >= 21"
   },
   "release": {
     "plugins": [


### PR DESCRIPTION
In order to support `require(esm)`, users need to use 20.17+ and >= 22.0.0
This corresponds with the EOL of Node 18

Because we don't use any default exports in Probot, no changes are necessary to support it.
Changes however will need to be done to the underlying Octokit packages, and all our dependencies

BREAKING CHANGE: Drop Node 18 support
BREAKING CHANGE: Drop Node 21 support