### PR TITLE
fix(types): preserve custom Octokit plugin types on context

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -58,7 +58,7 @@ const kOctokitRequestHookAdded = Symbol("octokit request hook added");
  */
 export class Context<
   Event extends WebhookEvents = WebhookEvents,
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 > {
   public name: WebhookEvents;
   public id: string;
@@ -70,14 +70,14 @@ export class Context<
    * An authenticated Octokit instance that can be used to make GitHub API
    * requests in the context of the webhook event.
    */
-  public octokit: OctokitType;
+  public octokit: Octokit;
 
   /**
    * A logger with context about the event.
    */
   public log: Logger;
 
-  constructor(event: WebhookEvent<Event>, octokit: OctokitType, log: Logger) {
+  constructor(event: WebhookEvent<Event>, octokit: Octokit, log: Logger) {
     this.name = event.name;
     this.id = event.id;
     this.payload = event.payload;

--- a/src/context.ts
+++ b/src/context.ts
@@ -56,7 +56,10 @@ const kOctokitRequestHookAdded = Symbol("octokit request hook added");
  *  };
  *  ```
  */
-export class Context<Event extends WebhookEvents = WebhookEvents> {
+export class Context<
+  Event extends WebhookEvents = WebhookEvents,
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+> {
   public name: WebhookEvents;
   public id: string;
   public payload: {
@@ -67,14 +70,14 @@ export class Context<Event extends WebhookEvents = WebhookEvents> {
    * An authenticated Octokit instance that can be used to make GitHub API
    * requests in the context of the webhook event.
    */
-  public octokit: ProbotOctokit;
+  public octokit: OctokitType;
 
   /**
    * A logger with context about the event.
    */
   public log: Logger;
 
-  constructor(event: WebhookEvent<Event>, octokit: ProbotOctokit, log: Logger) {
+  constructor(event: WebhookEvent<Event>, octokit: OctokitType, log: Logger) {
     this.name = event.name;
     this.id = event.id;
     this.payload = event.payload;

--- a/src/create-node-middleware.ts
+++ b/src/create-node-middleware.ts
@@ -37,13 +37,13 @@ const noop = () => {};
  * ```
  */
 export async function createNodeMiddleware<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 >(
-  appFn: ApplicationFunction<OctokitType>,
+  appFn: ApplicationFunction<Octokit>,
   {
-    probot = createProbot<OctokitType>(),
+    probot = createProbot<Octokit>(),
     webhooksPath,
-  } = {} as MiddlewareOptions<OctokitType>,
+  } = {} as MiddlewareOptions<Octokit>,
 ): Promise<
   (
     request: IncomingMessage,

--- a/src/create-node-middleware.ts
+++ b/src/create-node-middleware.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ProbotOctokit } from "./octokit/probot-octokit.js";
 
 import type {
   ApplicationFunction,
@@ -35,9 +36,14 @@ const noop = () => {};
  * });
  * ```
  */
-export async function createNodeMiddleware(
-  appFn: ApplicationFunction,
-  { probot = createProbot(), webhooksPath } = {} as MiddlewareOptions,
+export async function createNodeMiddleware<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+>(
+  appFn: ApplicationFunction<OctokitType>,
+  {
+    probot = createProbot<OctokitType>(),
+    webhooksPath,
+  } = {} as MiddlewareOptions<OctokitType>,
 ): Promise<
   (
     request: IncomingMessage,

--- a/src/create-probot.ts
+++ b/src/create-probot.ts
@@ -4,10 +4,11 @@ import { getPrivateKey } from "@probot/get-private-key";
 import type { Env, Options } from "./types.js";
 import { Probot } from "./probot.js";
 import { defaultWebhookPath } from "./server/server.js";
+import type { ProbotOctokit } from "./octokit/probot-octokit.js";
 
-type CreateProbotOptions = {
-  overrides?: Options;
-  defaults?: Options;
+type CreateProbotOptions<OctokitType extends ProbotOctokit = ProbotOctokit> = {
+  overrides?: Options<OctokitType>;
+  defaults?: Options<OctokitType>;
   env?: Partial<Env> | undefined;
 };
 
@@ -34,11 +35,13 @@ const DEFAULTS: Partial<Env> = {
  * @param overrides overwrites defaults and according environment variables
  * @param env defaults to process.env
  */
-export function createProbot({
+export function createProbot<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+>({
   overrides = {},
   defaults = {},
   env = process.env,
-}: CreateProbotOptions = {}): Probot {
+}: CreateProbotOptions<OctokitType> = {}): Probot<OctokitType> {
   let privateKey;
 
   try {
@@ -47,7 +50,7 @@ export function createProbot({
 
   const envWithDefaults = { ...DEFAULTS, ...env };
 
-  const envOptions: Options = {
+  const envOptions: Options<OctokitType> = {
     logLevel: envWithDefaults.LOG_LEVEL as LogLevel,
     appId: Number(envWithDefaults.APP_ID),
     privateKey: (privateKey && privateKey.toString()) || undefined,
@@ -67,7 +70,7 @@ export function createProbot({
     ...overrides,
   };
 
-  return new Probot({
+  return new Probot<OctokitType>({
     log: probotOptions.log,
     logLevel: probotOptions.logLevel,
     logFormat: envWithDefaults.LOG_FORMAT as PinoOptions["logFormat"],

--- a/src/create-probot.ts
+++ b/src/create-probot.ts
@@ -6,9 +6,9 @@ import { Probot } from "./probot.js";
 import { defaultWebhookPath } from "./server/server.js";
 import type { ProbotOctokit } from "./octokit/probot-octokit.js";
 
-type CreateProbotOptions<OctokitType extends ProbotOctokit = ProbotOctokit> = {
-  overrides?: Options<OctokitType>;
-  defaults?: Options<OctokitType>;
+type CreateProbotOptions<Octokit extends ProbotOctokit = ProbotOctokit> = {
+  overrides?: Options<Octokit>;
+  defaults?: Options<Octokit>;
   env?: Partial<Env> | undefined;
 };
 
@@ -36,12 +36,12 @@ const DEFAULTS: Partial<Env> = {
  * @param env defaults to process.env
  */
 export function createProbot<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 >({
   overrides = {},
   defaults = {},
   env = process.env,
-}: CreateProbotOptions<OctokitType> = {}): Probot<OctokitType> {
+}: CreateProbotOptions<Octokit> = {}): Probot<Octokit> {
   let privateKey;
 
   try {
@@ -50,7 +50,7 @@ export function createProbot<
 
   const envWithDefaults = { ...DEFAULTS, ...env };
 
-  const envOptions: Options<OctokitType> = {
+  const envOptions: Options<Octokit> = {
     logLevel: envWithDefaults.LOG_LEVEL as LogLevel,
     appId: Number(envWithDefaults.APP_ID),
     privateKey: (privateKey && privateKey.toString()) || undefined,
@@ -70,7 +70,7 @@ export function createProbot<
     ...overrides,
   };
 
-  return new Probot<OctokitType>({
+  return new Probot<Octokit>({
     log: probotOptions.log,
     logLevel: probotOptions.logLevel,
     logFormat: envWithDefaults.LOG_FORMAT as PinoOptions["logFormat"],

--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -8,9 +8,9 @@ import type { OctokitOptions, ProbotOctokitConstructor } from "../types.js";
 import { ProbotOctokit } from "./probot-octokit.js";
 import { getOctokitThrottleOptions } from "./get-octokit-throttle-options.js";
 
-type Options<OctokitType extends ProbotOctokit = ProbotOctokit> = {
+type Options<Octokit extends ProbotOctokit = ProbotOctokit> = {
   cache: Lru<string>;
-  Octokit: ProbotOctokitConstructor<OctokitType>;
+  Octokit: ProbotOctokitConstructor<Octokit>;
   log: Logger;
   githubToken?: string | undefined;
   appId?: number | undefined;
@@ -31,10 +31,10 @@ type Options<OctokitType extends ProbotOctokit = ProbotOctokit> = {
  * against a GitHub Enterprise Server with a custom domain.
  */
 export async function getProbotOctokitWithDefaults<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 >(
-  options: Options<OctokitType>,
-): Promise<ProbotOctokitConstructor<OctokitType>> {
+  options: Options<Octokit>,
+): Promise<ProbotOctokitConstructor<Octokit>> {
   const authOptions = options.githubToken
     ? {
         token: options.githubToken,
@@ -95,5 +95,5 @@ export async function getProbotOctokitWithDefaults<
     }
 
     return options;
-  }) as ProbotOctokitConstructor<OctokitType>;
+  }) as ProbotOctokitConstructor<Octokit>;
 }

--- a/src/octokit/get-probot-octokit-with-defaults.ts
+++ b/src/octokit/get-probot-octokit-with-defaults.ts
@@ -4,13 +4,13 @@ import type { RedisOptions } from "ioredis";
 import type { Logger } from "pino";
 import type { Lru } from "toad-cache";
 
-import type { OctokitOptions } from "../types.js";
+import type { OctokitOptions, ProbotOctokitConstructor } from "../types.js";
 import { ProbotOctokit } from "./probot-octokit.js";
 import { getOctokitThrottleOptions } from "./get-octokit-throttle-options.js";
 
-type Options = {
+type Options<OctokitType extends ProbotOctokit = ProbotOctokit> = {
   cache: Lru<string>;
-  Octokit: typeof ProbotOctokit;
+  Octokit: ProbotOctokitConstructor<OctokitType>;
   log: Logger;
   githubToken?: string | undefined;
   appId?: number | undefined;
@@ -30,9 +30,11 @@ type Options = {
  * Besides the authentication, the Octokit's baseUrl is set as well when run
  * against a GitHub Enterprise Server with a custom domain.
  */
-export async function getProbotOctokitWithDefaults(
-  options: Options,
-): Promise<typeof ProbotOctokit> {
+export async function getProbotOctokitWithDefaults<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+>(
+  options: Options<OctokitType>,
+): Promise<ProbotOctokitConstructor<OctokitType>> {
   const authOptions = options.githubToken
     ? {
         token: options.githubToken,
@@ -93,5 +95,5 @@ export async function getProbotOctokitWithDefaults(
     }
 
     return options;
-  });
+  }) as ProbotOctokitConstructor<OctokitType>;
 }

--- a/src/octokit/get-webhooks.ts
+++ b/src/octokit/get-webhooks.ts
@@ -7,15 +7,15 @@ import type { ProbotWebhooks } from "../types.js";
 import { getErrorHandler } from "../helpers/get-error-handler.js";
 import { webhookTransform } from "./octokit-webhooks-transform.js";
 
-type GetWebhooksOptions<OctokitType extends ProbotOctokit> = {
+type GetWebhooksOptions<Octokit extends ProbotOctokit> = {
   log: Logger;
-  octokit: OctokitType;
+  octokit: Octokit;
   webhookSecret: string;
 };
 
-export function getWebhooks<OctokitType extends ProbotOctokit>(
-  options: GetWebhooksOptions<OctokitType>,
-): ProbotWebhooks<OctokitType> {
+export function getWebhooks<Octokit extends ProbotOctokit>(
+  options: GetWebhooksOptions<Octokit>,
+): ProbotWebhooks<Octokit> {
   const webhooks = new Webhooks({
     log: options.log,
     secret: options.webhookSecret,

--- a/src/octokit/get-webhooks.ts
+++ b/src/octokit/get-webhooks.ts
@@ -7,13 +7,15 @@ import type { ProbotWebhooks } from "../types.js";
 import { getErrorHandler } from "../helpers/get-error-handler.js";
 import { webhookTransform } from "./octokit-webhooks-transform.js";
 
-type GetWebhooksOptions = {
+type GetWebhooksOptions<OctokitType extends ProbotOctokit> = {
   log: Logger;
-  octokit: ProbotOctokit;
+  octokit: OctokitType;
   webhookSecret: string;
 };
 
-export function getWebhooks(options: GetWebhooksOptions): ProbotWebhooks {
+export function getWebhooks<OctokitType extends ProbotOctokit>(
+  options: GetWebhooksOptions<OctokitType>,
+): ProbotWebhooks<OctokitType> {
   const webhooks = new Webhooks({
     log: options.log,
     secret: options.webhookSecret,

--- a/src/octokit/octokit-webhooks-transform.ts
+++ b/src/octokit/octokit-webhooks-transform.ts
@@ -4,9 +4,9 @@ import type { Logger } from "pino";
 import type { ProbotOctokit } from "./probot-octokit.js";
 import { Context } from "../context.js";
 
-type WebhookTransformOptions = {
+type WebhookTransformOptions<OctokitType extends ProbotOctokit> = {
   log: Logger;
-  octokit: ProbotOctokit;
+  octokit: OctokitType;
 };
 
 /**
@@ -14,14 +14,14 @@ type WebhookTransformOptions = {
  * to webhook event handlers by `@octokit/webhooks`
  * @see https://github.com/octokit/webhooks.js/#constructor
  */
-export async function webhookTransform(
-  options: WebhookTransformOptions,
+export async function webhookTransform<OctokitType extends ProbotOctokit>(
+  options: WebhookTransformOptions<OctokitType>,
   event: WebhookEvent,
 ) {
   const octokit = (await options.octokit.auth({
     type: "event-octokit",
     event,
-  })) as ProbotOctokit;
+  })) as OctokitType;
   const log = options.log.child({ name: "event", id: event.id });
   return new Context(event, octokit, log);
 }

--- a/src/octokit/octokit-webhooks-transform.ts
+++ b/src/octokit/octokit-webhooks-transform.ts
@@ -4,9 +4,9 @@ import type { Logger } from "pino";
 import type { ProbotOctokit } from "./probot-octokit.js";
 import { Context } from "../context.js";
 
-type WebhookTransformOptions<OctokitType extends ProbotOctokit> = {
+type WebhookTransformOptions<Octokit extends ProbotOctokit> = {
   log: Logger;
-  octokit: OctokitType;
+  octokit: Octokit;
 };
 
 /**
@@ -14,14 +14,14 @@ type WebhookTransformOptions<OctokitType extends ProbotOctokit> = {
  * to webhook event handlers by `@octokit/webhooks`
  * @see https://github.com/octokit/webhooks.js/#constructor
  */
-export async function webhookTransform<OctokitType extends ProbotOctokit>(
-  options: WebhookTransformOptions<OctokitType>,
+export async function webhookTransform<Octokit extends ProbotOctokit>(
+  options: WebhookTransformOptions<Octokit>,
   event: WebhookEvent,
 ) {
   const octokit = (await options.octokit.auth({
     type: "event-octokit",
     event,
-  })) as OctokitType;
+  })) as Octokit;
   const log = options.log.child({ name: "event", id: event.id });
   return new Context(event, octokit, log);
 }

--- a/src/octokit/probot-octokit.ts
+++ b/src/octokit/probot-octokit.ts
@@ -39,6 +39,7 @@ const defaultOptions = {
   },
   userAgent: `probot/${VERSION}`,
 };
+
 export const ProbotOctokit: typeof Octokit &
   Constructor<
     ReturnType<typeof retry> &

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -22,6 +22,7 @@ import type {
   ApplicationFunction,
   ApplicationFunctionOptions,
   Options,
+  ProbotOctokitConstructor,
   ProbotWebhooks,
 } from "./types.js";
 import {
@@ -45,13 +46,13 @@ type OnHandler = ["on", any, any];
 type OnAnyHandler = ["onAny", any];
 type OnErrorHandler = ["onError", any];
 
-export type State = {
+export type State<OctokitType extends ProbotOctokit = ProbotOctokit> = {
   initializationState: InitializationState;
   initializedPromise: DeferredPromise<void>;
   initEventListeners: (OnHandler | OnAnyHandler | OnErrorHandler)[];
   cache: Lru<string> | null;
   octokit: ProbotOctokit | null;
-  webhooks: ProbotWebhooks | null;
+  webhooks: ProbotWebhooks<OctokitType> | null;
   log: Logger | null;
   logFormat?: "pretty" | "json";
   logLevelInString?: boolean;
@@ -61,7 +62,7 @@ export type State = {
   appId?: number | undefined;
   privateKey?: string | undefined;
   githubToken?: string | undefined;
-  OctokitBase: typeof ProbotOctokit;
+  OctokitBase: ProbotOctokitConstructor;
   port?: number | undefined;
   host?: string | undefined;
   baseUrl?: string | undefined;
@@ -72,7 +73,7 @@ export type State = {
   server?: Server | void;
 };
 
-export class Probot {
+export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
   static defaults<S extends Constructor>(
     this: S,
     defaults: Options,
@@ -91,9 +92,9 @@ export class Probot {
     return ProbotWithDefaults;
   }
 
-  #state: State;
+  #state: State<OctokitType>;
 
-  constructor(options: Options = {}) {
+  constructor(options: Options<OctokitType> = {}) {
     if (!options.githubToken) {
       if (!options.appId) {
         throw new Error("appId option is required");
@@ -122,7 +123,8 @@ export class Probot {
       privateKey: options.privateKey,
       host: options.host,
       port: options.port,
-      OctokitBase: options.Octokit || ProbotOctokit,
+      OctokitBase: (options.Octokit ||
+        ProbotOctokit) as ProbotOctokitConstructor,
       baseUrl: options.baseUrl,
       redisConfig: options.redisConfig,
       webhookPath: options.webhookPath || defaultWebhookPath,
@@ -162,7 +164,7 @@ export class Probot {
 
       this.#state.log = this.#state.log.child({ name: "probot" });
 
-      const Octokit = await getProbotOctokitWithDefaults({
+      const Octokit = (await getProbotOctokitWithDefaults({
         githubToken: this.#state.githubToken,
         Octokit: this.#state.OctokitBase,
         appId: this.#state.appId,
@@ -172,26 +174,28 @@ export class Probot {
         redisConfig: this.#state.redisConfig,
         baseUrl: this.#state.baseUrl,
         request: this.#state.request,
-      });
-      this.#state.octokit = new Octokit();
+      })) as ProbotOctokitConstructor<OctokitType>;
+      const octokit = new Octokit();
+      this.#state.octokit = octokit;
       this.#state.webhooks = getWebhooks({
         log: this.#state.log,
-        octokit: this.#state.octokit,
+        octokit: octokit as OctokitType,
         webhookSecret: this.#state.webhookSecret,
       });
 
       this.#state.initializationState = INITIALIZED;
 
+      const webhooks = this.#state.webhooks;
       for (const [type, listener, name] of this.#state.initEventListeners) {
         switch (type) {
           case "on":
-            this.#state.webhooks.on(name, listener);
+            webhooks!.on(name, listener);
             break;
           case "onAny":
-            this.#state.webhooks.onAny(listener);
+            webhooks!.onAny(listener);
             break;
           case "onError":
-            this.#state.webhooks.onError(listener);
+            webhooks!.onError(listener);
             break;
         }
       }
@@ -225,20 +229,20 @@ export class Probot {
     });
   }
 
-  public async auth(
-    installationId?: number | undefined,
-  ): Promise<ProbotOctokit> {
+  public async auth(installationId?: number | undefined): Promise<OctokitType> {
     await this.#initialize();
 
-    return await getAuthenticatedOctokit({
+    return (await getAuthenticatedOctokit({
       log: this.#state.log!,
       octokit: this.#state.octokit!,
       installationId,
-    });
+    })) as OctokitType;
   }
 
   public async load(
-    appFn: ApplicationFunction | ApplicationFunction[],
+    appFn:
+      | ApplicationFunction<OctokitType>
+      | ApplicationFunction<OctokitType>[],
     options: ApplicationFunctionOptions = {
       cwd: process.cwd(),
     } as ApplicationFunctionOptions,
@@ -268,7 +272,7 @@ export class Probot {
     return this.#state.log!;
   }
 
-  public on: ProbotWebhooks["on"] = (eventName, callback) => {
+  public on: ProbotWebhooks<OctokitType>["on"] = (eventName, callback) => {
     if (Array.isArray(eventName)) {
       for (const name of eventName) {
         validateEventName(name, {
@@ -289,7 +293,7 @@ export class Probot {
     this.#state.webhooks!.on(eventName, callback);
   };
 
-  public onAny: ProbotWebhooks["onAny"] = (callback) => {
+  public onAny: ProbotWebhooks<OctokitType>["onAny"] = (callback) => {
     if (this.#state.initializationState !== INITIALIZED) {
       this.#state.initEventListeners.push(["onAny", callback]);
       return;
@@ -297,7 +301,7 @@ export class Probot {
     this.#state.webhooks!.onAny(callback);
   };
 
-  public onError: ProbotWebhooks["onError"] = (callback) => {
+  public onError: ProbotWebhooks<OctokitType>["onError"] = (callback) => {
     if (this.#state.initializationState !== INITIALIZED) {
       this.#state.initEventListeners.push(["onError", callback]);
       return;

--- a/src/probot.ts
+++ b/src/probot.ts
@@ -46,13 +46,13 @@ type OnHandler = ["on", any, any];
 type OnAnyHandler = ["onAny", any];
 type OnErrorHandler = ["onError", any];
 
-export type State<OctokitType extends ProbotOctokit = ProbotOctokit> = {
+export type State<Octokit extends ProbotOctokit = ProbotOctokit> = {
   initializationState: InitializationState;
   initializedPromise: DeferredPromise<void>;
   initEventListeners: (OnHandler | OnAnyHandler | OnErrorHandler)[];
   cache: Lru<string> | null;
   octokit: ProbotOctokit | null;
-  webhooks: ProbotWebhooks<OctokitType> | null;
+  webhooks: ProbotWebhooks<Octokit> | null;
   log: Logger | null;
   logFormat?: "pretty" | "json";
   logLevelInString?: boolean;
@@ -73,7 +73,7 @@ export type State<OctokitType extends ProbotOctokit = ProbotOctokit> = {
   server?: Server | void;
 };
 
-export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
+export class Probot<Octokit extends ProbotOctokit = ProbotOctokit> {
   static defaults<S extends Constructor>(
     this: S,
     defaults: Options,
@@ -92,9 +92,9 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
     return ProbotWithDefaults;
   }
 
-  #state: State<OctokitType>;
+  #state: State<Octokit>;
 
-  constructor(options: Options<OctokitType> = {}) {
+  constructor(options: Options<Octokit> = {}) {
     if (!options.githubToken) {
       if (!options.appId) {
         throw new Error("appId option is required");
@@ -174,12 +174,12 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
         redisConfig: this.#state.redisConfig,
         baseUrl: this.#state.baseUrl,
         request: this.#state.request,
-      })) as ProbotOctokitConstructor<OctokitType>;
+      })) as ProbotOctokitConstructor<Octokit>;
       const octokit = new Octokit();
       this.#state.octokit = octokit;
       this.#state.webhooks = getWebhooks({
         log: this.#state.log,
-        octokit: octokit as OctokitType,
+        octokit: octokit as Octokit,
         webhookSecret: this.#state.webhookSecret,
       });
 
@@ -229,20 +229,20 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
     });
   }
 
-  public async auth(installationId?: number | undefined): Promise<OctokitType> {
+  public async auth(installationId?: number | undefined): Promise<Octokit> {
     await this.#initialize();
 
     return (await getAuthenticatedOctokit({
       log: this.#state.log!,
       octokit: this.#state.octokit!,
       installationId,
-    })) as OctokitType;
+    })) as Octokit;
   }
 
   public async load(
     appFn:
-      | ApplicationFunction<OctokitType>
-      | ApplicationFunction<OctokitType>[],
+      | ApplicationFunction<Octokit>
+      | ApplicationFunction<Octokit>[],
     options: ApplicationFunctionOptions = {
       cwd: process.cwd(),
     } as ApplicationFunctionOptions,
@@ -272,7 +272,7 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
     return this.#state.log!;
   }
 
-  public on: ProbotWebhooks<OctokitType>["on"] = (eventName, callback) => {
+  public on: ProbotWebhooks<Octokit>["on"] = (eventName, callback) => {
     if (Array.isArray(eventName)) {
       for (const name of eventName) {
         validateEventName(name, {
@@ -293,7 +293,7 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
     this.#state.webhooks!.on(eventName, callback);
   };
 
-  public onAny: ProbotWebhooks<OctokitType>["onAny"] = (callback) => {
+  public onAny: ProbotWebhooks<Octokit>["onAny"] = (callback) => {
     if (this.#state.initializationState !== INITIALIZED) {
       this.#state.initEventListeners.push(["onAny", callback]);
       return;
@@ -301,7 +301,7 @@ export class Probot<OctokitType extends ProbotOctokit = ProbotOctokit> {
     this.#state.webhooks!.onAny(callback);
   };
 
-  public onError: ProbotWebhooks<OctokitType>["onError"] = (callback) => {
+  public onError: ProbotWebhooks<Octokit>["onError"] = (callback) => {
     if (this.#state.initializationState !== INITIALIZED) {
       this.#state.initEventListeners.push(["onError", callback]);
       return;

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,19 +15,19 @@ import type { Server } from "./server/server.js";
 import type { ProbotOctokit } from "./octokit/probot-octokit.js";
 
 export type ProbotOctokitConstructor<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 > = typeof ProbotOctokit &
-  (new (...args: ConstructorParameters<typeof ProbotOctokit>) => OctokitType);
+  (new (...args: ConstructorParameters<typeof ProbotOctokit>) => Octokit);
 
 export type StripUndefined<T> = {
   [K in keyof T]-?: Exclude<T[K], undefined>;
 };
 
-export interface Options<OctokitType extends ProbotOctokit = ProbotOctokit> {
+export interface Options<Octokit extends ProbotOctokit = ProbotOctokit> {
   privateKey?: string | undefined;
   githubToken?: string | undefined;
   appId?: number | string | undefined;
-  Octokit?: ProbotOctokitConstructor<OctokitType> | undefined;
+  Octokit?: ProbotOctokitConstructor<Octokit> | undefined;
   log?: Logger | undefined;
   redisConfig?: RedisOptions | string | undefined;
   secret?: string | undefined;
@@ -58,12 +58,12 @@ export interface Options<OctokitType extends ProbotOctokit = ProbotOctokit> {
 // Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer
 // See https://github.com/probot/probot/issues/1388
 // See https://github.com/probot/probot/issues/1815 as for why this is in a seperate type, and not directly passed to `Webhooks`
-type SimplifiedObject<OctokitType extends ProbotOctokit> = Omit<
-  Context<WebhookEvents, OctokitType>,
+type SimplifiedObject<Octokit extends ProbotOctokit> = Omit<
+  Context<WebhookEvents, Octokit>,
   keyof WebhookEvent
 >;
-export type ProbotWebhooks<OctokitType extends ProbotOctokit = ProbotOctokit> =
-  Webhooks<SimplifiedObject<OctokitType>>;
+export type ProbotWebhooks<Octokit extends ProbotOctokit = ProbotOctokit> =
+  Webhooks<SimplifiedObject<Octokit>>;
 
 export type ApplicationFunctionOptions = {
   cwd: string;
@@ -71,16 +71,16 @@ export type ApplicationFunctionOptions = {
   [key: string]: unknown;
 };
 
-export type HandlerFactory<OctokitType extends ProbotOctokit = ProbotOctokit> =
+export type HandlerFactory<Octokit extends ProbotOctokit = ProbotOctokit> =
   (
-    app: Probot<OctokitType>,
+    app: Probot<Octokit>,
     options: ApplicationFunctionOptions,
   ) => Handler | Promise<Handler>;
 
 export type ApplicationFunction<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 > = (
-  app: Probot<OctokitType>,
+  app: Probot<Octokit>,
   options: ApplicationFunctionOptions,
 ) => void | Promise<void>;
 
@@ -107,9 +107,9 @@ export type ServerOptions = {
 };
 
 export type MiddlewareOptions<
-  OctokitType extends ProbotOctokit = ProbotOctokit,
+  Octokit extends ProbotOctokit = ProbotOctokit,
 > = {
-  probot: Probot<OctokitType>;
+  probot: Probot<Octokit>;
   webhooksPath?: string | undefined;
   [key: string]: unknown;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { RequestRequestOptions } from "@octokit/types";
 import type {
   EmitterWebhookEvent as WebhookEvent,
+  EmitterWebhookEventName as WebhookEvents,
   Webhooks,
 } from "@octokit/webhooks";
 import type { RedisOptions } from "ioredis";
@@ -13,15 +14,20 @@ import type { Probot } from "./probot.js";
 import type { Server } from "./server/server.js";
 import type { ProbotOctokit } from "./octokit/probot-octokit.js";
 
+export type ProbotOctokitConstructor<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+> = typeof ProbotOctokit &
+  (new (...args: ConstructorParameters<typeof ProbotOctokit>) => OctokitType);
+
 export type StripUndefined<T> = {
   [K in keyof T]-?: Exclude<T[K], undefined>;
 };
 
-export interface Options {
+export interface Options<OctokitType extends ProbotOctokit = ProbotOctokit> {
   privateKey?: string | undefined;
   githubToken?: string | undefined;
   appId?: number | string | undefined;
-  Octokit?: typeof ProbotOctokit | undefined;
+  Octokit?: ProbotOctokitConstructor<OctokitType> | undefined;
   log?: Logger | undefined;
   redisConfig?: RedisOptions | string | undefined;
   secret?: string | undefined;
@@ -52,8 +58,12 @@ export interface Options {
 // Simply passing `Context` as `TTransformed` would result in the payload types being too complex for TypeScript to infer
 // See https://github.com/probot/probot/issues/1388
 // See https://github.com/probot/probot/issues/1815 as for why this is in a seperate type, and not directly passed to `Webhooks`
-type SimplifiedObject = Omit<Context, keyof WebhookEvent>;
-export type ProbotWebhooks = Webhooks<SimplifiedObject>;
+type SimplifiedObject<OctokitType extends ProbotOctokit> = Omit<
+  Context<WebhookEvents, OctokitType>,
+  keyof WebhookEvent
+>;
+export type ProbotWebhooks<OctokitType extends ProbotOctokit = ProbotOctokit> =
+  Webhooks<SimplifiedObject<OctokitType>>;
 
 export type ApplicationFunctionOptions = {
   cwd: string;
@@ -61,13 +71,16 @@ export type ApplicationFunctionOptions = {
   [key: string]: unknown;
 };
 
-export type HandlerFactory = (
-  app: Probot,
-  options: ApplicationFunctionOptions,
-) => Handler | Promise<Handler>;
+export type HandlerFactory<OctokitType extends ProbotOctokit = ProbotOctokit> =
+  (
+    app: Probot<OctokitType>,
+    options: ApplicationFunctionOptions,
+  ) => Handler | Promise<Handler>;
 
-export type ApplicationFunction = (
-  app: Probot,
+export type ApplicationFunction<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+> = (
+  app: Probot<OctokitType>,
   options: ApplicationFunctionOptions,
 ) => void | Promise<void>;
 
@@ -93,8 +106,10 @@ export type ServerOptions = {
   request?: RequestRequestOptions | undefined;
 };
 
-export type MiddlewareOptions = {
-  probot: Probot;
+export type MiddlewareOptions<
+  OctokitType extends ProbotOctokit = ProbotOctokit,
+> = {
+  probot: Probot<OctokitType>;
   webhooksPath?: string | undefined;
   [key: string]: unknown;
 };

--- a/test/types/probot-custom-octokit.test-d.ts
+++ b/test/types/probot-custom-octokit.test-d.ts
@@ -1,0 +1,44 @@
+import { expectType } from "tsd";
+import {
+  createNodeMiddleware,
+  createProbot,
+  Probot,
+  ProbotOctokit,
+} from "../../src/index.js";
+
+const MyOctokit = ProbotOctokit.plugin(() => {
+  return {
+    methods: {
+      itWorks: async () => {},
+    },
+  };
+});
+
+type MyOctokitType = InstanceType<typeof MyOctokit>;
+
+const typedApp = (bot: Probot<MyOctokitType>) => {
+  bot.on("issues.opened", async (context) => {
+    expectType<MyOctokitType>(context.octokit);
+    await context.octokit.methods.itWorks();
+  });
+};
+
+void createNodeMiddleware(typedApp, {
+  probot: createProbot({
+    defaults: { Octokit: MyOctokit },
+  }),
+});
+
+void createNodeMiddleware(
+  (bot) => {
+    bot.on("issues.opened", async (context) => {
+      expectType<MyOctokitType>(context.octokit);
+      await context.octokit.methods.itWorks();
+    });
+  },
+  {
+    probot: createProbot({
+      defaults: { Octokit: MyOctokit },
+    }),
+  },
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "noFallthroughCasesInSwitch": true,
     "pretty": true,
     "sourceMap": false,
+    "rootDir": "./",
     "outDir": "./lib",
     "skipLibCheck": true,
     "noImplicitAny": true,


### PR DESCRIPTION
## Summary
- make Probot/Context/webhooks typings generic over the Octokit instance type
- thread custom Octokit types through createProbot() and createNodeMiddleware()
- preserve runtime behavior while fixing type inference for plugin-extended Octokit methods on context.octokit
- add a focused tsd regression test for custom plugin methods

Fixes #1658

## Validation
- npm run build
- npx tsc --noEmit -p test
- npx tsd --files test/types/probot-custom-octokit.test-d.ts