### PR TITLE
Security: XSS risk in import view from unescaped URL and text interpolation

### DIFF
--- a/src/views/import.ts
+++ b/src/views/import.ts
@@ -7,6 +7,32 @@ export function importView({
   GH_HOST: string | undefined;
   WEBHOOK_PROXY_URL?: string | undefined;
 }): string {
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
+  const sanitizeHttpUrl = (value: string | undefined): string => {
+    if (!value) return "";
+
+    try {
+      const url = new URL(value);
+      if (url.protocol === "http:" || url.protocol === "https:") return url.toString();
+    } catch {}
+
+    return "";
+  };
+
+  const safeName = escapeHtml(name || "Your App");
+  const safeWebhookProxyUrl = escapeHtml(WEBHOOK_PROXY_URL);
+  const hostUrl = sanitizeHttpUrl(GH_HOST);
+  const safeSettingsAppsUrl = escapeHtml(
+    hostUrl ? new URL("/settings/apps", hostUrl).toString() : "#",
+  );
+
   return `<!DOCTYPE html>
 <html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
 
@@ -14,7 +40,7 @@ export function importView({
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Import ${name || "Your App"} | built with Probot</title>
+    <title>Import ${safeName} | built with Probot</title>
     <link rel="icon" href="/probot/static/probot-head.svg">
     <link rel="stylesheet" href="/probot/static/primer.css">
 </head>
@@ -29,9 +55,9 @@ export function importView({
             <h3>Step 1:</h3>
             <p class="d-block mt-2">
                 Replace your app's Webhook URL with <br>
-                <b>${WEBHOOK_PROXY_URL}</b>
+                <b>${safeWebhookProxyUrl}</b>
             </p>
-            <a class="d-block mt-2" href="${GH_HOST}/settings/apps" target="__blank" rel="noreferrer">
+            <a class="d-block mt-2" href="${safeSettingsAppsUrl}" target="__blank" rel="noreferrer">
                 You can do it here
             </a>
 

--- a/src/views/setup.ts
+++ b/src/views/setup.ts
@@ -11,6 +11,34 @@ export function setupView({
   createAppUrl: string | undefined;
   manifest: string | undefined;
 }): string {
+  const escapeHtml = (value: string): string =>
+    value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+
+  const sanitizeHttpUrl = (value: string | undefined): string => {
+    if (!value) return "";
+
+    try {
+      const url = new URL(value);
+      if (url.protocol === "http:" || url.protocol === "https:") return url.toString();
+    } catch {}
+
+    return "";
+  };
+
+  const safeName = escapeHtml(name || "Your App");
+  const safeWelcomeName = escapeHtml(name || "your Probot App");
+  const safeVersion = version ? escapeHtml(version) : "";
+  const safeDescription = description
+    ? escapeHtml(description)
+    : 'This app was built using <a href="https://github.com/probot/probot">Probot</a>, a framework for building GitHub Apps.';
+  const safeCreateAppUrl = escapeHtml(sanitizeHttpUrl(createAppUrl) || "#");
+  const safeManifest = escapeHtml(manifest || "");
+
   return `<!DOCTYPE html>
 <!DOCTYPE html>
 <html lang="en" class="height-full" data-color-mode="auto" data-light-theme="light" data-dark-theme="dark">
@@ -18,7 +46,7 @@ export function setupView({
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>Setup ${name || "Your App"} | built with Probot</title>
+    <title>Setup ${safeName} | built with Probot</title>
     <link rel="icon" href="/probot/static/probot-head.svg">
     <link rel="stylesheet" href="/probot/static/primer.css">
   </head>
@@ -27,19 +55,15 @@ export function setupView({
       <img src="/probot/static/robot.svg" alt="Probot Logo" width="100" class="mb-6">
       <div class="box-shadow rounded-2 border p-6 bg-white">
         <h1>
-          Welcome to ${name || "your Probot App"}
+          Welcome to ${safeWelcomeName}
           ${
             version
-              ? `<span class="Label Label--outline v-align-middle ml-2 text-gray-light">v${version}</span>`
+              ? `<span class="Label Label--outline v-align-middle ml-2 text-gray-light">v${safeVersion}</span>`
               : ""
           }
         </h1>
 
-        <p>${
-          description
-            ? description
-            : 'This app was built using <a href="https://github.com/probot/probot">Probot</a>, a framework for building GitHub Apps.'
-        }</p>
+        <p>${safeDescription}</p>
 
         <div class="text-left mt-6">
           <h2 class="alt-h3 mb-2">Getting Started</h2>
@@ -47,8 +71,8 @@ export function setupView({
           <p>To start building a GitHub App, you'll need to register a new app on GitHub.</p>
           <br>
 
-          <form action="${createAppUrl}" method="post" target="_blank" class="d-flex flex-items-center">
-            <button class="btn btn-outline" name="manifest" id="manifest" value='${manifest}' >Register GitHub App</button>
+          <form action="${safeCreateAppUrl}" method="post" target="_blank" class="d-flex flex-items-center">
+            <button class="btn btn-outline" name="manifest" id="manifest" value='${safeManifest}' >Register GitHub App</button>
             <a href="/probot/import" class="ml-2">or use an existing Github App</a>
           </form>
         </div>


### PR DESCRIPTION
## Problem

`importView` injects `GH_HOST`, `WEBHOOK_PROXY_URL`, and `name` directly into HTML (`href`, text, and title) without sanitization. If attacker-controlled input reaches these values, this enables script injection or malicious-link injection (e.g., `javascript:` URL or quote-breaking payloads).

**Severity**: `medium`
**File**: `src/views/import.ts`

## Solution

Escape interpolated values for HTML/attribute context and strictly validate `GH_HOST`/URL inputs (allowlist `http`/`https`, reject `javascript:` and malformed values). Consider constructing links server-side from trusted config only.

## Changes

- `src/views/import.ts` (modified)
- `src/views/setup.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
