### PR TITLE
feat: renove legacy REST endpoint method access

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -202,8 +202,8 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
    * const config = await context.config('config.yml')
    *
    * if (config.close) {
-   *   context.octokit.issues.comment(context.issue({body: config.comment}))
-   *   context.octokit.issues.edit(context.issue({state: 'closed'}))
+   *   context.octokit.rest.issues.comment(context.issue({body: config.comment}))
+   *   context.octokit.rest.issues.edit(context.issue({state: 'closed'}))
    * }
    * ```
    *
@@ -214,8 +214,8 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
    * const config = await context.config('config.yml', {comment: 'Make sure to check all the specs.'})
    *
    * if (config.close) {
-   *   context.octokit.issues.comment(context.issue({body: config.comment}));
-   *   context.octokit.issues.edit(context.issue({state: 'closed'}))
+   *   context.octokit.rest.issues.comment(context.issue({body: config.comment}));
+   *   context.octokit.rest.issues.edit(context.issue({state: 'closed'}))
    * }
    * ```
    *

--- a/src/octokit/probot-octokit.ts
+++ b/src/octokit/probot-octokit.ts
@@ -2,7 +2,7 @@ import { Octokit } from "@octokit/core";
 import { enterpriseCompatibility } from "@octokit/plugin-enterprise-compatibility";
 import type { RequestOptions } from "@octokit/types";
 import { paginateRest } from "@octokit/plugin-paginate-rest";
-import { legacyRestEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
+import { restEndpointMethods } from "@octokit/plugin-rest-endpoint-methods";
 import { retry } from "@octokit/plugin-retry";
 import { throttling } from "@octokit/plugin-throttling";
 import { config } from "@probot/octokit-plugin-config";
@@ -43,13 +43,13 @@ export const ProbotOctokit: typeof Octokit &
   Constructor<
     ReturnType<typeof retry> &
       ReturnType<typeof paginateRest> &
-      ReturnType<typeof legacyRestEndpointMethods> &
+      ReturnType<typeof restEndpointMethods> &
       ReturnType<typeof config>
   > = Octokit.plugin(
   throttling,
   retry,
   paginateRest,
-  legacyRestEndpointMethods,
+  restEndpointMethods,
   enterpriseCompatibility,
   probotRequestLogging,
   config,

--- a/test/e2e/hello-world.cjs
+++ b/test/e2e/hello-world.cjs
@@ -13,7 +13,7 @@ module.exports = (app) => {
     const params = context.issue({ body: "Hello World!" });
 
     // Post a comment on the issue
-    await context.octokit.issues.createComment(params);
+    await context.octokit.rest.issues.createComment(params);
     console.log("issue comment created");
   });
 };

--- a/test/e2e/hello-world.mjs
+++ b/test/e2e/hello-world.mjs
@@ -13,7 +13,7 @@ export default (app) => {
     const params = context.issue({ body: "Hello World!" });
 
     // Post a comment on the issue
-    await context.octokit.issues.createComment(params);
+    await context.octokit.rest.issues.createComment(params);
     console.log("issue comment created");
   });
 };

--- a/test/probot-octokit.test.ts
+++ b/test/probot-octokit.test.ts
@@ -29,7 +29,7 @@ describe("ProbotOctokit", () => {
       },
     });
 
-    expect((await octokit.users.getAuthenticated({})).data).toEqual(
+    expect((await octokit.rest.users.getAuthenticated({})).data).toEqual(
       '{"login": "ohai"}',
     );
   });
@@ -360,7 +360,7 @@ describe("ProbotOctokit", () => {
       callCountSpy++;
     };
     const res = await octokit.paginate(
-      octokit.issues.listForRepo.endpoint.merge({
+      octokit.rest.issues.listForRepo.endpoint.merge({
         owner: "JasonEtco",
         repo: "pizza",
         per_page: 1,
@@ -417,7 +417,7 @@ describe("ProbotOctokit", () => {
       if (response.data[0].id === 2) done();
     }) as any;
     const res = await octokit.paginate(
-      octokit.issues.listForRepo.endpoint.merge({
+      octokit.rest.issues.listForRepo.endpoint.merge({
         owner: "JasonEtco",
         repo: "pizza",
         per_page: 1,
@@ -467,7 +467,7 @@ describe("ProbotOctokit", () => {
       },
     });
     const res = await octokit.paginate(
-      octokit.issues.listForRepo.endpoint.merge({
+      octokit.rest.issues.listForRepo.endpoint.merge({
         owner: "JasonEtco",
         repo: "pizza",
         per_page: 1,

--- a/test/probot.test.ts
+++ b/test/probot.test.ts
@@ -103,7 +103,7 @@ describe("Probot", () => {
         request: { fetch: mock.fetchHandler },
       });
       const octokit = await probot.auth();
-      await octokit.apps.getAuthenticated();
+      await octokit.rest.apps.getAuthenticated();
     });
   });
 


### PR DESCRIPTION
BREAKING CHANGE: Remove legacy REST enpoint method access. Users will now have to use the `octokit.rest.*` methods