### PR TITLE
fix #2293 calling 'probot receive --arg...'

### DIFF
--- a/src/bin/probot.ts
+++ b/src/bin/probot.ts
@@ -41,6 +41,7 @@ const { values, positionals } = parseArgs({
     help: { type: "boolean", short: "h", default: false },
     version: { type: "boolean", short: "v", default: false },
   },
+  strict: false,
 });
 
 if (values.version) {


### PR DESCRIPTION
with strict:true, parseArgs will throw due to unrecognized args for run/receive commands

ref https://nodejs.org/api/util.html#utilparseargsconfig