### PR TITLE
Fix TypeScript errors

### DIFF
--- a/src/helpers/get-log.ts
+++ b/src/helpers/get-log.ts
@@ -14,8 +14,7 @@
  * app.log.fatal("Goodbye, cruel world!");
  * ```
  */
-import { pino } from "pino";
-import type { Logger, LoggerOptions } from "pino";
+import pino, { type Logger, type LoggerOptions } from "pino";
 import { getTransformStream, type Options, type LogLevel } from "@probot/pino";
 
 export type GetLogOptions = {


### PR DESCRIPTION
```
Property 'destination' does not exist on type '{ <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(optionsOrStream?: LoggerOptions<CustomLevels, UseOnlyCustomLevels> | DestinationStream | undefined): Logger<...>; <CustomLevels extends string = never, UseOnlyCustomLevels extends boolean = boolean>(options: LoggerOptions<...>, st...'.
```