### PR TITLE
feat: use npx-probot-light for smee-client and ioredis

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
         "@octokit/types": "^14.1.0",
         "@octokit/webhooks": "^14.1.0",
         "@probot/get-private-key": "^2.0.0",
-        "@probot/npx-import": "probot/npx-import",
         "@probot/octokit-plugin-config": "^3.0.2",
         "@probot/pino": "^4.0.0",
         "bottleneck": "^2.19.5",
@@ -28,6 +27,7 @@
         "import-meta-resolve": "^4.1.0",
         "ioredis": "^5.3.2",
         "js-yaml": "^4.1.0",
+        "npx-import-light": "^1.0.0",
         "octokit-auth-probot": "^4.0.0",
         "package-config": "^5.0.0",
         "pino": "^9.0.0",
@@ -1788,11 +1788,6 @@
       "engines": {
         "node": ">= 18"
       }
-    },
-    "node_modules/@probot/npx-import": {
-      "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/probot/npx-import.git#e0489d6c47bcce2127bdd2eab4142b73562087e1",
-      "license": "ISC"
     },
     "node_modules/@probot/octokit-plugin-config": {
       "version": "3.0.2",
@@ -5243,6 +5238,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/npx-import-light": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/npx-import-light/-/npx-import-light-1.0.0.tgz",
+      "integrity": "sha512-OgOY4wh4tfj6G7nKYobbpYg2yhYH/19dz/ZRzcOGN+rP3wjLHTRb6ZMM5UshLu4gbDdwwZ8VX2fXBr4krsYHzQ==",
+      "license": "ISC"
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@octokit/types": "^14.1.0",
         "@octokit/webhooks": "^14.1.0",
         "@probot/get-private-key": "^2.0.0",
+        "@probot/npx-import": "probot/npx-import",
         "@probot/octokit-plugin-config": "^3.0.2",
         "@probot/pino": "^4.0.0",
         "bottleneck": "^2.19.5",
@@ -1787,6 +1788,11 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/@probot/npx-import": {
+      "version": "0.0.0",
+      "resolved": "git+ssh://git@github.com/probot/npx-import.git#e0489d6c47bcce2127bdd2eab4142b73562087e1",
+      "license": "ISC"
     },
     "node_modules/@probot/octokit-plugin-config": {
       "version": "3.0.2",
@@ -7079,9 +7085,9 @@
       }
     },
     "node_modules/validator": {
-      "version": "13.15.0",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.0.tgz",
-      "integrity": "sha512-36B2ryl4+oL5QxZ3AzD0t5SsMNGvTtQHpjgFO5tbNxfXbMFkY822ktCDe1MnlqV3301QQI9SLHDNJokDI+Z9pA==",
+      "version": "13.15.15",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.15.15.tgz",
+      "integrity": "sha512-BgWVbCI72aIQy937xbawcs+hrVaN/CZ2UwutgaJ36hGqRrLNM+f5LUT/YPRbo8IV/ASeFzXszezV+y2+rq3l8A==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@octokit/types": "^14.1.0",
     "@octokit/webhooks": "^14.1.0",
     "@probot/get-private-key": "^2.0.0",
+    "@probot/npx-import": "probot/npx-import",
     "@probot/octokit-plugin-config": "^3.0.2",
     "@probot/pino": "^4.0.0",
     "bottleneck": "^2.19.5",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@octokit/types": "^14.1.0",
     "@octokit/webhooks": "^14.1.0",
     "@probot/get-private-key": "^2.0.0",
-    "@probot/npx-import": "probot/npx-import",
+    "npx-import-light": "^1.0.0",
     "@probot/octokit-plugin-config": "^3.0.2",
     "@probot/pino": "^4.0.0",
     "bottleneck": "^2.19.5",

--- a/src/helpers/webhook-proxy.ts
+++ b/src/helpers/webhook-proxy.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "pino";
-import { npxImport } from "@probot/npx-import";
+import { npxImport } from "npx-import-light";
 
 let SmeeClient: any;
 

--- a/src/helpers/webhook-proxy.ts
+++ b/src/helpers/webhook-proxy.ts
@@ -1,17 +1,20 @@
 import type { Logger } from "pino";
+import { npxImport } from "@probot/npx-import";
 
-let SmeeClient;
+let SmeeClient: any;
 
 export const createWebhookProxy = async (
   opts: WebhookProxyOptions,
 ): Promise<EventSource | undefined> => {
   try {
-    SmeeClient ??= (await import("smee-client")).SmeeClient;
+    SmeeClient ??= (
+      await npxImport<any>("smee-client@4.3.1", { onlyPackageRunner: true })
+    ).SmeeClient;
   } catch {
     opts.logger.warn(
       "Run `npm install --save-dev smee-client` to proxy webhooks to localhost.",
     );
-    return;
+    return undefined;
   }
   const smeeClient = new SmeeClient({
     logger: opts.logger,

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
+import { npxImport } from "@probot/npx-import";
 import yaml from "js-yaml";
 import type { RequestParameters } from "@octokit/types";
 import type { Logger } from "pino";
@@ -32,7 +33,8 @@ export class ManifestCreation {
   ): Promise<string | undefined> {
     let SmeeClient: any;
     try {
-      SmeeClient = SmeeClientParam || (await import("smee-client")).SmeeClient;
+      SmeeClient =
+        SmeeClientParam || (await npxImport("smee-client@4.3.1")).SmeeClient;
     } catch {
       log.warn("SmeeClient is not available");
       return void 0;

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 
-import { npxImport } from "@probot/npx-import";
+import { npxImport } from "npx-import-light";
 import yaml from "js-yaml";
 import type { RequestParameters } from "@octokit/types";
 import type { Logger } from "pino";

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -34,7 +34,7 @@ export class ManifestCreation {
     let SmeeClient: any;
     try {
       SmeeClient =
-        SmeeClientParam || (await npxImport("smee-client@4.3.1")).SmeeClient;
+        SmeeClientParam || (await npxImport("smee-client@4.3.1", { onlyPackageRunner:  true })).SmeeClient;
     } catch {
       log.warn("SmeeClient is not available");
       return void 0;

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -34,7 +34,9 @@ export class ManifestCreation {
     let SmeeClient: any;
     try {
       SmeeClient =
-        SmeeClientParam || (await npxImport("smee-client@4.3.1", { onlyPackageRunner:  true })).SmeeClient;
+        SmeeClientParam ||
+        (await npxImport("smee-client@4.3.1", { onlyPackageRunner: true }))
+          .SmeeClient;
     } catch {
       log.warn("SmeeClient is not available");
       return void 0;

--- a/src/octokit/get-octokit-throttle-options.ts
+++ b/src/octokit/get-octokit-throttle-options.ts
@@ -1,4 +1,4 @@
-import { npxImport } from "@probot/npx-import";
+import { npxImport } from "npx-import-light";
 import Bottleneck from "bottleneck";
 import { type RedisOptions } from "ioredis";
 import type { Logger } from "pino";

--- a/src/octokit/get-octokit-throttle-options.ts
+++ b/src/octokit/get-octokit-throttle-options.ts
@@ -1,5 +1,6 @@
+import { npxImport } from "@probot/npx-import";
 import Bottleneck from "bottleneck";
-import { Redis, type RedisOptions } from "ioredis";
+import { type RedisOptions } from "ioredis";
 import type { Logger } from "pino";
 import type { ThrottlingOptions } from "@octokit/plugin-throttling";
 
@@ -8,7 +9,7 @@ type Options = {
   redisConfig?: RedisOptions | string;
 };
 
-export function getOctokitThrottleOptions(options: Options): ThrottlingOptions {
+export async function getOctokitThrottleOptions(options: Options): Promise<ThrottlingOptions> {
   const { log, redisConfig } = options;
 
   const throttlingOptions: ThrottlingOptions = {
@@ -35,7 +36,7 @@ export function getOctokitThrottleOptions(options: Options): ThrottlingOptions {
   if (!redisConfig) return throttlingOptions;
 
   const connection = new Bottleneck.IORedisConnection({
-    client: getRedisClient(options),
+    client: await getRedisClient(options),
   });
   connection.on("error", (error) => {
     log.error(Object.assign(error, { source: "bottleneck" }));
@@ -47,6 +48,9 @@ export function getOctokitThrottleOptions(options: Options): ThrottlingOptions {
   return throttlingOptions;
 }
 
-function getRedisClient({ redisConfig }: Options): Redis | void {
+let Redis = null;
+
+async function getRedisClient({ redisConfig }: Options): Promise<any> {
+  Redis ??= (await npxImport("ioredis@5.6.1", { onlyPackageRunner: true })).Redis
   if (redisConfig) return new Redis(redisConfig as RedisOptions);
 }

--- a/src/octokit/get-octokit-throttle-options.ts
+++ b/src/octokit/get-octokit-throttle-options.ts
@@ -9,7 +9,9 @@ type Options = {
   redisConfig?: RedisOptions | string;
 };
 
-export async function getOctokitThrottleOptions(options: Options): Promise<ThrottlingOptions> {
+export async function getOctokitThrottleOptions(
+  options: Options,
+): Promise<ThrottlingOptions> {
   const { log, redisConfig } = options;
 
   const throttlingOptions: ThrottlingOptions = {
@@ -51,6 +53,7 @@ export async function getOctokitThrottleOptions(options: Options): Promise<Throt
 let Redis = null;
 
 async function getRedisClient({ redisConfig }: Options): Promise<any> {
-  Redis ??= (await npxImport("ioredis@5.6.1", { onlyPackageRunner: true })).Redis
+  Redis ??= (await npxImport("ioredis@5.6.1", { onlyPackageRunner: true }))
+    .Redis;
   if (redisConfig) return new Redis(redisConfig as RedisOptions);
 }

--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -31,9 +31,9 @@ type Options = {
  * Besides the authentication, the Octokit's baseUrl is set as well when run
  * against a GitHub Enterprise Server with a custom domain.
  */
-export function getProbotOctokitWithDefaults(
+export async function getProbotOctokitWithDefaults(
   options: Options,
-): typeof ProbotOctokit {
+): Promise<typeof ProbotOctokit> {
   const authOptions = options.githubToken
     ? {
         token: options.githubToken,
@@ -54,7 +54,7 @@ export function getProbotOctokitWithDefaults(
         }),
       };
 
-  const octokitThrottleOptions = getOctokitThrottleOptions({
+  const octokitThrottleOptions = await getOctokitThrottleOptions({
     log: options.log,
     redisConfig: options.redisConfig,
   });

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -151,7 +151,7 @@ export class Probot {
           }),
       );
 
-      const Octokit = getProbotOctokitWithDefaults({
+      const Octokit = await getProbotOctokitWithDefaults({
         githubToken: this.#state.githubToken,
         Octokit: this.#state.OctokitBase,
         appId: this.#state.appId,

--- a/test/npx-import.test.ts
+++ b/test/npx-import.test.ts
@@ -50,3 +50,16 @@ describe("smee-client", () => {
     );
   });
 });
+
+describe("ioredis", () => {
+  it("should be ensured that ioredis is the same version as in the package-lock.json", () => {
+    expect(
+      typeof packageLockJson.packages["node_modules/ioredis"].version,
+    ).toBe("string");
+    checkForFixedNpxImport(
+      join(__dirname, "../src"),
+      "ioredis",
+      packageLockJson.packages["node_modules/ioredis"].version,
+    );
+  });
+});

--- a/test/probot.test.ts
+++ b/test/probot.test.ts
@@ -378,13 +378,15 @@ describe("Probot", () => {
     () => {
       it("sets throttle options", async () => {
         const pluginCalls: any[] = [];
-        new Probot({
+        const probot = new Probot({
           githubToken: "faketoken",
           redisConfig: process.env.REDIS_URL,
           Octokit: ProbotOctokit.plugin((_octokit, options) => {
             pluginCalls.push({ _octokit, options });
           }),
         });
+
+        await probot.ready();
 
         expect(pluginCalls.length).toBe(1);
         expect(pluginCalls[0].options.throttle?.Bottleneck).toBe(Bottleneck);
@@ -405,7 +407,7 @@ describe("Probot", () => {
         };
 
         const pluginCalls: any[] = [];
-        new Probot({
+        const probot = new Probot({
           githubToken: "faketoken",
           redisConfig,
           Octokit: ProbotOctokit.plugin((_octokit, options) => {
@@ -413,6 +415,7 @@ describe("Probot", () => {
           }),
         });
 
+        await probot.ready();
         expect(pluginCalls.length).toBe(1);
 
         expect(pluginCalls[0].options.throttle?.Bottleneck).toBe(Bottleneck);

--- a/test/smee-client-npx-import.test.ts
+++ b/test/smee-client-npx-import.test.ts
@@ -1,0 +1,52 @@
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { describe, expect, it } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const packageLockJson = JSON.parse(
+  readFileSync(join(__dirname, "../package-lock.json"), "utf8"),
+);
+
+const npxImportRE = /npxImport(?:<[^>]+>)?\("([^"]+)/gu;
+
+const checkForFixedNpxImport = (dir: string, pkg: string, version: string) => {
+  const files = readdirSync(dir);
+
+  for (let i = 0; i < files.length; i++) {
+    let file = join(dir, files[i]);
+    if (statSync(file).isDirectory()) {
+      checkForFixedNpxImport(file, pkg, version);
+    } else {
+      if (file.endsWith(".ts")) {
+        const fileContent = readFileSync(file, "utf8"); // Ensure the file is readable
+        const matches = npxImportRE.exec(fileContent);
+        if (matches) {
+          if (
+            matches[1].startsWith(pkg) &&
+            matches[1] !== `${pkg}@${version}`
+          ) {
+            throw new Error(
+              `Found npxImport for ${matches[1]} in ${file}, expected version ${pkg}@${version}. Please update the import to use the fixed version.`,
+            );
+          }
+        }
+      }
+    }
+  }
+};
+
+describe("smee-client", () => {
+  it("should be ensured that smee-client is the same version as in the package-lock.json", () => {
+    expect(
+      typeof packageLockJson.packages["node_modules/smee-client"].version,
+    ).toBe("string");
+    checkForFixedNpxImport(
+      join(__dirname, "../src"),
+      "smee-client",
+      packageLockJson.packages["node_modules/smee-client"].version,
+    );
+  });
+});


### PR DESCRIPTION
As we have now the initialization async, we can dynamically load ioredis and smee-client when running probot with npx.

Needs that we agree on publishing @probot/npx-import
we would need to make ioredis and smee-client to be dev dependencies