### PR TITLE
docs: fix middleware config example for GCF

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -191,7 +191,7 @@ Please add yours!
 import { createNodeMiddleware, createProbot } from "probot";
 import app from "./app.js";
 
-const middleware = createNodeMiddleware(app, { probot: createProbot() });
+const middleware = createNodeMiddleware(app, { probot: createProbot(), webhooksPath: "/" });
 exports.probotApp = (req, res) => {
   middleware(req, res, () => {
     res.writeHead(404);


### PR DESCRIPTION
Sets the `webhooksPath` property in the example to enable the probot function to be executed.

Without this, the default path set by @octokit/webhooks when creating the middleware is `/api/github/webhooks` and the request always falls through to the `next()` handler.

Lost a couple of days debugging this, so updating the example to save any future users from the same headache