### PR TITLE
refactor: getWebhooks,  avoid passing state

### DIFF
--- a/src/octokit/get-webhooks.ts
+++ b/src/octokit/get-webhooks.ts
@@ -1,15 +1,24 @@
 import { Webhooks } from "@octokit/webhooks";
+import type { Logger } from "pino";
 
-import type { State } from "../types.js";
+import type { ProbotOctokit } from "../exports.js";
+import type { ProbotWebhooks } from "../types.js";
+
 import { getErrorHandler } from "../helpers/get-error-handler.js";
 import { webhookTransform } from "./octokit-webhooks-transform.js";
 
-export function getWebhooks(state: State) {
+type GetWebhooksOptions = {
+  log: Logger;
+  octokit: ProbotOctokit;
+  webhookSecret: string;
+};
+
+export function getWebhooks(options: GetWebhooksOptions): ProbotWebhooks {
   const webhooks = new Webhooks({
-    log: state.log,
-    secret: state.webhookSecret!,
-    transform: (hook) => webhookTransform(state, hook),
+    log: options.log,
+    secret: options.webhookSecret,
+    transform: (event) => webhookTransform(options, event),
   });
-  webhooks.onError(getErrorHandler(state.log));
+  webhooks.onError(getErrorHandler(options.log));
   return webhooks;
 }

--- a/src/octokit/octokit-webhooks-transform.ts
+++ b/src/octokit/octokit-webhooks-transform.ts
@@ -1,18 +1,27 @@
 import type { EmitterWebhookEvent as WebhookEvent } from "@octokit/webhooks";
+import type { Logger } from "pino";
 
+import type { ProbotOctokit } from "../exports.js";
 import { Context } from "../context.js";
-import type { State } from "../types.js";
+
+type WebhookTransformOptions = {
+  log: Logger;
+  octokit: ProbotOctokit;
+};
 
 /**
  * Probot's transform option, which extends the `event` object that is passed
  * to webhook event handlers by `@octokit/webhooks`
  * @see https://github.com/octokit/webhooks.js/#constructor
  */
-export async function webhookTransform(state: State, event: WebhookEvent) {
-  const log = state.log.child({ name: "event", id: event.id });
-  const octokit = (await state.octokit.auth({
+export async function webhookTransform(
+  options: WebhookTransformOptions,
+  event: WebhookEvent,
+) {
+  const octokit = (await options.octokit.auth({
     type: "event-octokit",
     event,
-  })) as typeof state.octokit;
+  })) as ProbotOctokit;
+  const log = options.log.child({ name: "event", id: event.id });
   return new Context(event, octokit, log);
 }

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -94,7 +94,11 @@ export class Probot {
       server: options.server,
     };
 
-    this.#state.webhooks = getWebhooks(this.#state);
+    this.#state.webhooks = getWebhooks({
+      log: this.#state.log,
+      octokit: this.#state.octokit,
+      webhookSecret: this.#state.webhookSecret,
+    });
   }
 
   public async auth(installationId?: number): Promise<ProbotOctokit> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type State = {
   baseUrl?: string;
   webhooks?: ProbotWebhooks;
   webhookPath: string;
-  webhookSecret?: string;
+  webhookSecret: string;
   request?: RequestRequestOptions;
   server?: Server | void;
 };


### PR DESCRIPTION
avoid the need to pass the state object to getWebhooks()