### PR TITLE
fix: receive command failing when LOG_LEVEL is set

### DIFF
--- a/src/bin/receive.ts
+++ b/src/bin/receive.ts
@@ -72,7 +72,7 @@ export async function receive(args: string[]) {
       },
       "log-format": {
         type: "string",
-        default: process.env.LOG_LEVEL || "pretty",
+        default: process.env.LOG_FORMAT || "pretty",
       },
       "log-level-in-string": {
         type: "boolean",


### PR DESCRIPTION
Fixes an issue where the `receive` command fails with `Error: Invalid log format` when the `LOG_LEVEL` env var is set.