### PR TITLE
implement detectRuntime and change is-SupportedNodeVersion to isSupportedRuntime

### DIFF
--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -3,7 +3,7 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 
 import { config as dotenvConfig } from "dotenv";
-import { isSupportedNodeVersion } from "../helpers/is-supported-node-version.js";
+import { isSupportedRuntime } from "../helpers/is-supported-runtime.js";
 import { loadPackageJson } from "../helpers/load-package-json.js";
 import { run } from "../run.js";
 import { receive } from "./receive.js";
@@ -13,7 +13,7 @@ dotenvConfig();
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const pkg = loadPackageJson(resolve(__dirname, "package.json"));
 
-if (!isSupportedNodeVersion()) {
+if (!isSupportedRuntime(globalThis)) {
   console.log(
     `Node.js version 20.17 or 22 is required. You have ${process.version}.`,
   );

--- a/src/helpers/detect-runtime.ts
+++ b/src/helpers/detect-runtime.ts
@@ -1,0 +1,38 @@
+type Runtime = "node" | "deno" | "bun" | "browser";
+
+type GlobalThis = {
+  process?: {
+    versions?: {
+      node?: string;
+      deno?: string;
+      bun?: string;
+    };
+  };
+  window?: object;
+};
+
+export function detectRuntime(globalThis: GlobalThis): Runtime {
+  if (typeof globalThis === "object" && globalThis !== null) {
+    if (
+      typeof globalThis.process === "object" &&
+      globalThis.process !== null &&
+      typeof globalThis.process.versions === "object" &&
+      globalThis.process.versions !== null
+    ) {
+      if (typeof globalThis.process.versions.deno === "string") {
+        return "deno";
+      }
+      if (typeof globalThis.process.versions.bun === "string") {
+        return "bun";
+      }
+      if (typeof globalThis.process.versions.node === "string") {
+        return "node";
+      }
+    }
+    if (typeof globalThis.window === "object" && globalThis.window !== null) {
+      return "browser";
+    }
+  }
+
+  throw new Error("Unable to detect runtime");
+}

--- a/src/helpers/is-supported-node-version.ts
+++ b/src/helpers/is-supported-node-version.ts
@@ -1,5 +1,0 @@
-export function isSupportedNodeVersion(nodeVersion = process.versions.node) {
-  const [major, minor] = nodeVersion.split(".", 10).map(Number);
-
-  return major >= 22 || (major === 20 && minor >= 17);
-}

--- a/src/helpers/is-supported-runtime.ts
+++ b/src/helpers/is-supported-runtime.ts
@@ -9,6 +9,12 @@ export function isSupportedRuntime(globalThis: any): boolean {
 
       return major >= 22 || (major === 20 && minor >= 17);
     }
+    case "deno": {
+      return false;
+    }
+    case "bun": {
+      return false;
+    }
     default: {
       return false;
     }

--- a/src/helpers/is-supported-runtime.ts
+++ b/src/helpers/is-supported-runtime.ts
@@ -1,0 +1,16 @@
+import { detectRuntime } from "./detect-runtime.js";
+
+export function isSupportedRuntime(globalThis: any): boolean {
+  switch (detectRuntime(globalThis)) {
+    case "node": {
+      const [major, minor] = globalThis.process.versions.node
+        .split(".", 2)
+        .map(Number);
+
+      return major >= 22 || (major === 20 && minor >= 17);
+    }
+    default: {
+      return false;
+    }
+  }
+}

--- a/test/bin/detect-runtime.test.ts
+++ b/test/bin/detect-runtime.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+import { detectRuntime } from "../../src/helpers/detect-runtime.js";
+
+describe("detectRuntime", () => {
+  it("returns 'node' if node is detected", () => {
+    expect(detectRuntime({ process: { versions: { node: "20.17.0" } } })).toBe(
+      "node",
+    );
+  });
+
+  it("returns 'deno' if deno is detected", () => {
+    expect(detectRuntime({ process: { versions: { deno: "1.0.0" } } })).toBe(
+      "deno",
+    );
+    expect(
+      detectRuntime({
+        process: { versions: { deno: "1.0.0", node: "20.17.0" } },
+      }),
+    ).toBe("deno");
+  });
+
+  it("returns 'bun' if bun is detected", () => {
+    expect(
+      detectRuntime({
+        process: { versions: { bun: "1.0.0", node: "20.17.0" } },
+      }),
+    ).toBe("bun");
+  });
+
+  it("returns 'browser' if browser is detected", () => {
+    expect(detectRuntime({ window: {} })).toBe("browser");
+  });
+
+  it("throws an error if runtime cannot be detected", () => {
+    expect(() => detectRuntime({})).toThrow("Unable to detect runtime");
+    // @ts-ignore
+    expect(() => detectRuntime(null)).toThrow("Unable to detect runtime");
+    // @ts-ignore
+    expect(() => detectRuntime({ process: null })).toThrow(
+      "Unable to detect runtime",
+    );
+    // @ts-ignore
+    expect(() => detectRuntime({ process: { versions: null } })).toThrow(
+      "Unable to detect runtime",
+    );
+  });
+});

--- a/test/bin/is-supported-node-version.test.ts
+++ b/test/bin/is-supported-node-version.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { isSupportedNodeVersion } from "../../src/helpers/is-supported-node-version.js";
+import { isSupportedRuntime } from "../../src/helpers/is-supported-runtime.js";
 import { loadPackageJson } from "../../src/helpers/load-package-json.js";
 
 describe("isSupportedNodeVersion", () => {
@@ -10,17 +10,45 @@ describe("isSupportedNodeVersion", () => {
   });
 
   it("returns true if node is bigger or equal v20.17 or v22", () => {
-    expect(isSupportedNodeVersion("20.17.0")).toBe(true);
-    expect(isSupportedNodeVersion("22.0.0")).toBe(true);
-    expect(isSupportedNodeVersion("23.0.0")).toBe(true);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "20.17.0" } } }),
+    ).toBe(true);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "22.0.0" } } }),
+    ).toBe(true);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "23.0.0" } } }),
+    ).toBe(true);
   });
 
   it("returns false if node is smaller than v20.17", () => {
-    expect(isSupportedNodeVersion("17.0.0")).toBe(false);
-    expect(isSupportedNodeVersion("17.9.0")).toBe(false);
-    expect(isSupportedNodeVersion("17.9.9")).toBe(false);
-    expect(isSupportedNodeVersion("18.0.0")).toBe(false);
-    expect(isSupportedNodeVersion("20.16.9")).toBe(false);
-    expect(isSupportedNodeVersion("21.0.0")).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "17.0.0" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "17.9.0" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "17.9.9" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "18.0.0" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "20.16.9" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { node: "21.0.0" } } }),
+    ).toBe(false);
+  });
+
+  it("returns false if runtime is bun, deno or browser", () => {
+    expect(
+      isSupportedRuntime({ process: { versions: { bun: "1.0.0" } } }),
+    ).toBe(false);
+    expect(
+      isSupportedRuntime({ process: { versions: { deno: "1.0.0" } } }),
+    ).toBe(false);
+    expect(isSupportedRuntime({ window: {} })).toBe(false);
   });
 });


### PR DESCRIPTION
I am continously trying if we can improve the compatibility with bun and deno.

bun is not implementing the use of getaddrinfo so the unit tests fail completely. 
deno is throwing anyhow alot of typing issues.

With this, the tests somewhat run in bun (but still fail).

