### PR TITLE
fix: stop server in `run` if we send SIGINT

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "pretest": "npm run rm:lib && npm run build && tsc --noEmit -p test",
     "redis:start": "docker run -p 6379:6379 --name probot-redis -d --rm redis",
     "redis:stop": "docker stop probot-redis",
+    "start": "node ./bin/probot.js",
     "test": "vitest run",
     "test:code": "vitest run",
     "test:coverage": "vitest run --coverage",

--- a/src/run.ts
+++ b/src/run.ts
@@ -187,5 +187,17 @@ export async function run(
   await server.load(appFnOrArgv);
   await server.start();
 
+  process.on("SIGINT", async () => {
+    console.info("Stopping server...");
+    try {
+      await server.stop();
+      console.info("Server stopped");
+      process.exit(0);
+    } catch (e) {
+      console.error({ err: e as Error }, "Error while stopping server");
+      process.exit(1);
+    }
+  });
+
   return server;
 }


### PR DESCRIPTION
Was testing probot locally, and the port was still blocked, so this PR fixes it by shutting down the server when receiving SIGINT. Should we also listen to SIGKILL? SIGTERM?