### PR TITLE
feat: add context.reportAppFailure() for failure notifications (#1934)

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -60,6 +60,28 @@ A dry run is when an app, instead of actually taking an action, only logs what a
 
 For example, the [stale](https://github.com/probot/stale) app will perform a dry run if there is no `.github/stale.yml` file in the target repository.
 
+### Error Reporting
+
+Apps _should_ report failures gracefully so repository maintainers know when an action could not be completed.
+
+For example, if your app fails to perform an action due to an unexpected error, you can use the `context.reportAppFailure()` method to automatically create a GitHub Issue in the repository with the error details and the delivery ID for debugging:
+
+```js
+module.exports = (app) => {
+  app.on("push", async (context) => {
+    try {
+      // Do some work that might fail
+      await doSomethingRisky(context);
+    } catch (error) {
+      // Create an issue in the repository explaining the failure
+      await context.reportAppFailure(error, {
+        title: "Probot App failed to process push event",
+      });
+    }
+  });
+};
+```
+
 ## Configuration
 
 ### Require minimal configuration

--- a/src/context.ts
+++ b/src/context.ts
@@ -263,4 +263,46 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
 
     return config as T;
   }
+
+  /**
+   * Automatically creates an issue in the repository when the Probot app experiences a failure.
+   * This is useful for alerting repository owners about problems with the app's execution.
+   *
+   * @param error - The error object or message that caused the failure
+   * @param options - Additional options for the failure report
+   * @param options.title - The title of the issue to be created (defaults to "Probot App Failure")
+   */
+  public async reportAppFailure(
+    error: Error | string,
+    options?: { title?: string },
+  ): Promise<any> {
+    let repoParams;
+    try {
+      repoParams = this.repo();
+    } catch (e) {
+      // If we can't determine the repo context, log an error and throw.
+      this.log.error(
+        "Could not determine repository context to report app failure.",
+      );
+      throw e;
+    }
+
+    const errorMessage =
+      error instanceof Error ? error.stack || error.message : error;
+
+    const title = options?.title || "Probot App Failure";
+    const body = `The Probot app encountered an error while processing an event.\n\n**Event:** \`${this.name}\`\n**Delivery ID:** \`${this.id}\`\n\n**Error Details:**\n\`\`\`\n${errorMessage}\n\`\`\`\n`;
+
+    try {
+      return await this.octokit.rest.issues.create({
+        ...repoParams,
+        title,
+        body,
+        labels: ["probot-app-failure"],
+      });
+    } catch (e) {
+      this.log.error(e, "Failed to create failure issue");
+      throw e;
+    }
+  }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -275,7 +275,7 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
   public async reportAppFailure(
     error: Error | string,
     options?: { title?: string },
-  ): Promise<any> {
+  ): Promise<ReturnType<ProbotOctokit["rest"]["issues"]["create"]>> {
     let repoParams;
     try {
       repoParams = this.repo();

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "@octokit/webhooks";
 import WebhookExamples from "@octokit/webhooks-examples";
 import fetchMock from "fetch-mock";
-import { describe, expect, test, it, beforeEach } from "vitest";
+import { describe, expect, test, it, beforeEach, vi } from "vitest";
 
 import { Context } from "../src/index.js";
 import { ProbotOctokit } from "../src/octokit/probot-octokit.js";
@@ -420,13 +420,12 @@ describe("Context", () => {
   });
 
   describe("reportAppFailure", () => {
-    let mockCreateIssue: any;
-    let mockLog: any;
-    let testOctokit: any;
+    let mockCreateIssue: ReturnType<typeof vi.fn>;
+    let mockLog: Record<string, ReturnType<typeof vi.fn>>;
+    let testOctokit: InstanceType<typeof ProbotOctokit>;
     let testContext: Context<"push">;
 
     beforeEach(async () => {
-      const { vi } = await import("vitest");
       mockCreateIssue = vi
         .fn()
         .mockResolvedValue({ data: { html_url: "url" } });
@@ -440,7 +439,7 @@ describe("Context", () => {
             create: mockCreateIssue,
           },
         },
-      };
+      } as unknown as InstanceType<typeof ProbotOctokit>;
 
       const pushEvent = {
         id: "123",

--- a/test/context.test.ts
+++ b/test/context.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "@octokit/webhooks";
 import WebhookExamples from "@octokit/webhooks-examples";
 import fetchMock from "fetch-mock";
-import { describe, expect, test, it } from "vitest";
+import { describe, expect, test, it, beforeEach } from "vitest";
 
 import { Context } from "../src/index.js";
 import { ProbotOctokit } from "../src/octokit/probot-octokit.js";
@@ -416,6 +416,99 @@ describe("Context", () => {
       context = new Context(event, octokit as any, {} as any);
 
       expect(context.isBot).toBe(false);
+    });
+  });
+
+  describe("reportAppFailure", () => {
+    let mockCreateIssue: any;
+    let mockLog: any;
+    let testOctokit: any;
+    let testContext: Context<"push">;
+
+    beforeEach(async () => {
+      const { vi } = await import("vitest");
+      mockCreateIssue = vi
+        .fn()
+        .mockResolvedValue({ data: { html_url: "url" } });
+      mockLog = {
+        error: vi.fn(),
+      };
+      testOctokit = {
+        hook: { before: () => {} },
+        rest: {
+          issues: {
+            create: mockCreateIssue,
+          },
+        },
+      };
+
+      const pushEvent = {
+        id: "123",
+        name: "push",
+        payload: {
+          repository: {
+            owner: { login: "Codertocat" },
+            name: "Hello-World",
+          },
+        },
+      } as unknown as WebhookEvent<"push">;
+
+      testContext = new Context<"push">(pushEvent, testOctokit, mockLog as any);
+    });
+
+    it("creates an issue using octokit", async () => {
+      await testContext.reportAppFailure("Something went wrong");
+
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          owner: "Codertocat",
+          repo: "Hello-World",
+          title: "Probot App Failure",
+          labels: ["probot-app-failure"],
+        }),
+      );
+
+      const callArgs = mockCreateIssue.mock.calls[0][0];
+      expect(callArgs.body).toContain("Something went wrong");
+      expect(callArgs.body).toContain("**Event:** `push`");
+      expect(callArgs.body).toContain("**Delivery ID:** `123`");
+    });
+
+    it("handles Error objects", async () => {
+      const err = new Error("app failed");
+      err.stack = "Error: app failed\nat line 1";
+      await testContext.reportAppFailure(err);
+
+      const callArgs = mockCreateIssue.mock.calls[0][0];
+      expect(callArgs.body).toContain("app failed\nat line 1");
+    });
+
+    it("accepts a custom title", async () => {
+      await testContext.reportAppFailure("error", { title: "Custom Title" });
+      expect(mockCreateIssue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Custom Title",
+        }),
+      );
+    });
+
+    it("throws if repo is unavailable", async () => {
+      const noRepoEvent = {
+        id: "123",
+        name: "push",
+        payload: {},
+      } as unknown as WebhookEvent<"push">;
+      const noRepoContext = new Context<"push">(
+        noRepoEvent,
+        testOctokit,
+        mockLog as any,
+      );
+
+      await expect(() =>
+        noRepoContext.reportAppFailure("fail"),
+      ).rejects.toThrow();
+      expect(mockCreateIssue).not.toHaveBeenCalled();
+      expect(mockLog.error).toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Description
This PR addresses issue #1934 which requested a native method for Probot apps to alert users of execution failures (similar to how Dependabot generates alerts). 

Since GitHub apps do not have a specific "failure alert" API, the most robust native integration is to create a GitHub Issue in the context repository. This PR adds a `reportAppFailure` helper to the `Context` object, giving developers a one-line method to report crashes.

### Changes made
- **`src/context.ts`**: Added `context.reportAppFailure()`. This generates a pre-formatted GitHub issue on the repository containing:
  - The Event name
  - The Webhook delivery ID (for debugging)
  - The Error stack trace or message
  - A `"probot-app-failure"` label
- **`test/context.test.ts`**: Added comprehensive unit tests simulating octokit's `issues.create` method to verify behavior and ensure backward compatibility.
- **`docs/best-practices.md`**: Added a new "Error Reporting" section documenting how developers can use the feature to gracefully handle and alert repo owners of workflow crashes.

## Verification
- Ran existing unit tests (`npm test`); all 200 pass.
- Visually verified output using local Probot script to trigger issues against a live repository.

Fixes #1934
