### PR TITLE
feat: remove sourcemaps, ensure only `erasableSyntaxOnly` is enforced

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "sonic-boom": "^4.0.0",
         "tsd": "^0.33.0",
         "typedoc": "^0.28.0",
-        "typescript": "^5.2.2",
+        "typescript": "^5.9.3",
         "vitest": "^3.0.0"
       },
       "engines": {
@@ -979,7 +979,6 @@
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.3.tgz",
       "integrity": "sha512-oNXsh2ywth5aowwIa7RKtawnkdH6LgU1ztfP9AIUCQCvzysB+WeU8o2kyyosDPwBZutPpjZDKPQGIzzrfTWweQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.1",
@@ -2104,7 +2103,6 @@
       "integrity": "sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "fflate": "^0.8.2",
@@ -4951,7 +4949,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -6396,12 +6393,11 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
-      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6506,7 +6502,6 @@
       "integrity": "sha512-4nVGliEpxmhCL8DslSAUdxlB6+SMrhB0a1v5ijlh1xB1nEPuy1mxaHxysVucLHuWryAxLWg6a5ei+U4TLn/rFg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.5.0",
@@ -6605,7 +6600,6 @@
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "sonic-boom": "^4.0.0",
     "tsd": "^0.33.0",
     "typedoc": "^0.28.0",
-    "typescript": "^5.2.2",
+    "typescript": "^5.9.3",
     "vitest": "^3.0.0"
   },
   "exports": {

--- a/src/manifest-creation.ts
+++ b/src/manifest-creation.ts
@@ -38,7 +38,6 @@ export class ManifestCreation {
         (await npxImport("smee-client@4.3.1", { onlyPackageRunner: true }))
           .SmeeClient;
     } catch {
-      // @ts-expect-error TypeScript is just being difficult here, since https://github.com/pinojs/pino/pull/2230
       log.warn("SmeeClient is not available");
       return void 0;
     }
@@ -49,7 +48,6 @@ export class ManifestCreation {
       });
       return WEBHOOK_PROXY_URL;
     } catch {
-      // @ts-expect-error TypeScript is just being difficult here, since https://github.com/pinojs/pino/pull/2230
       log.warn("Unable to connect to smee.io, try restarting your server.");
       return void 0;
     }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,13 +4,16 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
-    "sourceMap": true,
+    "sourceMap": false,
     "outDir": "./lib",
     "skipLibCheck": true,
     "noImplicitAny": true,
     "declaration": true,
     "allowJs": true,
-    "lib": ["es2023", "dom"]
+    "lib": ["es2023"],
+    "strict": true,
+    "strictNullChecks": true,
+    "erasableSyntaxOnly": true
   },
   "include": ["src/**/*"],
   "compileOnSave": false


### PR DESCRIPTION
Reduces the package size and we are basically now just stripping the types away. So no need for sourcemaps anymore...