### PR TITLE
fix(deps): bump smee-client to v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "get-port": "^7.0.0",
         "prettier": "^3.0.3",
         "semantic-release-plugin-update-version-in-files": "^2.0.0",
-        "smee-client": "^3.1.1",
+        "smee-client": "^4.0.0",
         "sonic-boom": "^4.0.0",
         "tsd": "^0.32.0",
         "typedoc": "^0.28.0",
@@ -63,7 +63,7 @@
         "vitest": "^3.0.0"
       },
       "engines": {
-        "node": "^20.17 || >= 22"
+        "node": "^20.18.1 || >= 22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3536,16 +3536,16 @@
       }
     },
     "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-4.0.0.tgz",
+      "integrity": "sha512-fvIkb9qZzdMxgZrEQDyll+9oJsyaVvY92I2Re+qK0qEJ+w5s0X3dtz+M0VAPOjP1gtU3iqWyjQ0G3nvd5CLZ2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "eventsource-parser": "^3.0.1"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/eventsource-parser": {
@@ -6495,22 +6495,22 @@
       }
     },
     "node_modules/smee-client": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/smee-client/-/smee-client-3.1.1.tgz",
-      "integrity": "sha512-2XGrGA83suqtC/Vn1v/MUAPN+hLSYwTiopqjx97tHGzKMBLJYIeCEcch2dfqFLEXInS6U1pm+jwSQFbphLrg9w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/smee-client/-/smee-client-4.0.0.tgz",
+      "integrity": "sha512-TZ/Eacqqn1OtaqGw0ONkQltR1eVGlqYBPH9tb+2NcgdgOTR/U0Pe5+A5DgSSrCgQ0hkcVH5l2jXY48qQEPmKfw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "commander": "^12.0.0",
-        "eventsource": "^3.0.5",
-        "undici": "^6.19.8",
+        "eventsource": "^4.0.0",
+        "undici": "^7.0.0",
         "validator": "^13.11.0"
       },
       "bin": {
         "smee": "bin/smee.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": "^20.18 || >= 22"
       }
     },
     "node_modules/sonic-boom": {
@@ -7021,13 +7021,13 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "6.21.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
-      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "get-port": "^7.0.0",
     "prettier": "^3.0.3",
     "semantic-release-plugin-update-version-in-files": "^2.0.0",
-    "smee-client": "^3.1.1",
+    "smee-client": "^4.0.0",
     "sonic-boom": "^4.0.0",
     "tsd": "^0.32.0",
     "typedoc": "^0.28.0",
@@ -97,7 +97,7 @@
     "default": "./lib/index.js"
   },
   "engines": {
-    "node": "^20.17 || >= 22"
+    "node": "^20.18.1 || >= 22"
   },
   "release": {
     "plugins": [

--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -16,7 +16,7 @@ const pkg = loadPackageJson(resolve(__dirname, "package.json"));
 
 if (!isSupportedRuntime(globalThis)) {
   console.log(
-    `Node.js version 20.17 or 22, Deno version 2.3.0 or Bun version 1.2.14 is required. You have ${detectRuntime(globalThis)} ${process.version}.`,
+    `Node.js version 20.18.1 or 22, Deno version 2.3.0 or Bun version 1.2.14 is required. You have ${detectRuntime(globalThis)} ${process.version}.`,
   );
   process.exit(1);
 }

--- a/src/helpers/is-supported-runtime.ts
+++ b/src/helpers/is-supported-runtime.ts
@@ -3,11 +3,14 @@ import { detectRuntime } from "./detect-runtime.js";
 export function isSupportedRuntime(globalThis: any): boolean {
   switch (detectRuntime(globalThis)) {
     case "node": {
-      const [major, minor] = globalThis.process.versions.node
-        .split(".", 2)
+      const [major, minor, patch] = globalThis.process.versions.node
+        .split(".", 3)
         .map(Number);
 
-      return major >= 22 || (major === 20 && minor >= 17);
+      return (
+        major >= 22 ||
+        (major === 20 && (minor > 18 || (minor === 18 && patch >= 1)))
+      );
     }
     case "deno": {
       const [major, minor] = globalThis.process.versions.deno

--- a/test/bin/is-supported-runtime.test.ts
+++ b/test/bin/is-supported-runtime.test.ts
@@ -5,13 +5,13 @@ import { loadPackageJson } from "../../src/helpers/load-package-json.js";
 
 describe("isSupportedRuntime", () => {
   const { engines } = loadPackageJson();
-  it(`engines value is set to "^20.17 || >= 22"`, () => {
-    expect(engines!.node).toBe("^20.17 || >= 22");
+  it(`engines value is set to "^20.18.1 || >= 22"`, () => {
+    expect(engines!.node).toBe("^20.18.1 || >= 22");
   });
 
-  it("returns true if node is bigger or equal v20.17 or v22", () => {
+  it("returns true if node is bigger or equal v20.18.1 or v22", () => {
     expect(
-      isSupportedRuntime({ process: { versions: { node: "20.17.0" } } }),
+      isSupportedRuntime({ process: { versions: { node: "20.18.1" } } }),
     ).toBe(true);
     expect(
       isSupportedRuntime({ process: { versions: { node: "22.0.0" } } }),
@@ -21,7 +21,7 @@ describe("isSupportedRuntime", () => {
     ).toBe(true);
   });
 
-  it("returns false if node is smaller than v20.17", () => {
+  it("returns false if node is smaller than v20.18.1 or v22.0.0", () => {
     expect(
       isSupportedRuntime({ process: { versions: { node: "17.0.0" } } }),
     ).toBe(false);


### PR DESCRIPTION
BREAKING CHANGE: Bump minimum required Node version to 20.18.1 to match undici v7