### PR TITLE
chore: reduce ts-instructions

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -179,9 +179,9 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
    * @type {boolean}
    */
   get isBot(): boolean {
-    // @ts-expect-error - `sender` key is currently not present in all events
+    // `sender` key is not present in all events
     // see https://github.com/octokit/webhooks/issues/510
-    return this.payload.sender.type === "Bot";
+    return this.payload.sender?.type === "Bot";
   }
 
   /**

--- a/src/run.ts
+++ b/src/run.ts
@@ -116,8 +116,13 @@ export async function run(
         privateKey: "dummy value for setup, see #1512",
       }),
     });
-    await server.load(setupAppFactory(host, port));
+
+    await server.load(
+      setupAppFactory({ host: server.host, port: server.port }),
+    );
+
     await server.start();
+
     return server;
   }
 

--- a/test/apps/setup.test.ts
+++ b/test/apps/setup.test.ts
@@ -45,7 +45,9 @@ describe("Setup app", () => {
       port: await getPort(),
     });
 
-    await server.load(setupAppFactory(server.host, server.port));
+    await server.load(
+      setupAppFactory({ host: server.host, port: server.port }),
+    );
 
     await server.start();
   });
@@ -90,7 +92,9 @@ describe("Setup app", () => {
         }),
       });
 
-      await server.load(setupAppFactory(server.host, server.port));
+      await server.load(
+        setupAppFactory({ host: server.host, port: server.port }),
+      );
 
       const expMsg = `Please follow the instructions at http://${server.host}:${server.port} to configure .env.`;
 
@@ -140,7 +144,15 @@ describe("Setup app", () => {
         port: await getPort(),
       });
 
-      await server.load(setupAppFactory(undefined, undefined));
+      await server.load(
+        setupAppFactory({
+          host: server.host,
+          port: server.port,
+          request: {
+            fetch: mock.fetchHandler,
+          },
+        }),
+      );
 
       await server.start();
 
@@ -174,7 +186,9 @@ describe("Setup app", () => {
         port: await getPort(),
       });
 
-      await server.load(setupAppFactory(undefined, undefined));
+      await server.load(
+        setupAppFactory({ host: server.host, port: server.port }),
+      );
 
       await server.start();
 
@@ -200,7 +214,9 @@ describe("Setup app", () => {
         port: await getPort(),
       });
 
-      await server.load(setupAppFactory(undefined, undefined));
+      await server.load(
+        setupAppFactory({ host: server.host, port: server.port }),
+      );
 
       await server.start();
 

--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -2,14 +2,15 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { sign } from "@octokit/webhooks-methods";
+import WebhookExamples, {
+  type WebhookDefinition,
+} from "@octokit/webhooks-examples";
 import { describe, expect, it } from "vitest";
+import getPort from "get-port";
 
 import { Probot, run, Server } from "../src/index.js";
 
 import { captureLogOutput } from "./helpers/capture-log-output.js";
-import WebhookExamples, {
-  type WebhookDefinition,
-} from "@octokit/webhooks-examples";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -57,7 +58,7 @@ describe("run", () => {
       const env = { ...defaultEnv };
 
       delete env.PRIVATE_KEY_PATH;
-      env.PORT = "3003";
+      env.PORT = (await getPort()).toString();
 
       return new Promise(async (resolve) => {
         server = await run(


### PR DESCRIPTION
Reduce some `// @ts-expect-error` and `// @ts-ignore` instructions in the ` /src` folder.  Especially the access to the internal state of the Probot Instance in setup.ts was always strange, especially since the state property was declared as private. Maybe someday we want to use real private fields by prefixing them with `#` and then it would not work... :D